### PR TITLE
Update memory mapped datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Faster dataset initialization with SLURM and Windows.
 - Transforms and methods are now documented on dedicated pages.
 - Add [version compatibility table](https://docs.lightly.ai/train/stable/installation.html#version-compatibility) to the documentation.
 

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -339,37 +339,37 @@ def get_dataset_mmap_filenames(
     """
     tmp_path = mmap_filepath.with_suffix(".temp")
     LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC = "LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC"
-    if is_rank_zero():
-        # Save filenames to temporary file. Create the final file only once rank zero has
-        # finished writing all the filenames.
-        try:
+    try:
+        if is_rank_zero():
+            # Save filenames to temporary file. Create the final file only once rank zero has
+            # finished writing all the filenames.
             memory_mapped_sequence.write_filenames_to_file(
                 filenames=filenames,
                 mmap_filepath=tmp_path,
             )
             # Rename the temporary file to mmap_filepath.
             tmp_path.replace(mmap_filepath.resolve())
-        finally:
-            tmp_path.unlink(missing_ok=True)
-    else:
-        # Wait for rank zero to finish writing the filenames.
-        timeout_sec = int(os.getenv(LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC, 300))
-        start_time_sec = time.time()
-        while not mmap_filepath.exists():
-            if tmp_path.exists():
-                # Reset timeout if the temporary file exists. This means that rank zero
-                # is still writing the filenames.
-                start_time_sec = time.time()
+        else:
+            # Wait for rank zero to finish writing the filenames.
+            timeout_sec = int(os.getenv(LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC, 300))
+            start_time_sec = time.time()
+            while not mmap_filepath.exists():
+                if tmp_path.exists():
+                    # Reset timeout if the temporary file exists. This means that rank zero
+                    # is still writing the filenames.
+                    start_time_sec = time.time()
 
-            if timeout_sec >= 0 and time.time() - start_time_sec > timeout_sec:
-                raise RuntimeError(
-                    f"Rank {get_rank()}: Timeout after {timeout_sec} seconds "
-                    f"while waiting for the memory-mapped file '{mmap_filepath}' to be created. "
-                    "Please contact Lightly support if this happens. This is most likely a bug. "
-                    f"You can increase the timeout with the {LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC} "
-                    "environment variable. Setting it to -1 disables the timeout. "
-                )
-            time.sleep(0.2)
+                if timeout_sec >= 0 and time.time() - start_time_sec > timeout_sec:
+                    raise RuntimeError(
+                        f"Rank {get_rank()}: Timeout after {timeout_sec} seconds "
+                        f"while waiting for the memory-mapped file '{mmap_filepath}' to be created. "
+                        "Please contact Lightly support if this happens. This is most likely a bug. "
+                        f"You can increase the timeout with the {LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC} "
+                        "environment variable. Setting it to -1 disables the timeout. "
+                    )
+                time.sleep(0.2)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
     # Return memory-mapped filenames from file.
     return memory_mapped_sequence.memory_mapped_sequence_from_file(

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -148,12 +148,12 @@ def get_sha256(value: Any) -> str:
 
 @contextlib.contextmanager
 def verify_out_dir_equal_on_all_ranks(out: Path) -> Generator[None, None, None]:
-    """Verify that the out directory is the same on all ranks.
+    """Verify that the out path is the same on all ranks.
 
-    This is important for distributed training, as the out directory is used as
+    This is important for distributed training, as the out path is used as
     a deterministic value that is consistent across all ranks.
 
-    A common case where this can fail is when the out directory contains a timestamp
+    A common case where this can fail is when the out path contains a timestamp
     in the path that is generated inside the training script. For example with:
     >>> out = f"out/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
     This will result in different paths for each rank as the timestamp is generated
@@ -161,7 +161,7 @@ def verify_out_dir_equal_on_all_ranks(out: Path) -> Generator[None, None, None]:
     """
     out_dir = Path(out).resolve()
     out_tmp = get_verify_out_tmp_dir() / get_sha256(out_dir)
-    logger.debug(f"Creating temporary file '{out_tmp}' to verify out directory.")
+    logger.debug(f"Creating temporary file '{out_tmp}' to verify out path.")
 
     LIGHTLY_TRAIN_VERIFY_OUT_DIR_TIMEOUT_SEC = (
         "LIGHTLY_TRAIN_VERIFY_OUT_DIR_TIMEOUT_SEC"
@@ -182,9 +182,9 @@ def verify_out_dir_equal_on_all_ranks(out: Path) -> Generator[None, None, None]:
                 if timeout_sec >= 0 and time.time() - start_time_sec > timeout_sec:
                     raise RuntimeError(
                         f"Rank {get_rank()}: Timeout after {timeout_sec} seconds "
-                        "while verifying that all ranks (processes) have the same 'out' directory. "
-                        "This means that the 'out' directory is not set to the same path on all ranks. "
-                        "If the path to your 'out' directory contains any timestamps make sure that "
+                        "while verifying that all ranks (processes) have the same 'out' path. "
+                        "This means that the 'out' path is not set to the same path on all ranks. "
+                        "If the path to your 'out' path contains any timestamps make sure that "
                         "they are provided from OUTSIDE of the training script. Either via the "
                         "command line or an environment variable. Timestamps created inside a Python "
                         "script, for example with 'datetime.now()' or 'time.time()', will result "

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -123,7 +123,9 @@ def embed_from_config(config: EmbedConfig) -> None:
     )
     # Create a temporary file to use as a memory map for dataset items. The
     # file has to exist while the dataset is used.
-    with common_helpers.get_dataset_temp_mmap_path(out=out_path) as mmap_filepath:
+    with common_helpers.verify_out_dir_equal_on_all_ranks(
+        out=out_path
+    ), common_helpers.get_dataset_temp_mmap_path(out=out_path) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
             transform=transform,

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -123,7 +123,7 @@ def embed_from_config(config: EmbedConfig) -> None:
     )
     # Create a temporary file to use as a memory map for dataset items. The
     # file has to exist while the dataset is used.
-    with common_helpers.get_dataset_temp_mmap_path() as mmap_filepath:
+    with common_helpers.get_dataset_temp_mmap_path(out=out_path) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
             transform=transform,

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -236,7 +236,7 @@ def train_from_config(config: TrainConfig) -> None:
     # file has to exist while the dataset is used.
     # TODO(Philipp, 10/24): For training it could make sense to store the
     # file in the output directory and recover it on resume.
-    with common_helpers.get_dataset_temp_mmap_path() as mmap_filepath:
+    with common_helpers.get_dataset_temp_mmap_path(out=out_dir) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
             transform=transform_instance,

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -236,7 +236,9 @@ def train_from_config(config: TrainConfig) -> None:
     # file has to exist while the dataset is used.
     # TODO(Philipp, 10/24): For training it could make sense to store the
     # file in the output directory and recover it on resume.
-    with common_helpers.get_dataset_temp_mmap_path(out=out_dir) as mmap_filepath:
+    with common_helpers.verify_out_dir_equal_on_all_ranks(
+        out=out_dir
+    ), common_helpers.get_dataset_temp_mmap_path(out=out_dir) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
             transform=transform_instance,

--- a/src/lightly_train/_data/_serialize/memory_mapped_sequence.py
+++ b/src/lightly_train/_data/_serialize/memory_mapped_sequence.py
@@ -19,6 +19,24 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def write_filenames_to_file(
+    filenames: Iterable[str],
+    mmap_filepath: Path,
+    chunk_size: int = 10_000,
+    column_name: str = "filenames",
+) -> None:
+    """Writes the filenames to a file for memory mapping."""
+    if chunk_size <= 0:
+        raise ValueError(f"Invalid `chunk_size` {chunk_size} must be positive!")
+    logger.debug(f"Writing filenames to '{mmap_filepath}' (chunk_size={chunk_size})")
+    _stream_write_table_to_file(
+        items=filenames,
+        mmap_filepath=mmap_filepath,
+        chunk_size=chunk_size,
+        column_name=column_name,
+    )
+
+
 def memory_mapped_sequence_from_filenames(
     filenames: Iterable[str],
     mmap_filepath: Path,

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -296,27 +296,27 @@ def test_get_num_workers__slurm(
     )
 
 
-def test_get_dataset_temp_mmap_path__rank0() -> None:
-    with common_helpers.get_dataset_temp_mmap_path() as mmap_path:
-        assert mmap_path.exists()
-        assert mmap_path.is_file()
+def test_get_dataset_temp_mmap_path(tmp_path: Path) -> None:
+    with common_helpers.get_dataset_temp_mmap_path(out=tmp_path) as mmap_path:
+        mmap_path.touch()
+    # Make sure file is deleted after exiting the context manager.
+    assert not mmap_path.exists()
 
 
-def test_get_dataset_temp_mmap_path__rank1(mocker: MockerFixture) -> None:
-    with common_helpers.get_dataset_temp_mmap_path() as mmap_path_rank0:
-        # Simulate calling the function from rank 1
-        mocker.patch.dict(os.environ, {"RANK": "1"})
-        with common_helpers.get_dataset_temp_mmap_path() as mmap_path_rank1:
-            assert mmap_path_rank0 == mmap_path_rank1
+def test_get_dataset_temp_mmap_path__rank(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    # Simulate calling the function from rank 0
+    mocker.patch.dict(os.environ, {"RANK": "0"})
+    with common_helpers.get_dataset_temp_mmap_path(out=tmp_path) as mmap_path_rank0:
+        pass
 
+    # Simulate calling the function from rank 1
+    mocker.patch.dict(os.environ, {"RANK": "1"})
+    with common_helpers.get_dataset_temp_mmap_path(out=tmp_path) as mmap_path_rank1:
+        pass
 
-def test_get_dataset_temp_mmap_path__rank1_srun(mocker: MockerFixture) -> None:
-    mocker.patch.dict(os.environ, {"SLURM_NTASKS": "2"})  # created through srun useage
-    with common_helpers.get_dataset_temp_mmap_path() as mmap_path_rank0:
-        # Simulate calling the function from rank 1
-        mocker.patch.dict(os.environ, {"RANK": "1"})
-        with common_helpers.get_dataset_temp_mmap_path() as mmap_path_rank1:
-            assert mmap_path_rank0 != mmap_path_rank1
+    assert mmap_path_rank0 == mmap_path_rank1
 
 
 def test_get_dataset_mmap_filenames__rank0(tmp_path: Path) -> None:
@@ -329,15 +329,19 @@ def test_get_dataset_mmap_filenames__rank0(tmp_path: Path) -> None:
     assert list(mmap_filenames) == filenames
 
 
-def test_get_dataset_mmap_filenames__rank1(
+def test_get_dataset_mmap_filenames__rank(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
     filenames = ["file1.jpg", "file2.jpg", "file3.jpg"]
     mmap_filepath = tmp_path / "test.mmap"
+
+    # Simulate calling the function from rank 0
+    mocker.patch.dict(os.environ, {"RANK": "0"})
     mmap_filenames_rank0 = common_helpers.get_dataset_mmap_filenames(
         filenames=filenames,
         mmap_filepath=mmap_filepath,
     )
+
     # Simulate calling the function from rank 1
     mocker.patch.dict(os.environ, {"RANK": "1"})
     mmap_filenames_rank1 = common_helpers.get_dataset_mmap_filenames(
@@ -348,16 +352,28 @@ def test_get_dataset_mmap_filenames__rank1(
     assert list(mmap_filenames_rank1) == filenames
 
 
-def test_get_dataset_mmap_filenames__rank1_error(
+def test_get_dataset_mmap_filenames__rank_error(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
-    # Check that function fails if it is called from rank1 before rank0.
-    # Simulate calling the function from rank 1
-    mocker.patch.dict(os.environ, {"RANK": "1"})
-    with pytest.raises(FileNotFoundError):
+    # Test that the function raises an error if it is called with different paths
+    # from different ranks.
+    filenames = ["file1.jpg", "file2.jpg", "file3.jpg"]
+    mmap_filepath_rank0 = tmp_path / "rank0.mmap"
+    mmap_filepath_rank1 = tmp_path / "rank1.mmap"
+
+    # Simulate calling the function from rank 0.
+    mocker.patch.dict(os.environ, {"RANK": "0"})
+    common_helpers.get_dataset_mmap_filenames(
+        filenames=filenames,
+        mmap_filepath=mmap_filepath_rank0,
+    )
+
+    # Simulate calling the function from rank 1.
+    mocker.patch.dict(os.environ, {"RANK": "1", "LIGHTLY_TRAIN_MMAP_TIMEOUT_SEC": "5"})
+    with pytest.raises(RuntimeError, match="Rank 1: Timeout after 5 seconds"):
         common_helpers.get_dataset_mmap_filenames(
-            filenames=["file1.jpg", "file2.jpg", "file3.jpg"],
-            mmap_filepath=tmp_path / "test.mmap",
+            filenames=filenames,
+            mmap_filepath=mmap_filepath_rank1,
         )
 
 


### PR DESCRIPTION
## What has changed and why?

* Create single memory mapped dataset files with SLURM and Windows
* Check that `out` path is identical on all ranks

We now create only a single mmap file on all platforms and in all distributed settings (SLURM, torch.distributed, lightning, ...). This speeds up dataset initialization a lot as we only iterate once over the dataset to initialize it. Before this was done on every rank individually.

I could make a follow-up PR to handle cases where we can recover from different out paths on different processes. We can do this if the processes are initialized after the training script is called. In that case we can share the out path from rank 0 to all other ranks. This could avoid errors in many cases.

## How has it been tested?

Tested on Mac and Linux (with and without SLURM):
* `out = Path("out/test") / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")` --> Raises error as expected
* `out = Path("out/test")` -> No error and only a single mmap file is created. Verified that files are cleaned up after run.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)
