### PR TITLE
Move augmentation docs

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -211,7 +211,7 @@ maxdepth: 2
 ---
 quick_start
 installation
-train
+train/index
 export
 embed
 models/index

--- a/docs/source/methods/dino.md
+++ b/docs/source/methods/dino.md
@@ -34,9 +34,11 @@ DINO trains a student network to match the output of a momentum-averaged teacher
 - **Batch Size**: We recommend somewhere between 256 and 1024 for DINO as the original paper suggested.
 - **Number of Epochs**: We recommend somewhere between 100 to 300 epochs. However, DINO benefits from longer schedules and may still improve after training for more than 300 epochs.
 
-## Default Augmentation Settings
+## Default Image Transform Settings
 
 The following are the default augmentation settings for DINO. To learn how you can override these settings, see {ref}`method-transform-args`.
 
+````{dropdown} Default Image Transforms
 ```{include} _auto/dino_transform_args.md
 ```
+````

--- a/docs/source/methods/dino.md
+++ b/docs/source/methods/dino.md
@@ -34,9 +34,9 @@ DINO trains a student network to match the output of a momentum-averaged teacher
 - **Batch Size**: We recommend somewhere between 256 and 1024 for DINO as the original paper suggested.
 - **Number of Epochs**: We recommend somewhere between 100 to 300 epochs. However, DINO benefits from longer schedules and may still improve after training for more than 300 epochs.
 
-## Default Image Transform Settings
+## Default Image Transforms Settings
 
-The following are the default transform settings for DINO. To learn how you can override these settings, see {ref}`method-transform-args`.
+The following are the default transforms settings for DINO. To learn how you can override these settings, see {ref}`method-transform-args`.
 
 ````{dropdown} Default Image Transforms
 ```{include} _auto/dino_transform_args.md

--- a/docs/source/methods/dino.md
+++ b/docs/source/methods/dino.md
@@ -36,7 +36,7 @@ DINO trains a student network to match the output of a momentum-averaged teacher
 
 ## Default Image Transform Settings
 
-The following are the default augmentation settings for DINO. To learn how you can override these settings, see {ref}`method-transform-args`.
+The following are the default transform settings for DINO. To learn how you can override these settings, see {ref}`method-transform-args`.
 
 ````{dropdown} Default Image Transforms
 ```{include} _auto/dino_transform_args.md

--- a/docs/source/methods/distillation.md
+++ b/docs/source/methods/distillation.md
@@ -42,7 +42,7 @@ Our distillation method directly applies a mean squared error (MSE) loss between
 
 ## Default Image Transform Settings
 
-The following are the default augmentation settings for Distillation. To learn how you can override these settings, see {ref}`method-transform-args`.
+The following are the default transform settings for Distillation. To learn how you can override these settings, see {ref}`method-transform-args`.
 
 ````{dropdown} Default Image Transforms
 ```{include} _auto/distillation_transform_args.md

--- a/docs/source/methods/distillation.md
+++ b/docs/source/methods/distillation.md
@@ -40,9 +40,9 @@ Our distillation method directly applies a mean squared error (MSE) loss between
 - **Batch Size**: We recommend somewhere between 128 and 2048 for knowledge distillation.
 - **Number of Epochs**: We recommend somewhere between 100 and 3000. However, distillation benefits from longer schedules and models still improve after training for more than 3000 epochs. For small datasets (\<100k images) it can also be beneficial to train up to 10000 epochs.
 
-## Default Image Transform Settings
+## Default Image Transforms Settings
 
-The following are the default transform settings for Distillation. To learn how you can override these settings, see {ref}`method-transform-args`.
+The following are the default transforms settings for Distillation. To learn how you can override these settings, see {ref}`method-transform-args`.
 
 ````{dropdown} Default Image Transforms
 ```{include} _auto/distillation_transform_args.md

