### PR TITLE
Add benchmark results to docs

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -35,6 +35,14 @@ a wide range of model architectures and use-cases out of the box.
 - 🏗️ **Model & Task Agnostic**: Compatible with any architecture and task, including detection, classification, and segmentation.
 - 🚀 **Industrial-Scale Support**: LightlyTrain scales from thousands to millions of images. Supports on-prem, cloud, single, and multi-GPU setups.
 
+```{figure} https://github.com/user-attachments/assets/99cded12-7f16-498d-ab54-aee60b26b5ae
+:alt: benchmark results
+
+On COCO, YOLOv8-s models pretrained with LightlyTrain achieve high performance across all tested label fractions.
+These improvements hold for other architectures like YOLOv11, RT-DETR, and Faster R-CNN.
+See our [announcement post](https://www.lightly.ai/blog/introducing-lightly-train) for more details.
+```
+
 ## How It Works [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/quick_start.ipynb)
 
 Install Lightly**Train**:


### PR DESCRIPTION
## What has changed and why?

* Add benchmark results to docs

Same plot that was also added to README. Link works once the repo is published

## How has it been tested?

* Built docs locally

[LightlyTrain documentation benchmark.pdf](https://github.com/user-attachments/files/19753039/LightlyTrain.documentation.benchmark.pdf)


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
