### PR TITLE
Fix versions links in docs.

### DIFF
--- a/docs/source/_templates/sidebar/version.html
+++ b/docs/source/_templates/sidebar/version.html
@@ -1,1 +1,1 @@
-<a class="sidebar-version" href="../versions.html">{{ version }} ▼</a>
+<a class="sidebar-version" href="{{ pathto('versions.html', 1) }}">{{ version }} ▼</a>


### PR DESCRIPTION
## What has changed and why?

Changed the path to `versions.html`.

## How has it been tested?

The doc was built locally and it was verified that the "versions" page was accessible from other pages.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