--- a/docs/source/methods/distillation.md
+++ b/docs/source/methods/distillation.md
@@ -40,9 +40,11 @@ Our distillation method directly applies a mean squared error (MSE) loss between
 - **Batch Size**: We recommend somewhere between 128 and 2048 for knowledge distillation.
 - **Number of Epochs**: We recommend somewhere between 100 and 3000. However, distillation benefits from longer schedules and models still improve after training for more than 3000 epochs. For small datasets (\<100k images) it can also be beneficial to train up to 10000 epochs.
 
-## Default Augmentation Settings
+## Default Image Transform Settings
 
 The following are the default augmentation settings for Distillation. To learn how you can override these settings, see {ref}`method-transform-args`.
 
+````{dropdown} Default Image Transforms
 ```{include} _auto/distillation_transform_args.md
 ```
+````

--- a/docs/source/methods/index.md
+++ b/docs/source/methods/index.md
@@ -68,5 +68,4 @@ maxdepth: 1
 distillation
 dino
 simclr
-method_transform_args
 ```

--- a/docs/source/methods/simclr.md
+++ b/docs/source/methods/simclr.md
@@ -34,9 +34,9 @@ SimCLR learns representations by creating two augmented views of the same imageâ
 - **Batch Size**: We recommend a minimum of 256, though somewhere between 1024 and 4096 is ideal since SimCLR usually benefits from large batch sizes.
 - **Number of Epochs**: We recommend a minimum of 800 epochs based on the top-5 linear evaluation results using ResNet-50 on ImageNet-1k reported by the original paper. The top-1 results continues to increase even after 3200 epochs. Also, using a large number of epochs compensates for using a relatively smaller batch size.
 
-## Default Image Transform Settings
+## Default Image Transforms Settings
 
-The following are the default transform settings for SimCLR. To learn how you can override these settings, see {ref}`method-transform-args`.
+The following are the default transforms settings for SimCLR. To learn how you can override these settings, see {ref}`method-transform-args`.
 
 ````{dropdown} Default Image Transforms
 ```{include} _auto/simclr_transform_args.md

--- a/docs/source/methods/simclr.md
+++ b/docs/source/methods/simclr.md
@@ -34,9 +34,11 @@ SimCLR learns representations by creating two augmented views of the same imageâ
 - **Batch Size**: We recommend a minimum of 256, though somewhere between 1024 and 4096 is ideal since SimCLR usually benefits from large batch sizes.
 - **Number of Epochs**: We recommend a minimum of 800 epochs based on the top-5 linear evaluation results using ResNet-50 on ImageNet-1k reported by the original paper. The top-1 results continues to increase even after 3200 epochs. Also, using a large number of epochs compensates for using a relatively smaller batch size.
 
-## Default Augmentation Settings
+## Default Image Transform Settings
 
 The following are the default augmentation settings for SimCLR. To learn how you can override these settings, see {ref}`method-transform-args`.
 
+````{dropdown} Default Image Transforms
 ```{include} _auto/simclr_transform_args.md
 ```
+````

--- a/docs/source/methods/simclr.md
+++ b/docs/source/methods/simclr.md
@@ -36,7 +36,7 @@ SimCLR learns representations by creating two augmented views of the same imageâ
 
 ## Default Image Transform Settings
 
-The following are the default augmentation settings for SimCLR. To learn how you can override these settings, see {ref}`method-transform-args`.
+The following are the default transform settings for SimCLR. To learn how you can override these settings, see {ref}`method-transform-args`.
 
 ````{dropdown} Default Image Transforms
 ```{include} _auto/simclr_transform_args.md

--- a/docs/source/train/index.md
+++ b/docs/source/train/index.md
@@ -59,7 +59,7 @@ out/my_experiment
 The final model checkpoint is saved to `out/my_experiment/checkpoints/last.ckpt`. The
 file `out/my_experiment/exported_models/exported_last.pt` contains the final model,
 exported in the default format (`package_default`) of the used library (see
-[export format](export.md#format) for more details).
+{ref}`export format <export-format>` for more details).
 
 ```{tip}
 Create a new output directory for each experiment to keep training logs, model exports,

