### PR TITLE
Fix Quote in f-string

### DIFF
--- a/docs/source/tutorials/yolo/index.md
+++ b/docs/source/tutorials/yolo/index.md
@@ -79,8 +79,8 @@ dataset = check_det_dataset("VOC.yaml")
 
 detections = sv.DetectionDataset.from_yolo(
     data_yaml_path=dataset["yaml_file"],
-    images_directory_path=f"{settings["datasets_dir"]}/VOC/images/train2012",
-    annotations_directory_path=f"{settings["datasets_dir"]}/VOC/labels/train2012",
+    images_directory_path=f"{settings['datasets_dir']}/VOC/images/train2012",
+    annotations_directory_path=f"{settings['datasets_dir']}/VOC/labels/train2012",
 )
 
 with open(dataset["yaml_file"], "r") as f:


### PR DESCRIPTION
## What has changed and why?

The f-strings in this code example don’t work because we use the wrong quotes inside the code. We fixed it so it is aligned with the colab tutorial.

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
