### PR TITLE
Add `nbdev_clean` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
     - id: check-added-large-files
       description: "Avoid committing large files."
       args: ["--maxkb=2000", "--enforce-all"]
+ - repo: https://github.com/fastai/nbdev
+   rev: 2.4.2
+   hooks:
+    - id: nbdev_clean
+      args: [--fname=examples]

--- a/examples/notebooks/quick_start.ipynb
+++ b/examples/notebooks/quick_start.ipynb
@@ -258,13 +258,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/ultralytics_yolo.ipynb
+++ b/examples/notebooks/ultralytics_yolo.ipynb
@@ -272,21 +272,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".yolo_tutorial",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What has changed and why?

Add [`nbdev_clean` pre commit hooks](https://nbdev.fast.ai/tutorials/pre_commit.html) to strip notebook metadata

## How has it been tested?

Run pre-commit and the existing notebook metadata are stripped.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