--- a/docs/source/train/index.md
+++ b/docs/source/train/index.md
@@ -305,3 +305,11 @@ Not all models support all image sizes.
 ### Performance Optimizations
 
 For performance optimizations, e.g. using accelerators, multi-GPU, multi-node, and half precision training, see the [performance](#performance) page.
+
+```{toctree}
+---
+hidden:
+maxdepth: 1
+---
+method_transform_args
+```

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -4,19 +4,19 @@
 
 Pretraining relies strongly on image augmentations such as:
 
-- **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed 
+- **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed
   resolutions.
-- **Random Horizontal and Vertical Flipping**: Mirrors images across horizontal or vertical 
+- **Random Horizontal and Vertical Flipping**: Mirrors images across horizontal or vertical
   axes.
 - **Random Rotation**: Rotates images by random angles.
 - **Color Jittering**: Randomly modifies brightness, contrast, saturation, and hue.
 - **Random Grayscaling**: Converts images to grayscale with certain probability.
-- **Gaussian Blurring**: Applies Gaussian blur filter of random {math}`\sigma`, smoothing 
+- **Gaussian Blurring**: Applies Gaussian blur filter of random {math}`\sigma`, smoothing
   the image.
 - **Random Solarization**: Inverts pixel values above a random threshold.
 - **Normalization**: Scales pixel values using predefined mean and standard deviation.
 
-```{note}
+```{warning}
 In 99% of cases, it is not necessary to modify the default image augmentations in
 LightlyTrain. The default settings are carefully tuned to work well for most use cases.
 However, for specific downstream tasks or unique image domains, you might want to
@@ -85,7 +85,7 @@ lightly-train train \
 ```
 ````
 
-The next sections will cover which arguments are available across all methods, and also the 
+The next sections will cover which arguments are available across all methods, and also the
 arguments unique to specific methods.
 
 ```{seealso}
@@ -97,7 +97,7 @@ Interested in the default augmentation settings for each method? Check the metho
 
 ## Arguments available for all methods
 
-The following arguments are available for all methods {ref}`methods-distillation`, 
+The following arguments are available for all methods {ref}`methods-distillation`,
 {ref}`methods-dino` and {ref}`methods-simclr`.
 
 ### Random Cropping and Resizing
@@ -200,17 +200,17 @@ Cannot be disabled, required for all transforms.
 
 ## Arguments unique to methods
 
-The methods Distillation and SimCLR have no transform configuration options beyond the 
+The methods Distillation and SimCLR have no transform configuration options beyond the
 globally available ones, which were listed above.
 
 ### DINO
 
-DINO uses a multi-crop strategy with two full-resolution "global" views (which have slightly 
-different augmentation parameters) and optional additional smaller resolution "local" views 
+DINO uses a multi-crop strategy with two full-resolution "global" views (which have slightly
+different augmentation parameters) and optional additional smaller resolution "local" views
 (default: 6 views).
 
-Besides the default arguments, the following DINO-specific arguments are available. Note 
-that `local_view` itself can be disabled by setting it to `None`. Additionally, some 
+Besides the default arguments, the following DINO-specific arguments are available. Note
+that `local_view` itself can be disabled by setting it to `None`. Additionally, some
 augmentations within these structures can be disabled by setting them to `None`:
 
 ```python skip_ruff

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -1,8 +1,8 @@
 (method-transform-args)=
 
-# Configuring Image Augmentations
+# Configuring Image Transforms
 
-Pretraining relies strongly on image augmentations such as:
+Pretraining relies strongly on image transforms such as:
 
 - **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed
   resolutions.
@@ -17,16 +17,16 @@ Pretraining relies strongly on image augmentations such as:
 - **Normalization**: Scales pixel values using predefined mean and standard deviation.
 
 ```{warning}
-In 99% of cases, it is not necessary to modify the default image augmentations in
+In 99% of cases, it is not necessary to modify the default image transforms in
 LightlyTrain. The default settings are carefully tuned to work well for most use cases.
 However, for specific downstream tasks or unique image domains, you might want to
 override these defaults as shown below.
 ```
 
 ````{tab} Python
-For the Python API, use a dictionary structure to override any augmentations settings and 
+For the Python API, use a dictionary structure to override any transforms settings and 
 pass it to the `lightly_train.train` function through the `transform_args` argument. Many 
-augmentations can also be selectively turned off completely by setting them to `None`, as 
+transforms can also be selectively turned off completely by setting them to `None`, as 
 is demonstrated in this example with the `color_jitter` augmentation.
 ```python
 import lightly_train
@@ -48,7 +48,7 @@ if __name__ == "__main__":
 ````
 
 ````{tab} Command Line
-There are two options on how you can configure the augmentations on the command line:
+There are two options on how you can configure the transforms on the command line:
 1. Dotted Notation
 2. Pass all arguments as a single JSON structure
 
@@ -211,7 +211,7 @@ different augmentation parameters) and optional additional smaller resolution "l
 
 Besides the default arguments, the following DINO-specific arguments are available. Note
 that `local_view` itself can be disabled by setting it to `None`. Additionally, some
