### PR TITLE
Fix: training stops after one epoch

### DIFF
--- a/src/lightly_train/_callbacks/export.py
+++ b/src/lightly_train/_callbacks/export.py
@@ -34,6 +34,9 @@ class ModelExport(Callback):
         self._wrapped_model = wrapped_model
         self._out_dir = out_dir
         self._every_n_epochs = every_n_epochs
+        self._package = package_helpers.get_package_from_model(
+            self._wrapped_model, include_custom=True, fallback_custom=True
+        )
 
     @rank_zero_only  # type: ignore[misc]
     def _safe_export_model(self, export_path: Path) -> None:
@@ -41,14 +44,11 @@ class ModelExport(Callback):
         if export_path.exists():
             export_path.unlink(missing_ok=True)
 
-        package = package_helpers.get_package_from_model(
-            self._wrapped_model, include_custom=True, fallback_custom=True
-        )
         common_helpers.export_model(
             model=self._wrapped_model,
             out=export_path,
             format=ModelFormat.PACKAGE_DEFAULT,
-            package=package,
+            package=self._package,
             log_example=False,
         )
 


### PR DESCRIPTION
## What has changed and why?

This PR fixes this issue. In some settings, the training stoped after one epoch without any error. The issues was traced down to a ultralytics update and how we scan for packages available for the esport of the model. In short, ultralytics was imported on rank 0 but not on the others. The fix in this case was easy: simply scan the package on init, not only on rank 0.


## How has it been tested?
In the environment that crashed with the old version, the failure did occur again.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
