### PR TITLE
Add Colab Notebook for RF-DETR

### DIFF
--- a/examples/notebooks/rfdetr.ipynb
+++ b/examples/notebooks/rfdetr.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LightlyTrain with RF-DETR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook we will demonstrate how you can use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) to pretrain an [RF-DETR model](https://github.com/roboflow/rf-detr). To this end, we will first use the raw images (**no labels**) from the [Coconuts dataset](https://universe.roboflow.com/traindataset/coconuts-plj8h) for pretraining and then fine-tuning on the labeled dataset.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/rfdetr.ipynb)\n",
+    "\n",
+    "> **Important**: When running on Google Colab make sure to select a GPU runtime for faster processing. You can do this by going to `Runtime` > `Change runtime type` and selecting a GPU hardware accelerator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "You can install `lightly_train` directly from PyPI using pip with support of `rfdetr` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"lightly-train[rfdetr]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Important**: LightlyTrain is officially supported on\n",
+    "> - Linux: CPU or CUDA\n",
+    "> - MacOS: CPU only\n",
+    "> - Windows (experimental): CPU or CUDA\n",
+    ">\n",
+    "> We are planning to support MPS for MacOS.\n",
+    ">\n",
+    "> Check the installation instructions for more details on installation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download Dataset\n",
+    "\n",
+    "For now, `rfdetr` only supports training with datasets in COCO JSON format. They can be directly downloaded via their API:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from roboflow import Roboflow\n",
+    "\n",
+    "rf = Roboflow(api_key=\"ll0lyIdivnVNWuxBmPPM\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use Roboflow's [Coconuts dataset](https://universe.roboflow.com/traindataset/coconuts-plj8h) for pretraining."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project = rf.workspace(\"traindataset\").project(\"coconuts-plj8h\")\n",
+    "version = project.version(1)\n",
+    "pretrain_dataset = version.download(\"coco\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use Roboflow's [Coconut Custom Dataset](https://universe.roboflow.com/ravi-mgvlz/coconut-custom-dataset) for fine-tuning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project = rf.workspace(\"ravi-mgvlz\").project(\"coconut-custom-dataset\")\n",
+    "version = project.version(3)\n",
+    "finetune_dataset = version.download(\"coco\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pretrain and Fine-tune an RF-DETR Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pretraining an RF-DETR model with LightlyTrain is straightforward:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pretrain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lightly_train\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    lightly_train.train(\n",
+    "        out=\"out/my_experiment\",                                        # Output directory.\n",
+    "        data=pretrain_dataset.location,                                 # Directory with images.\n",
+    "        model=\"rfdetr/rf-detr-base\",                                    # Pass the RF-DETR model.\n",
+    "        epochs=5,                                                       # Number of epochs to train\n",
+    "        batch_size=16,                                                  # Batch size\n",
+    "        overwrite=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fine-tune\n",
+    "\n",
+    "You can use `rfdetr` for fine-tuning directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rfdetr import RFDETRBase\n",
+    "\n",
+    "model = RFDETRBase(pretrain_weights=\"out/my_experiment/exported_models/exported_last.pt\")\n",
+    "model.train(dataset_dir=finetune_dataset.location, epochs=10, batch_size=4, lr=1e-4)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## What has changed and why?

Add colab notebook for [RF-DETR PR](https://github.com/lightly-ai/rf-detr/pull/1).

Should be able to complete everything within 10 mins.

## How has it been tested?

Running on Colab

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