-augmentations within these structures can be disabled by setting them to `None`:
+transforms within these structures can be disabled by setting them to `None`:
 
 ```python skip_ruff
 "global_view_1": {                     # modifications for second global view (cannot be 

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -2,7 +2,7 @@
 
 # Configuring Image Transforms
 
-Pretraining relies strongly on image transforms such as:
+Pretraining relies strongly on image transforms (augmentations) such as:
 
 - **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed
   resolutions.
@@ -214,8 +214,7 @@ that `local_view` itself can be disabled by setting it to `None`. Additionally, 
 transforms within these structures can be disabled by setting them to `None`:
 
 ```python skip_ruff
-"global_view_1": {                     # modifications for second global view (cannot be 
-                                       # disabled)
+"global_view_1": {                     # modifications for second global view (cannot be disabled)
     "gaussian_blur": {                 # can be disabled by setting to None
         "prob": float,                 
         "sigmas": tuple[float, float],

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -16,9 +16,12 @@ Pretraining relies strongly on image augmentations such as:
 - **Random Solarization**: Inverts pixel values above a random threshold.
 - **Normalization**: Scales pixel values using predefined mean and standard deviation.
 
-While the default settings in LightlyTrain should work well for most use cases, for some 
-downstream tasks and image domains it might be beneficial to override the defaults and 
-adjust the applied augmentations. This can be done as follows:
+```{note}
+In 99% of cases, it is not necessary to modify the default image augmentations in
+LightlyTrain. The default settings are carefully tuned to work well for most use cases.
+However, for specific downstream tasks or unique image domains, you might want to
+override these defaults as shown below.
+```
 
 ````{tab} Python
 For the Python API, use a dictionary structure to override any augmentations settings and 

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -59,7 +59,7 @@ means:
    single quotes).
  - Tuples do not exist, use bracketed notation (like a Python list).
  - JSON's correspondence to Python's `None` is `null`, which you will have to use in order 
-   to selectively turn off an augmentation.
+   to turn off an augmentation.
 ```
 
 An example of how you can use the bracketed notation, would be:
@@ -205,13 +205,11 @@ globally available ones, which were listed above.
 
 ### DINO
 
-DINO uses a multi-crop strategy with two full-resolution "global" views (which have slightly
+DINO uses a multi-crop strategy with two "global" views (which have slightly
 different augmentation parameters) and optional additional smaller resolution "local" views
-(default: 6 views).
+(default: 6 local views).
 
-Besides the default arguments, the following DINO-specific arguments are available. Note
-that `local_view` itself can be disabled by setting it to `None`. Additionally, some
-transforms within these structures can be disabled by setting them to `None`:
+Besides the default arguments, the following DINO-specific arguments are available:
 
 ```python skip_ruff
 "global_view_1": {                     # modifications for second global view (cannot be disabled)
@@ -239,3 +237,6 @@ transforms within these structures can be disabled by setting them to `None`:
     }
 }
 ```
+
+Note that `local_view` itself can be disabled by setting it to `None`. Additionally, some
+transforms within these structures can be disabled by setting them to `None`

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -4,19 +4,27 @@
 
 Pretraining relies strongly on image augmentations such as:
 
-- **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed resolutions.
-- **Random Horizontal and Vertical Flipping**: Mirrors images across horizontal or vertical axes.
+- **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed 
+  resolutions.
+- **Random Horizontal and Vertical Flipping**: Mirrors images across horizontal or vertical 
+  axes.
 - **Random Rotation**: Rotates images by random angles.
 - **Color Jittering**: Randomly modifies brightness, contrast, saturation, and hue.
 - **Random Grayscaling**: Converts images to grayscale with certain probability.
-- **Gaussian Blurring**: Applies Gaussian blur filter of random {math}`\sigma`, smoothing the image.
+- **Gaussian Blurring**: Applies Gaussian blur filter of random {math}`\sigma`, smoothing 
+  the image.
 - **Random Solarization**: Inverts pixel values above a random threshold.
 - **Normalization**: Scales pixel values using predefined mean and standard deviation.
 
-While the default settings in LightlyTrain should work well for most use cases, for some downstream tasks and image domains it might be beneficial to override the defaults and adjust the applied augmentations. This can be done as follows:
+While the default settings in LightlyTrain should work well for most use cases, for some 
+downstream tasks and image domains it might be beneficial to override the defaults and 
+adjust the applied augmentations. This can be done as follows:
 
 ````{tab} Python
-For the Python API, use a dictionary structure to override any augmentations settings and pass it to the `lightly_train.train` function through the `transform_args` argument. Many augmentations can also be selectively turned off completely by setting them to `None`, as is demonstrated in this example with the `color_jitter` augmentation.
+For the Python API, use a dictionary structure to override any augmentations settings and 
+pass it to the `lightly_train.train` function through the `transform_args` argument. Many 
+augmentations can also be selectively turned off completely by setting them to `None`, as 
+is demonstrated in this example with the `color_jitter` augmentation.
 ```python
 import lightly_train
 my_transform_args = {
@@ -42,10 +50,13 @@ There are two options on how you can configure the augmentations on the command 
 2. Pass all arguments as a single JSON structure
 
 ```{important}
-Make sure that any values that you pass through the command line are JSON-compatible. This means:
- - Strings inside JSON structures must have double quotes (wrap the whole structure by single quotes).
+Make sure that any values that you pass through the command line are JSON-compatible. This 
+means:
+ - Strings inside JSON structures must have double quotes (wrap the whole structure by 
+   single quotes).
  - Tuples do not exist, use bracketed notation (like a Python list).
- - JSON's correspondence to Python's `None` is `null`, which you will have to use in order to selectively turn off an augmentation.
+ - JSON's correspondence to Python's `None` is `null`, which you will have to use in order 
+   to selectively turn off an augmentation.
 ```
 
 An example of how you can use the bracketed notation, would be:
@@ -66,22 +77,25 @@ And an example of using a single JSON structure would look as follows:
 lightly-train train \
     out="out/my_experiment" \
     data="my_data_dir" model="torchvision/resnet18" \
-    transform_args='{"image_size": [128, 128], "random_resize": {"min_scale": 0.1}, "color_jitter": null}'
+    transform_args='{"image_size": [128, 128], "random_resize": {"min_scale": 0.1}, 
+    "color_jitter": null}'
 ```
 ````
 
-The next sections will cover which arguments are available across all methods, and also the arguments unique to specific methods.
+The next sections will cover which arguments are available across all methods, and also the 
+arguments unique to specific methods.
 
 ```{seealso}
 Interested in the default augmentation settings for each method? Check the method pages:
- - {ref}`methods-dino`
  - {ref}`methods-distillation`
+ - {ref}`methods-dino`
  - {ref}`methods-simclr`
 ```
 
 ## Arguments available for all methods
 
-The following arguments are available for all methods {ref}`methods-distillation`, {ref}`methods-dino` and {ref}`methods-simclr`.
+The following arguments are available for all methods {ref}`methods-distillation`, 
+{ref}`methods-dino` and {ref}`methods-simclr`.
 
 ### Random Cropping and Resizing
 
@@ -183,16 +197,22 @@ Cannot be disabled, required for all transforms.
 
 ## Arguments unique to methods
 
-The methods Distillation and SimCLR have no transform configuration options beyond the globally available ones, which were listed above.
+The methods Distillation and SimCLR have no transform configuration options beyond the 
+globally available ones, which were listed above.
 
 ### DINO
 
-DINO uses a multi-crop strategy with two full-resolution "global" views (which have slightly different augmentation parameters) and optional additional smaller resolution "local" views (default: 6 views).
+DINO uses a multi-crop strategy with two full-resolution "global" views (which have slightly 
+different augmentation parameters) and optional additional smaller resolution "local" views 
+(default: 6 views).
 
-Besides the default arguments, the following DINO-specific arguments are available. Note that `local_view` itself can be disabled by setting it to `None`. Additionally, some augmentations within these structures can be disabled by setting them to `None`:
+Besides the default arguments, the following DINO-specific arguments are available. Note 
+that `local_view` itself can be disabled by setting it to `None`. Additionally, some 
+augmentations within these structures can be disabled by setting them to `None`:
 
 ```python skip_ruff
-"global_view_1": {                     # modifications for second global view (cannot be disabled)
+"global_view_1": {                     # modifications for second global view (cannot be 
+                                       # disabled)
     "gaussian_blur": {                 # can be disabled by setting to None
         "prob": float,                 
         "sigmas": tuple[float, float],

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -80,8 +80,7 @@ And an example of using a single JSON structure would look as follows:
 lightly-train train \
     out="out/my_experiment" \
     data="my_data_dir" model="torchvision/resnet18" \
-    transform_args='{"image_size": [128, 128], "random_resize": {"min_scale": 0.1}, 
-    "color_jitter": null}'
+    transform_args='{"image_size": [128, 128], "random_resize": {"min_scale": 0.1}, "color_jitter": null}'
 ```
 ````
 


### PR DESCRIPTION
## What has changed and why?

* Move augmentation docs under train docs
  * This declutters the Method section in the docs. I think it makes sense to put all train related configuration und the train command. 
* Add warning that augmentations should not be changed in most cases
  * Makes it a bit clearer that you really shouldn't have to change augmentations.
* Rename augmentations in docs to transforms to be consistent with code
  * I found it weird that the docs talk about augmentations but the argument is called `transform_args`. Hope it is a bit clearer now.
* Put default method transforms into dropdown to keep page concise
  * I'll do the same when adding the method args. Otherwise the page will be mostly arguments which feels overwhelming.

This PR prepares the docs for adding documentation for the method arguments.


## How has it been tested?

<img width="1567" alt="Screenshot 2025-05-15 at 13 24 53" src="https://github.com/user-attachments/assets/1ddc20d4-723d-49e9-a1ff-85e866030927" />

[Configuring Image Transforms - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20228182/Configuring.Image.Transforms.-.LightlyTrain.documentation.pdf)

[Distillation (recommended 🚀) - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20228184/Distillation.recommended.-.LightlyTrain.documentation.pdf)


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
