### PR TITLE
remove rank zero

### DIFF
--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -98,11 +98,7 @@ def get_out_dir(out: PathLike, resume: bool, overwrite: bool) -> Path:
 
         dir_not_empty = any(out_dir.iterdir())
 
-        if (
-            dir_not_empty
-            and (not (resume or overwrite))
-            and distributed_helpers.is_global_rank_zero()
-        ):
+        if dir_not_empty and (not (resume or overwrite)):
             raise ValueError(
                 f"Output '{out_dir}' is not empty! Set overwrite=True to overwrite the "
                 "directory or resume=True to resume training."


### PR DESCRIPTION
## What has changed and why?
- removes rank-zero check in `get_out_dir`
- this check had non-rank-zero processes dangling in SLURM's `srun` context
- the check is not necessary anymore, since we now 

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)
