### PR TITLE
Update logo and benchmark links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
   <!-- Use absolute links for images to make them render correctly on PyPI and Dockerhub -->
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/lightly-ai/lightly-train/refs/heads/main/docs/source/_static/lightly_train_light.svg">
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/lightly-ai/lightly-train/blob/main/docs/source/_static/lightly_train_dark.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lightly-ai/lightly-train/refs/heads/main/docs/source/_static/lightly_train_dark.svg">
   <img alt="LightlyTrain Logo" src="https://raw.githubusercontent.com/lightly-ai/lightly-train/refs/heads/main/docs/source/_static/lightly_train_light.svg">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <picture>
-  <source media="(prefers-color-scheme: light)" srcset="./docs/source/_static/lightly_train_light.svg">
-  <source media="(prefers-color-scheme: dark)" srcset="./docs/source/_static/lightly_train_dark.svg">
-  <img alt="LightlyTrain Logo" src="./docs/source/_static/lightly_train_light.svg">
+  <!-- Use absolute links for images to make them render correctly on PyPI and Dockerhub -->
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/lightly-ai/lightly-train/refs/heads/main/docs/source/_static/lightly_train_light.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/lightly-ai/lightly-train/blob/main/docs/source/_static/lightly_train_dark.svg">
+  <img alt="LightlyTrain Logo" src="https://raw.githubusercontent.com/lightly-ai/lightly-train/refs/heads/main/docs/source/_static/lightly_train_light.svg">
 </picture>
 
 [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/quick_start.ipynb)
@@ -29,7 +30,7 @@ a wide range of model architectures and use-cases out of the box.
 - 🏗️ **Model & Task Agnostic**: Compatible with any architecture and task, including detection, classification, and segmentation.
 - 🚀 **Industrial-Scale Support**: LightlyTrain scales from thousands to millions of images. Supports on-prem, cloud, single, and multi-GPU setups.
 
-![Benchmark Results](https://github.com/user-attachments/assets/554c4db2-d910-4cfb-9238-6a5d0faaeff8)
+![Benchmark Results](https://cdn.prod.website-files.com/62cd5ce03261cb3e98188470/67fe4efa0209fb4eb0c3da5c_Introducing%20LightlyTrain_imag_1.png)
 
 > On COCO, YOLOv8-s models pretrained with LightlyTrain achieve high performance across all tested label fractions.
 > These improvements hold for other architectures like YOLOv11, RT-DETR, and Faster R-CNN.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -35,7 +35,7 @@ a wide range of model architectures and use-cases out of the box.
 - 🏗️ **Model & Task Agnostic**: Compatible with any architecture and task, including detection, classification, and segmentation.
 - 🚀 **Industrial-Scale Support**: LightlyTrain scales from thousands to millions of images. Supports on-prem, cloud, single, and multi-GPU setups.
 
-```{figure} https://github.com/user-attachments/assets/554c4db2-d910-4cfb-9238-6a5d0faaeff8
+```{figure} https://cdn.prod.website-files.com/62cd5ce03261cb3e98188470/67fe4efa0209fb4eb0c3da5c_Introducing%20LightlyTrain_imag_1.png
 :alt: benchmark results
 
 On COCO, YOLOv8-s models pretrained with LightlyTrain achieve high performance across all tested label fractions.


### PR DESCRIPTION
## What has changed and why?

* Update logo and benchmark links to make them work from other sites like the [Docs](https://docs.lightly.ai/train/stable/), [PyPI](https://pypi.org/project/lightly-train/), and [DockerHub](https://hub.docker.com/repository/docker/lightly/train/general)

I already updated the DockerHub description. The docs and pypi will be updated with the next release. 

## How has it been tested?

* Tested it on DockerHub

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
