### PR TITLE
Add `dynamic_img_size=True` to TIMM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix image size mismatch issue when using TIMM models and DINO.
+
 ### Security
 
 ## [0.6.2] - 2025-04-09

--- a/src/lightly_train/_models/timm/timm_package.py
+++ b/src/lightly_train/_models/timm/timm_package.py
@@ -52,11 +52,11 @@ class TIMMPackage(Package):
                 f"Cannot create model '{model_name}' because timm is not installed."
             )
         args = dict(pretrained=False)
-        if model_args is not None:
-            args.update(model_args)
         # vit and eva models have dynamic_img_size defaulting to False, which would not allow inputs with varying image sizes, e.g., for DINO
         if model_name.startswith("vit") or model_name.startswith("eva"):
             args.update({"dynamic_img_size": True})
+        if model_args is not None:
+            args.update(model_args)
 
         # Type ignore as typing **args correctly is too complex
         model: Module = timm.create_model(model_name, **args)  # type: ignore[arg-type]

--- a/src/lightly_train/_models/timm/timm_package.py
+++ b/src/lightly_train/_models/timm/timm_package.py
@@ -54,7 +54,7 @@ class TIMMPackage(Package):
         args = dict(pretrained=False)
         if model_args is not None:
             args.update(model_args)
-        # vit and eva models has dynamic_image_size default to False, which would not allow inputs with different image sizes for e.g. dino
+        # vit and eva models have dynamic_img_size defaulting to False, which would not allow inputs with varying image sizes, e.g., for DINO
         if model_name.startswith("vit") or model_name.startswith("eva"):
             args.update({"dynamic_img_size": True})
 

--- a/src/lightly_train/_models/timm/timm_package.py
+++ b/src/lightly_train/_models/timm/timm_package.py
@@ -54,6 +54,10 @@ class TIMMPackage(Package):
         args = dict(pretrained=False)
         if model_args is not None:
             args.update(model_args)
+        # vit and eva models has dynamic_image_size default to False, which would not allow inputs with different image sizes for e.g. dino
+        if model_name.startswith("vit") or model_name.startswith("eva"):
+            args.update({"dynamic_img_size": True})
+
         # Type ignore as typing **args correctly is too complex
         model: Module = timm.create_model(model_name, **args)  # type: ignore[arg-type]
         return model

--- a/src/lightly_train/_models/timm/timm_package.py
+++ b/src/lightly_train/_models/timm/timm_package.py
@@ -53,7 +53,11 @@ class TIMMPackage(Package):
             )
         args = dict(pretrained=False)
         # vit and eva models have dynamic_img_size defaulting to False, which would not allow inputs with varying image sizes, e.g., for DINO
-        if model_name.startswith("vit") or model_name.startswith("eva"):
+        if (
+            model_name.startswith("vit")
+            or model_name.startswith("eva")
+            or model_name.startswith("deit")
+        ):
             args.update({"dynamic_img_size": True})
         if model_args is not None:
             args.update(model_args)


### PR DESCRIPTION
## What has changed and why?

Close #29 

See the issue for details.

## How has it been tested?

```python
lightly_train.train(
    out="out/vit_dino",
    data=data_path,
    method="dino",
    model="timm/vit_base_patch16_224", # and timm/resnet18
    ...
)
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
