### PR TITLE
Rewrite removesuffix

### DIFF
--- a/src/lightly_train/_modules/teachers/dinov2/models/__init__.py
+++ b/src/lightly_train/_modules/teachers/dinov2/models/__init__.py
@@ -15,7 +15,9 @@ from lightly_train._modules.teachers.dinov2.models import vision_transformer as 
 def build_model(
     args, only_teacher=False, img_size=224
 ) -> Union[Tuple[Module, int], Tuple[Module, Module, int]]:
-    args.arch = args.arch.removesuffix("_memeff")
+    suffix = "_memeff"
+    if args.arch.endswith(suffix):
+        args.arch = args.arch[:-len(suffix)]
     if "vit" in args.arch:
         vit_kwargs = dict(
             img_size=img_size,


### PR DESCRIPTION
## What has changed and why?
With the changes from #3 , a bug when using pyhton 3.8 was introduced since the carried over code from dinov2 did use removesuffix which is not available in python 3.8. This PR fixes the issue by rewriting the removesuffix to be python 3.8 compatible.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)
