### PR TITLE
Distillationv2 loss

### DIFF
--- a/src/lightly_train/_methods/distillationv2/distillationv2_loss.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2_loss.py
@@ -31,10 +31,10 @@ class DistillationV2Loss(Module):
 
         Args:
             teacher_features: Tensor containing teacher representations from the current batch.
-                The expected shape is (batch_size, n_features feature_dim).
+                The expected shape is (batch_size, n_features, feature_dim).
                 n_features is the number of tokens per sequence in the teacher model.
             student_features: Tensor containing student representations from the current batch.
-                The expected shape is (batch_size, n_features feature_dim).
+                The expected shape is (batch_size, n_features, feature_dim).
 
         Returns:
             MSE loss as a scalar tensor.

--- a/src/lightly_train/_methods/distillationv2/distillationv2_loss.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2_loss.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from torch import Tensor
+from torch.nn import Module, MSELoss
+
+
+class DistillationV2Loss(Module):
+    """
+    Computes the Mean Squared Error (MSE) loss used for DistillationV2.
+
+    The loss directly compares the student and teacher representations using the
+    MSE loss function. The student and teacher features are not normalized.
+
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__()
+        self.mse_loss = MSELoss()
+
+    def forward(self, teacher_features: Tensor, student_features: Tensor) -> Tensor:
+        """Computes the MSE loss between the student and teacher features.
+
+        Args:
+            teacher_features: Tensor containing teacher representations from the current batch.
+                The expected shape is (batch_size, n_features feature_dim).
+                n_features is the number of tokens per sequence in the teacher model.
+            student_features: Tensor containing student representations from the current batch.
+                The expected shape is (batch_size, n_features feature_dim).
+
+        Returns:
+            MSE loss as a scalar tensor.
+        """
+        # Compute the loss.
+        loss: Tensor = self.mse_loss(teacher_features, student_features)
+        return loss

--- a/tests/_methods/distillationv2/test_distillationv2_loss.py
+++ b/tests/_methods/distillationv2/test_distillationv2_loss.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+
+import torch
+from torch import Tensor
+
+from lightly_train._methods.distillationv2.distillationv2_loss import DistillationV2Loss
+
+
+class TestDistillationV2Loss:
+    def test_loss_returns_scalar(self) -> None:
+        """Test that the loss function returns a scalar tensor."""
+        # Instantiate the loss function.
+        loss_fn = DistillationV2Loss()
+
+        # Create some dummy inputs.
+        batch_size, n_features, feature_dim = 2, 4, 8
+        teacher_features = torch.randn(batch_size, n_features, feature_dim)
+        student_features = torch.randn(batch_size, n_features, feature_dim)
+
+        # Compute the loss.
+        loss = loss_fn(teacher_features, student_features)
+
+        # Check that loss is a Tensor.
+        assert isinstance(loss, Tensor)
+
+        # Check that loss is a scalar (0-dim).
+        assert loss.dim() == 0
+
+    def test_loss_zero_when_identical(self) -> None:
+        """Test that loss is nearly zero when teacher and student features are identical."""
+        # Instantiate the loss function.
+        loss_fn = DistillationV2Loss()
+
+        # Create some dummy inputs with identical teacher and student features.
+        batch_size, n_features, feature_dim = 2, 4, 8
+        teacher_features = torch.randn(batch_size, n_features, feature_dim)
+        student_features = teacher_features.clone()
+
+        # Compute the loss.
+        loss = loss_fn(teacher_features, student_features)
+
+        # When the features are identical, the MSE loss should be close to 0.
+        assert torch.isclose(loss, torch.tensor(0.0), atol=1e-6)
+
+    def test_loss_non_negative(self) -> None:
+        """Test that the computed loss is non-negative."""
+        # Instantiate the loss function.
+        loss_fn = DistillationV2Loss()
+
+        # Create some dummy inputs.
+        batch_size, n_features, feature_dim = 2, 4, 8
+        teacher_features = torch.randn(batch_size, n_features, feature_dim)
+        student_features = torch.randn(batch_size, n_features, feature_dim)
+
+        # Compute the loss.
+        loss = loss_fn(teacher_features, student_features)
+
+        # MSE loss should be non-negative.
+        assert loss >= 0

--- a/tests/_methods/distillationv2/test_distillationv2_transforms.py
+++ b/tests/_methods/distillationv2/test_distillationv2_transforms.py
@@ -15,7 +15,7 @@ from lightly_train._methods.distillationv2.distillationv2_transform import (
 from lightly_train.types import TransformInput
 
 
-class TestDistillationTransform:
+class TestDistillationV2Transform:
     def test_transform_shapes(self) -> None:
         img_np = np.random.uniform(0, 255, size=(1234, 1234, 3))
         input: TransformInput = {


### PR DESCRIPTION
## What has changed and why?

Add DistillationV2's loss and corresponding tests.

## How has it been tested?

Tests are implemented to check that the loss is a scalar, positive and close to zero when the teacher and student features are identical.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
