### PR TITLE
Fixed bug getting pool layer with timm

### DIFF
--- a/src/lightly_train/_models/timm/timm.py
+++ b/src/lightly_train/_models/timm/timm.py
@@ -124,7 +124,7 @@ def _get_pool_layer(model: Module) -> Module:
     ):
         # Get global_pool stored on the head. For example for RegNet:
         # https://github.com/huggingface/pytorch-image-models/blob/e748805be31318da1a0e34b61294704666f50397/timm/models/regnet.py#L452
-        global_pool_head: Module = model.global_pool
+        global_pool_head: Module = model.head.global_pool
         return global_pool_head
     logger.warning(
         "Could not find pooling layer on the model, defaulting to AdaptiveAvgPool2d"


### PR DESCRIPTION
## What has changed and why?

When loading a timm-wrapped model, it fails if the `global_pool` layer is within `model.head`.

## How has it been tested?

If you now try to use `convnext_base` as a timm model, it now works, while it didn't before.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [X] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [X] Not needed (internal change without effects for user)
