### PR TITLE
Fix docker test

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -35,6 +35,7 @@ test:
 		-v $(LIGHTLY_TRAIN_OUT):/out \
 		-v $(LIGHTLY_TRAIN_DATA):/data \
 		-v ./Makefile:/home/lightly_train/docker/Makefile \
+		-v ./variables.mk:/home/lightly_train/docker/variables.mk \
 		--gpus all \
 		lightly/$(IMAGE):$(TAG) \
 		make test-from-with-docker -C docker


### PR DESCRIPTION
## What has changed and why?

* Mount variables.mk file when running docker tests

Change was introduced in #75 

Without the fix the tests fail with:
```
	make test-from-with-docker -C docker
make: Entering directory '/home/lightly_train/docker'
Makefile:2: variables.mk: No such file or directory
make: Leaving directory '/home/lightly_train/docker'
make: *** No rule to make target 'variables.mk'.  Stop.
make: *** [Makefile:34: test] Error 2
```

## How has it been tested?

* Tested manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
