### PR TITLE
Improved logging for xformers

### DIFF
--- a/src/lightly_train/_modules/teachers/dinov2/layers/attention.py
+++ b/src/lightly_train/_modules/teachers/dinov2/layers/attention.py
@@ -9,12 +9,9 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
 
-import logging
 import os
 
 from torch import Tensor, nn
-
-logger = logging.getLogger(__name__)
 
 XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
@@ -22,15 +19,10 @@ try:
         from xformers.ops import memory_efficient_attention, unbind
 
         XFORMERS_AVAILABLE = True
-        logger.debug("xFormers is available (Attention).")
     else:
         raise ImportError
 except ImportError:
     XFORMERS_AVAILABLE = False
-    logger.debug(
-        "xFormers is not available. This may slow down attention computation and overall training. "
-        "For faster performance, install it via `pip install xformers`."
-    )
 
 
 class Attention(nn.Module):

--- a/src/lightly_train/_modules/teachers/dinov2/layers/block.py
+++ b/src/lightly_train/_modules/teachers/dinov2/layers/block.py
@@ -9,7 +9,6 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
 
-import logging
 import os
 from typing import Any, Callable, Dict, List, Tuple
 
@@ -24,24 +23,16 @@ from lightly_train._modules.teachers.dinov2.layers.drop_path import DropPath
 from lightly_train._modules.teachers.dinov2.layers.layer_scale import LayerScale
 from lightly_train._modules.teachers.dinov2.layers.mlp import Mlp
 
-logger = logging.getLogger(__name__)
-
-
 XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
         from xformers.ops import fmha, index_select_cat, scaled_index_add
 
         XFORMERS_AVAILABLE = True
-        logger.debug("xFormers is available (Block).")
     else:
         raise ImportError
 except ImportError:
     XFORMERS_AVAILABLE = False
-    logger.debug(
-        "xFormers is not available. This may slow down attention computation and overall training. "
-        "For faster performance, install it via `pip install xformers`."
-    )
 
 
 class Block(nn.Module):

--- a/src/lightly_train/_modules/teachers/dinov2/layers/swiglu_ffn.py
+++ b/src/lightly_train/_modules/teachers/dinov2/layers/swiglu_ffn.py
@@ -5,14 +5,11 @@
 # found in the LICENSE file in the root directory of this source tree.
 #
 
-import logging
 import os
 from typing import Callable, Optional
 
 import torch.nn.functional as F
 from torch import Tensor, nn
-
-logger = logging.getLogger(__name__)
 
 
 class SwiGLUFFN(nn.Module):
@@ -44,16 +41,11 @@ try:
         from xformers.ops import SwiGLU
 
         XFORMERS_AVAILABLE = True
-        logger.debug("xFormers is available (SwiGLU).")
     else:
         raise ImportError
 except ImportError:
     SwiGLU = SwiGLUFFN
     XFORMERS_AVAILABLE = False
-    logger.debug(
-        "xFormers is not available. This may slow down attention computation and overall training. "
-        "For faster performance, install it via `pip install xformers`."
-    )
 
 
 class SwiGLUFFNFused(SwiGLU):


### PR DESCRIPTION
## What has changed and why?

The logging around xFormers availability was overloaded. Hence in this PR all logging related to the availability of xFormers is moved to a single place (vision transformer). 

## How has it been tested?

Pending

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)
