### PR TITLE
Require kwarg for Public Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Make all public interface only allow keyword arguments.
+- All functions require keyword arguments as input.
 - Distillation uses the official DINOv2 implementation for the teacher model.
 - The RT-DETR example uses RT-DETRv2, which is backward compatible while imposing fewer constraints on package versions.
 - The original distillation method is now selected with `method="distillationv1"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Make all public interface only allow keyword arguments.
 - New, improved distillationv2 method that achieves higher accuracy and trains up to 3x faster than distillationv1.
   The new method is selected as default by LightlyTrain with `method="distillation"`. The old distillation method
   can still be used with `method="distillationv1"` for backwards compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Make all public interface only allow keyword arguments.
 - New, improved distillationv2 method that achieves higher accuracy and trains up to 3x faster than distillationv1.
   The new method is selected as default by LightlyTrain with `method="distillation"`. The old distillation method
   can still be used with `method="distillationv1"` for backwards compatibility.
@@ -20,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make all public interface only allow keyword arguments.
 - Distillation uses the official DINOv2 implementation for the teacher model.
 - The RT-DETR example uses RT-DETRv2, which is backward compatible while imposing fewer constraints on package versions.
 - The original distillation method is now selected with `method="distillationv1"`.

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def embed(
+    *,
     out: PathLike,
     data: PathLike | Sequence[PathLike],
     checkpoint: PathLike,

--- a/src/lightly_train/_commands/export.py
+++ b/src/lightly_train/_commands/export.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 def export(
+    *,
     out: PathLike,
     checkpoint: PathLike,
     part: str | ModelPart = "model",

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 def train(
+    *,
     out: PathLike,
     data: PathLike | Sequence[PathLike],
     model: str | Module | ModelWrapper,


### PR DESCRIPTION
## What has changed and why?

Make all public function accept only kwargs

## How has it been tested?

[lightly_train - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20351265/lightly_train.-.LightlyTrain.documentation.pdf)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [] Yes
- [x] Not needed (auto change)
