### PR TITLE
Fix MyPy for RF-DETR

### DIFF
--- a/src/lightly_train/_models/rfdetr/rfdetr_package.py
+++ b/src/lightly_train/_models/rfdetr/rfdetr_package.py
@@ -51,6 +51,7 @@ class RFDETRPackage(Package):
     ) -> Module:
         try:
             from rfdetr import RFDETRBase, RFDETRLarge
+            from rfdetr.detr import RFDETR
             from rfdetr.main import HOSTED_MODELS
             from rfdetr.models.lwdetr import LWDETR
         except ImportError:
@@ -71,10 +72,10 @@ class RFDETRPackage(Package):
             )
         if "base" in model_name:
             # Type ignore as typing **args correctly is too complex
-            model_rfdetr = RFDETRBase(**args)  # type: ignore[arg-type]
+            model_rfdetr: RFDETR = RFDETRBase(**args)  # type: ignore[arg-type, no-untyped-call]
         elif "large" in model_name:
             # Type ignore as typing **args correctly is too complex
-            model_rfdetr = RFDETRLarge(**args)  # type: ignore[arg-type]
+            model_rfdetr = RFDETRLarge(**args)  # type: ignore[arg-type, no-untyped-call]
         else:
             raise ValueError(
                 f"Model name '{model_name}' is not supported. "

--- a/tests/_models/rfdetr/test_rfdetr.py
+++ b/tests/_models/rfdetr/test_rfdetr.py
@@ -20,7 +20,7 @@ from rfdetr.detr import RFDETRBase
 
 class TestRFDETRFeatureExtractor:
     def test_init(self) -> None:
-        model = RFDETRBase().model.model
+        model = RFDETRBase().model.model  # type: ignore[no-untyped-call]
         feature_extractor = RFDETRFeatureExtractor(model=model)
 
         for name, param in feature_extractor.named_parameters():
@@ -30,7 +30,7 @@ class TestRFDETRFeatureExtractor:
             assert module.training, name
 
     def test_feature_dim(self) -> None:
-        model = RFDETRBase().model.model
+        model = RFDETRBase().model.model  # type: ignore[no-untyped-call]
 
         feature_extractor = RFDETRFeatureExtractor(model=model)
 
@@ -39,7 +39,7 @@ class TestRFDETRFeatureExtractor:
     def test_forward_features(
         self,
     ) -> None:
-        model_instance = RFDETRBase()
+        model_instance = RFDETRBase()  # type: ignore[no-untyped-call]
         model = model_instance.model.model
         device = model_instance.model.device
 
@@ -58,7 +58,7 @@ class TestRFDETRFeatureExtractor:
         )
 
     def test_forward_pool(self) -> None:
-        model_instance = RFDETRBase()
+        model_instance = RFDETRBase()  # type: ignore[no-untyped-call]
         model = model_instance.model.model
         device = model_instance.model.device
 

--- a/tests/_models/rfdetr/test_rfdetr_package.py
+++ b/tests/_models/rfdetr/test_rfdetr_package.py
@@ -41,7 +41,7 @@ class TestRFDETRPackage:
         assert (model_name in model_names) is supported
 
     def test_is_supported_model__true(self) -> None:
-        model = RFDETRBase().model.model
+        model = RFDETRBase().model.model  # type: ignore[no-untyped-call]
         assert RFDETRPackage.is_supported_model(model)
 
     def test_is_supported_model__false(self) -> None:
@@ -57,16 +57,16 @@ class TestRFDETRPackage:
         assert isinstance(model, LWDETR)
 
     def test_get_feature_extractor(self) -> None:
-        model = RFDETRBase().model.model
+        model = RFDETRBase().model.model  # type: ignore[no-untyped-call]
         fe = RFDETRPackage.get_feature_extractor(model=model)
         assert isinstance(fe, RFDETRFeatureExtractor)
 
     def test_export_model(self, tmp_path: Path) -> None:
         out = tmp_path / "model.pt"
-        model = RFDETRBase().model.model
+        model = RFDETRBase().model.model  # type: ignore[no-untyped-call]
 
         RFDETRPackage.export_model(model=model, out=out)
-        model_exported = RFDETRBase(pretrain_weights=out.as_posix()).model.model
+        model_exported = RFDETRBase(pretrain_weights=out.as_posix()).model.model  # type: ignore[no-untyped-call]
 
         # Check that parameters are the same.
         assert len(list(model.parameters())) == len(list(model_exported.parameters()))


### PR DESCRIPTION
## What has changed and why?

Appease new complains from MyPy re. the RF-DETR typing after version bump of LightlySSL

## How has it been tested?

`make type-check`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
