### PR TITLE
Add version compatibility table to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Transforms and methods are now documented on dedicated pages.
+- Add [version compatibility table](https://docs.lightly.ai/train/stable/installation.html#version-compatibility) to the documentation.
 
 ### Changed
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -2,15 +2,6 @@
 
 # Installation
 
-## Platform Compatibility
-
-LightlyTrain is officially supported on
-
-- Linux: CPU or CUDA
-- MacOS: CPU only
-- Windows (experimental): CPU or CUDA
-
-We are planning to support MPS for MacOS.
 
 ## Installation from PyPI
 
@@ -31,6 +22,29 @@ pip install --upgrade lightly-train
 ```
 
 See {ref}`docker` for Docker installation instructions.
+
+## Platform Compatibility
+
+| Platform | Supported Compute          |
+|----------|----------------------------|
+| Linux    | CPU or CUDA                |
+| MacOS    | CPU (MPS is planned)       |
+| Windows  | CPU or CUDA (experimental) |
+
+
+## Version Compatibility
+
+| `lightly-train` | `torch`         | `torchvision` | `pytorch-lightning` | Python           |
+|:---------------:|:---------------:|:-------------:|:-------------------:|:----------------:|
+| `0.6`           | `>=2.1`, `<2.6` | `>=0.16`      | `>=2.1`, `<2.6`     | `>=3.8`, `<3.13` |
+
+```{warning}
+We recommend installing versions of the `torch`, `torchvision`, and `pytorch-lightning` packages that
+are compatible with each other. The latest compatible versions are `torch==2.5 torchvision==0.21 pytorch-lightning==2.5`.
+
+See the [Torchvision](https://github.com/pytorch/vision?tab=readme-ov-file#installation) and [PyTorch Lightning](https://lightning.ai/docs/pytorch/stable/versioning.html#compatibility-matrix)
+documentation for more information on version compatibility between different PyTorch packages.
+```
 
 (optional-dependencies)=
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -2,7 +2,6 @@
 
 # Installation
 
-
 ## Installation from PyPI
 
 Lightly**Train** is available on [PyPI](https://pypi.org/project/lightly-train/) and can be installed via pip or other package managers.
@@ -25,18 +24,17 @@ See {ref}`docker` for Docker installation instructions.
 
 ## Platform Compatibility
 
-| Platform | Supported Compute          |
+| Platform | Supported Compute |
 |----------|----------------------------|
-| Linux    | CPU or CUDA                |
-| MacOS    | CPU (MPS is planned)       |
-| Windows  | CPU or CUDA (experimental) |
-
+| Linux | CPU or CUDA |
+| MacOS | CPU (MPS is planned) |
+| Windows | CPU or CUDA (experimental) |
 
 ## Version Compatibility
 
-| `lightly-train` | `torch`         | `torchvision` | `pytorch-lightning` | Python           |
+| `lightly-train` | `torch` | `torchvision` | `pytorch-lightning` | Python |
 |:---------------:|:---------------:|:-------------:|:-------------------:|:----------------:|
-| `0.6`           | `>=2.1`, `<2.6` | `>=0.16`      | `>=2.1`, `<2.6`     | `>=3.8`, `<3.13` |
+| `0.6` | `>=2.1`, `<2.6` | `>=0.16` | `>=2.1`, `<2.6` | `>=3.8`, `<3.13` |
 
 ```{warning}
 We recommend installing versions of the `torch`, `torchvision`, and `pytorch-lightning` packages that

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -33,14 +33,15 @@ See {ref}`docker` for Docker installation instructions.
 ## Version Compatibility
 
 | `lightly-train` | `torch` | `torchvision` | `pytorch-lightning` | Python |
-|:---------------:|:---------------:|:-------------:|:-------------------:|:----------------:|
+|:---------------:|:-------:|:-------------:|:-------------------:|:------:|
 | `0.6` | `>=2.1`, `<2.6` | `>=0.16` | `>=2.1`, `<2.6` | `>=3.8`, `<3.13` |
 
 ```{warning}
 We recommend installing versions of the `torch`, `torchvision`, and `pytorch-lightning` packages that
 are compatible with each other. The latest compatible versions are `torch==2.5 torchvision==0.21 pytorch-lightning==2.5`.
 
-See the [Torchvision](https://github.com/pytorch/vision?tab=readme-ov-file#installation) and [PyTorch Lightning](https://lightning.ai/docs/pytorch/stable/versioning.html#compatibility-matrix)
+See the [Torchvision](https://github.com/pytorch/vision?tab=readme-ov-file#installation)
+and [PyTorch Lightning](https://lightning.ai/docs/pytorch/stable/versioning.html#compatibility-matrix)
 documentation for more information on version compatibility between different PyTorch packages.
 ```
 


### PR DESCRIPTION
## What has changed and why?

* Add version compatibility table to docs

I also moved the platform compatibility down and changed it to a table. This way both sections have the same structure. I moved them below the installation instructions as the installation instruction is the most important part and the two tables would take too much space above it.

## How has it been tested?

[Installation - LightlyTrain documentation version table.pdf](https://github.com/user-attachments/files/19796349/Installation.-.LightlyTrain.documentation.version.table.pdf)


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
