### PR TITLE
Disable albumentations update check

### DIFF
--- a/src/lightly_train/__init__.py
+++ b/src/lightly_train/__init__.py
@@ -26,7 +26,7 @@ torchvision.disable_beta_transforms_warning()
 # Disable albumentations update check.
 import os
 
-os.environ["NO_ALBUMENTATIONS_UPDATE_CHECK"] = "1"
+os.environ["NO_ALBUMENTATIONS_UPDATE"] = "1"
 
 from lightly_train._commands.common_helpers import ModelFormat, ModelPart
 from lightly_train._commands.embed import embed

--- a/src/lightly_train/__init__.py
+++ b/src/lightly_train/__init__.py
@@ -23,6 +23,11 @@ import torchvision
 
 torchvision.disable_beta_transforms_warning()
 
+# Disable albumentations update check.
+import os
+
+os.environ["NO_ALBUMENTATIONS_UPDATE_CHECK"] = "1"
+
 from lightly_train._commands.common_helpers import ModelFormat, ModelPart
 from lightly_train._commands.embed import embed
 from lightly_train._commands.export import export


### PR DESCRIPTION
## What has changed and why?

* Disable the albumentations update check

This hides the following warning that pops up if not the latest albumentations version is installed:
```
UserWarning: A new version of Albumentations is available: '2.0.7' (you have '2.0.6'). Upgrade using: pip install -U albumentations. To disable automatic update checks, set the environment variable NO_ALBUMENTATIONS_UPDATE to 1.
  check_for_updates()
```

The check sadly runs at import of albumentations and not when the library is actually used. This is why we have to set the env variable so early.

## How has it been tested?

Tested manually. Didn't write a unit test as it would require manually installed an outdated albumentations version.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
