### PR TITLE
Only show info when xformers are available

### DIFF
--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
@@ -42,11 +42,6 @@ XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 def check_xformers():
     if XFORMERS_INSTALLED and XFORMERS_ENABLED:
         logger.debug("xFormers is available.")
-    else:
-        logger.warning(
-            "xFormers is not available. This may slow down attention computation and overall training. "
-            "For faster performance, install it via `pip install xformers`."
-        )
 
 
 def named_apply(


### PR DESCRIPTION
## What has changed and why?

Since we only so around 10% performance improvement when using xformers, we decide to not bother users by warning about xformers missing.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
