### PR TITLE
Add LIGHTLY_TRAIN_TMP_DIR variable

### DIFF
--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -115,8 +115,8 @@ def get_tmp_dir() -> Path:
     """Get the temporary directory for Lightly Train."""
     tmp_dir = Env.LIGHTLY_TRAIN_TMP_DIR.value
     if tmp_dir is None:
-        tmp_dir = Path(tempfile.gettempdir())
-    return tmp_dir / "lightly-train"
+        tmp_dir = Path(tempfile.gettempdir()) / "lightly-train"
+    return tmp_dir
 
 
 def get_data_tmp_dir() -> Path:

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -113,7 +113,10 @@ def get_out_dir(out: PathLike, resume: bool, overwrite: bool) -> Path:
 
 def get_tmp_dir() -> Path:
     """Get the temporary directory for Lightly Train."""
-    return Path(tempfile.gettempdir()) / "lightly-train"
+    tmp_dir = Env.LIGHTLY_TRAIN_TMP_DIR.value
+    if tmp_dir is None:
+        tmp_dir = Path(tempfile.gettempdir())
+    return tmp_dir / "lightly-train"
 
 
 def get_data_tmp_dir() -> Path:

--- a/src/lightly_train/_env.py
+++ b/src/lightly_train/_env.py
@@ -58,6 +58,13 @@ class Env:
         default=Path.home() / ".cache" / "lightly-train",
         type_=Path,
     )
+    # Path to directory where temporary files are stored. By default, the temporary
+    # directory from the system is used.
+    LIGHTLY_TRAIN_TMP_DIR: EnvVar[Path | None] = EnvVar(
+        name="LIGHTLY_TRAIN_TMP_DIR",
+        default=None,
+        type_=Path,
+    )
     # Timeout in seconds for the dataloader to collect a batch from the workers. This is
     # used to prevent the dataloader from hanging indefinitely. Set to 0 to disable the
     # timeout.

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -146,7 +146,7 @@ def test_verify_out_dir_equal_on_all_local_ranks(
             pass
 
     # Make sure that no files are left in the temporary directory.
-    assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
+    assert not tmp_dir.exists() or not any(f for f in tmp_dir.iterdir() if f.is_file())
 
 
 def test_verify_out_dir_equal_on_all_local_ranks__different(
@@ -172,7 +172,7 @@ def test_verify_out_dir_equal_on_all_local_ranks__different(
                 pass
 
     # Make sure that no files are left in the temporary directory.
-    assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
+    assert not tmp_dir.exists() or not any(f for f in tmp_dir.iterdir() if f.is_file())
 
 
 def test_verify_out_dir_equal_on_all_local_ranks__no_rank0(
@@ -193,7 +193,7 @@ def test_verify_out_dir_equal_on_all_local_ranks__no_rank0(
             pass
 
     # Make sure that no files are left in the temporary directory.
-    assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
+    assert not tmp_dir.exists() or not any(f for f in tmp_dir.iterdir() if f.is_file())
 
 
 @pytest.mark.parametrize(

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -120,9 +120,22 @@ def test_get_out_dir__nonempty(
             common_helpers.get_out_dir(out=tmp_path, resume=resume, overwrite=overwrite)
 
 
+def test_get_tmp_dir() -> None:
+    assert common_helpers.get_tmp_dir()
+
+
+def test_get_tmp_dir__custom(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch.dict(os.environ, {"LIGHTLY_TRAIN_TMP_DIR": str(tmp_path)})
+    assert common_helpers.get_tmp_dir() == tmp_path / "lightly-train"
+
+
 def test_verify_out_dir_equal_on_all_local_ranks(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
+    # Use clean temporary directory for the test.
+    tmp_dir = tmp_path / "tmp"
+    mocker.patch.dict(os.environ, {"LIGHTLY_TRAIN_TMP_DIR": str(tmp_dir)})
+
     out_dir = tmp_path / "out"
     # Simulate calling the function from rank 0
     mocker.patch.dict(os.environ, {"LOCAL_RANK": "0"})
@@ -133,12 +146,16 @@ def test_verify_out_dir_equal_on_all_local_ranks(
             pass
 
     # Make sure that no files are left in the temporary directory.
-    assert not any(common_helpers.get_verify_out_tmp_dir().iterdir())
+    assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
 
 
 def test_verify_out_dir_equal_on_all_local_ranks__different(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
+    # Use clean temporary directory for the test.
+    tmp_dir = tmp_path / "tmp"
+    mocker.patch.dict(os.environ, {"LIGHTLY_TRAIN_TMP_DIR": str(tmp_dir)})
+
     out_dir_rank0 = tmp_path / "rank0"
     out_dir_rank1 = tmp_path / "rank1"
 
@@ -155,12 +172,16 @@ def test_verify_out_dir_equal_on_all_local_ranks__different(
                 pass
 
     # Make sure that no files are left in the temporary directory.
-    assert not any(common_helpers.get_verify_out_tmp_dir().iterdir())
+    assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
 
 
 def test_verify_out_dir_equal_on_all_local_ranks__no_rank0(
     tmp_path: Path, mocker: MockerFixture
 ) -> None:
+    # Use clean temporary directory for the test.
+    tmp_dir = tmp_path / "tmp"
+    mocker.patch.dict(os.environ, {"LIGHTLY_TRAIN_TMP_DIR": str(tmp_dir)})
+
     out_dir = tmp_path / "rank1"
 
     mocker.patch.dict(
@@ -172,7 +193,7 @@ def test_verify_out_dir_equal_on_all_local_ranks__no_rank0(
             pass
 
     # Make sure that no files are left in the temporary directory.
-    assert not any(common_helpers.get_verify_out_tmp_dir().iterdir())
+    assert not tmp_dir.exists() or not any(tmp_dir.iterdir())
 
 
 @pytest.mark.parametrize(

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -126,7 +126,7 @@ def test_get_tmp_dir() -> None:
 
 def test_get_tmp_dir__custom(tmp_path: Path, mocker: MockerFixture) -> None:
     mocker.patch.dict(os.environ, {"LIGHTLY_TRAIN_TMP_DIR": str(tmp_path)})
-    assert common_helpers.get_tmp_dir() == tmp_path / "lightly-train"
+    assert common_helpers.get_tmp_dir() == tmp_path
 
 
 def test_verify_out_dir_equal_on_all_local_ranks(


### PR DESCRIPTION
## What has changed and why?

* Allow overwriting the temporary directory used by LightlyTrain

The directory can be overwritten with the `LIGHTLY_TRAIN_TMP_DIR` variable.
Added this as it is also helpful for testing. 

## How has it been tested?

* Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
