### PR TITLE
Revert changes to original vit cfgs

### DIFF
--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vitb14.yaml
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vitb14.yaml
@@ -3,5 +3,3 @@ student:
   patch_size: 14
   drop_path_rate: 0.2
   ffn_layer: swiglufused
-crops:
-  global_crops_size: 518  # this is to set up the position embeddings properly

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vitg14.yaml
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vitg14.yaml
@@ -24,4 +24,3 @@ optim:
   layerwise_decay: 1.0
 crops:
   local_crops_size: 98
-  global_crops_size: 518  # this is to set up the position embeddings properly

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vitl14.yaml
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vitl14.yaml
@@ -24,4 +24,3 @@ optim:
   layerwise_decay: 1.0
 crops:
   local_crops_size: 98
-  global_crops_size: 518  # this is to set up the position embeddings properly

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vits14.yaml
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/vits14.yaml
@@ -2,5 +2,3 @@ student:
   arch: vit_small
   patch_size: 14
   drop_path_rate: 0.1
-crops:
-  global_crops_size: 518  # this is to set up the position embeddings properly


### PR DESCRIPTION
## What has changed and why?

Due to changes in #72 we need to revert the changes in the train cfgs. The reason it was introduced: there were situations where the train cfg was used with pre-trained weights, which required the cfg to be changed. This situation can not happen anymore, hence it is changed back.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
