### PR TITLE
Update rfdetr notebooks

### DIFF
--- a/examples/notebooks/rfdetr.ipynb
+++ b/examples/notebooks/rfdetr.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will demonstrate how you can use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) to pretrain an [RF-DETR model](https://github.com/roboflow/rf-detr) from Roboflow. For now, `rfdetr` only supports training with datasets in COCO JSON format. To this end, for pretraining we use the raw images (**no labels**) from [the COCO-minibatch dataset](https://github.com/giddyyupp/coco-minitrain), a subset of the COCO dataset with 25k images, and for fine-tuning we use the Roboflow's [Coconut Custom Dataset](https://universe.roboflow.com/ravi-mgvlz/coconut-custom-dataset).\n",
+    "In this notebook we will demonstrate how you can use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) to pretrain an [RF-DETR model](https://github.com/roboflow/rf-detr) from Roboflow. For now, `rfdetr` only supports training with datasets in COCO JSON format. To this end, for pretraining we use the raw images (**no labels**) from [the COCO-minitrain dataset](https://github.com/giddyyupp/coco-minitrain), a subset of the COCO dataset with 25k images, and for fine-tuning we use the Roboflow's [Coconut Custom Dataset](https://universe.roboflow.com/ravi-mgvlz/coconut-custom-dataset).\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/rfdetr.ipynb)\n",
     "\n",
@@ -56,7 +56,7 @@
    "source": [
     "## Pretrain on COCO-minitrain-25k Dataset\n",
     "\n",
-    "We use [the COCO-minibatch dataset](https://github.com/giddyyupp/coco-minitrain), a subset of the COCO dataset with 25k images for pretraining the RF-DETR model. This dataset is available in COCO JSON format.\n",
+    "We use [the COCO-minitrain dataset](https://github.com/giddyyupp/coco-minitrain), a subset of the COCO dataset with 25k images for pretraining the RF-DETR model.\n",
     "\n",
     "### Download the Dataset\n",
     "\n",
@@ -140,6 +140,11 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Fine-tune on Coconuts Custom Dataset\n",
     "\n",
@@ -178,7 +183,7 @@
    "source": [
     "### Fine-tune an RF-DETR Model\n",
     "\n",
-    "You can use the `rfdetr` package for fine-tuning directly."
+    "You can directly use the `rfdetr` package for fine-tuning."
    ]
   },
   {

--- a/examples/notebooks/rfdetr.ipynb
+++ b/examples/notebooks/rfdetr.ipynb
@@ -92,7 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "... and since LightlyTrain does not require any labels, we can can also confidently delete all the labels:"
+    "... and since LightlyTrain does not require any labels, we can also confidently delete all the labels:"
    ]
   },
   {

--- a/examples/notebooks/rfdetr.ipynb
+++ b/examples/notebooks/rfdetr.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we will demonstrate how you can use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) to pretrain an [RF-DETR model](https://github.com/roboflow/rf-detr). To this end, we will first use the raw images (**no labels**) from the [Coconuts dataset](https://universe.roboflow.com/traindataset/coconuts-plj8h) for pretraining and then fine-tuning on the labeled dataset.\n",
+    "In this notebook we will demonstrate how you can use [LightlyTrain](https://docs.lightly.ai/train/stable/index.html) to pretrain an [RF-DETR model](https://github.com/roboflow/rf-detr) from Roboflow. For now, `rfdetr` only supports training with datasets in COCO JSON format. To this end, for pretraining we use the raw images (**no labels**) from [the COCO-minibatch dataset](https://github.com/giddyyupp/coco-minitrain), a subset of the COCO dataset with 25k images, and for fine-tuning we use the Roboflow's [Coconut Custom Dataset](https://universe.roboflow.com/ravi-mgvlz/coconut-custom-dataset).\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/rfdetr.ipynb)\n",
     "\n",
@@ -54,9 +54,100 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download Dataset\n",
+    "## Pretrain on COCO-minitrain-25k Dataset\n",
     "\n",
-    "For now, `rfdetr` only supports training with datasets in COCO JSON format. They can be directly downloaded via their API:\n"
+    "We use [the COCO-minibatch dataset](https://github.com/giddyyupp/coco-minitrain), a subset of the COCO dataset with 25k images for pretraining the RF-DETR model. This dataset is available in COCO JSON format.\n",
+    "\n",
+    "### Download the Dataset\n",
+    "\n",
+    "We can download the COCO-minitrain dataset (25k images) directly from HuggingFace\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget https://huggingface.co/datasets/bryanbocao/coco_minitrain/resolve/main/coco_minitrain_25k.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... unzip it..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!unzip coco_minitrain_25k.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... and since LightlyTrain does not require any labels, we can can also confidently delete all the labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf coco_minitrain_25k/labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pretrain an RF-DETR Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pretraining an RF-DETR model with LightlyTrain is straightforward:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lightly_train\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    lightly_train.train(\n",
+    "        out=\"out/my_experiment\",                                        # Output directory.\n",
+    "        data=\"coco_minitrain_25k/images\",                               # Directory with images.\n",
+    "        model=\"rfdetr/rf-detr-base\",                                    # Pass the RF-DETR model.\n",
+    "        epochs=5,                                                       # Number of epochs to train\n",
+    "        batch_size=16,                                                  # Batch size\n",
+    "        overwrite=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fine-tune on Coconuts Custom Dataset\n",
+    "\n",
+    "We use Roboflow's [Coconut Custom Dataset](https://universe.roboflow.com/ravi-mgvlz/coconut-custom-dataset) for fine-tuning.\n",
+    "\n",
+    "### Download the Dataset\n",
+    "\n",
+    "The dataset can be directly downloaded via Roboflow API:"
    ]
   },
   {
@@ -68,31 +159,6 @@
     "from roboflow import Roboflow\n",
     "\n",
     "rf = Roboflow(api_key=\"your_roboflow_api_key\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We use Roboflow's [Coconuts dataset](https://universe.roboflow.com/traindataset/coconuts-plj8h) for pretraining."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "project = rf.workspace(\"traindataset\").project(\"coconuts-plj8h\")\n",
-    "version = project.version(1)\n",
-    "pretrain_dataset = version.download(\"coco\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We use Roboflow's [Coconut Custom Dataset](https://universe.roboflow.com/ravi-mgvlz/coconut-custom-dataset) for fine-tuning."
    ]
   },
   {
@@ -110,49 +176,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pretrain and Fine-tune an RF-DETR Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Pretraining an RF-DETR model with LightlyTrain is straightforward:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Pretrain"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lightly_train\n",
+    "### Fine-tune an RF-DETR Model\n",
     "\n",
-    "if __name__ == \"__main__\":\n",
-    "    lightly_train.train(\n",
-    "        out=\"out/my_experiment\",                                        # Output directory.\n",
-    "        data=pretrain_dataset.location,                                 # Directory with images.\n",
-    "        model=\"rfdetr/rf-detr-base\",                                    # Pass the RF-DETR model.\n",
-    "        epochs=5,                                                       # Number of epochs to train\n",
-    "        batch_size=16,                                                  # Batch size\n",
-    "        overwrite=True,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Fine-tune\n",
-    "\n",
-    "You can use `rfdetr` for fine-tuning directly."
+    "You can use the `rfdetr` package for fine-tuning directly."
    ]
   },
   {
@@ -171,6 +197,7 @@
  "metadata": {
   "kernelspec": {
    "display_name": "python3",
+   "language": "python",
    "name": "python3"
   }
  },

--- a/examples/notebooks/ultralytics_yolo.ipynb
+++ b/examples/notebooks/ultralytics_yolo.ipynb
@@ -84,7 +84,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "... and since Lightly**Train** does not require any labels, we can can also confidently delete all the labels:"
+    "... and since Lightly**Train** does not require any labels, we can also confidently delete all the labels:"
    ]
   },
   {


### PR DESCRIPTION
## What has changed and why?

Use distinct datasets for pretraining and fine-tuning in the RFDETR tutorial notebook. 
Make pretraining and fine-tuning into individual sections.

## How has it been tested?

Run on Colab

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
