### PR TITLE
Add Links to Method and Distillation Docs

### DIFF
--- a/docs/source/methods/index.md
+++ b/docs/source/methods/index.md
@@ -10,6 +10,8 @@ Lightly**Train** supports the following pretraining methods:
 
 For detailed information on each method, please refer to the respective sections below.
 
+(methods-comparison)=
+
 ## Which Method to Choose?
 
 We strongly recommend Lightly’s custom distillation method (the default in LightlyTrain) for pretraining your models.

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -57,7 +57,7 @@ This is a minimal example for illustration purposes. In practice you would want 
 a larger dataset (>=10'000 images), more epochs (>=100), and a larger batch size (>=128).
 
 **Best Choice**: 
-The default pretraining method `distillation` is recommended, as it consistently outperforms others in extensive experiments. Batch sizes between `128` and `1536` strike a good balance between speed and performance. Moreover, long training runs, such as 2,000 epochs on COCO, significantly improve results.
+The default pretraining method `distillation` is recommended, as it consistently outperforms others in extensive experiments. Batch sizes between `128` and `1536` strike a good balance between speed and performance. Moreover, long training runs, such as 2,000 epochs on COCO, significantly improve results. Check the [Methods](#methods-comparison) page for more details why `distillation` is the best choice.
 ```
 
 ```{tip}

--- a/docs/source/train.md
+++ b/docs/source/train.md
@@ -26,7 +26,7 @@ lightly-train train out="out/my_experiment" data="my_data_dir" model="torchvisio
 ````
 
 ```{important}
-The default pretraining method `distillation` is recommended, as it consistently outperforms others in extensive experiments. Batch sizes between `128` and `1536` strike a good balance between speed and performance. Moreover, long training runs, such as 2,000 epochs on COCO, significantly improve results.
+The default pretraining method `distillation` is recommended, as it consistently outperforms others in extensive experiments. Batch sizes between `128` and `1536` strike a good balance between speed and performance. Moreover, long training runs, such as 2,000 epochs on COCO, significantly improve results. Check the [Methods](#methods-comparison) page for more details why `distillation` is the best choice.
 ```
 
 This will pretrain a ResNet-50 model from TorchVision using images from `my_data_dir`

--- a/docs/source/tutorials/resnet/index.md
+++ b/docs/source/tutorials/resnet/index.md
@@ -344,6 +344,6 @@ For more advanced options, explore the [LightlyTrain Python API](#lightly-train)
 
 ## Next Steps
 
-- Go beyond the default distillation pretraining and experiment with other pre-training methods in LightlyTrain, such as DINO or SimCLR.
+- Go beyond the default distillation pretraining and experiment with other pretraining methods in LightlyTrain. Check [Methods](#methods) for more information.
 - Try various [Torchvision models](#models-torchvision) supported by LightlyTrain.
 - Use the pre-trained model for other tasks, like {ref}`image embeddings <embed>`.

--- a/docs/source/tutorials/yolo/index.md
+++ b/docs/source/tutorials/yolo/index.md
@@ -172,6 +172,6 @@ For more advanced options, explore the [LightlyTrain Python API](#lightly-train)
 
 ## Next Steps
 
-- Go beyond the default distillation pretraining and experiment other pre-training learning methods in LightlyTrain, such as DINO or SimCLR.
+- Go beyond the default distillation pretraining and experiment other pretraining learning methods in LightlyTrain. Check [Methods](#methods) for more information.
 - Try various YOLO models (`YOLOv5`, `YOLOv6`, `YOLOv8`).
 - Use the pre-trained model for other tasks, like {ref}`image embeddings <embed>`.


### PR DESCRIPTION
## What has changed and why?

Add links to the Method / Distillation docs page where necessary, including:

- [ ] In the tutorial where we suggest users to explore more methods than distillation
- [ ] Callouts where recommendations to distillation is mentioned

## How has it been tested?

[Classification with Torchvision’s ResNet - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/19736014/Classification.with.Torchvision.s.ResNet.-.LightlyTrain.documentation.pdf)
[Object Detection with Ultralytics’ YOLO - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/19736015/Object.Detection.with.Ultralytics.YOLO.-.LightlyTrain.documentation.pdf)
[Quick Start - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/19736016/Quick.Start.-.LightlyTrain.documentation.pdf)
[Train - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/19736017/Train.-.LightlyTrain.documentation.pdf)


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
