### PR TITLE
Add RT-DETR ModelWrapper to `model_wrappers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- RT-DETR has now an integrated model wrapper.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - RT-DETR has now an integrated model wrapper.
 
 ### Changed

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -29,6 +29,13 @@ cd RT-DETR/rtdetrv2_pytorch
 Next, create a Python environment using your preferred tool and install the required dependencies.
 Some dependencies are fixed to specific versions to ensure compatibility with RT-DETR:
 
+```{note}
+Due to recent changes in the RT-DETR repository, RT-DETR's dependencies are compatible
+with Python >=3.8 and <=3.10. However, if you don't need TensorRT support, you can 
+simply comment out the `tensorrt` dependency in the `requirements.txt` file and you 
+should be able to use Python 3.11 or 3.12 as well.
+```
+
 ```bash
 pip install lightly-train -r requirements.txt
 ```
@@ -50,27 +57,8 @@ from torch import Tensor
 from torch.nn import AdaptiveAvgPool2d, Module
 
 import lightly_train
+from lightly_train.model_wrappers import RTDETRModelWrapper
 from src.core import YAMLConfig
-
-
-class RTDETRModelWrapper(Module):
-    def __init__(self, model: Module):
-        super().__init__()
-        self._model = model
-        self._pool = AdaptiveAvgPool2d((1, 1))
-
-    def get_model(self) -> Module:
-        return self._model
-
-    def forward_features(self, x: Tensor) -> Dict[str, Tensor]:
-        features = self._model.backbone(x)[-1]
-        return {"features": features}
-
-    def forward_pool(self, x: Dict[str, Tensor]) -> Dict[str, Tensor]:
-        return {"pooled_features": self._pool(x["features"])}
-
-    def feature_dim(self) -> int:
-        return self._model.backbone.out_channels[-1]
 
 
 if __name__ == "__main__":
@@ -85,11 +73,8 @@ if __name__ == "__main__":
     lightly_train.train(
         out="out/my_experiment",
         model=wrapped_model,
-        data="./dataset/coco/train2017", # Replace with your dataset path.
+        data="my_data_dir", # Replace with your dataset path.
     )
-
-    # Save the pretrained model for fine-tuning
-    torch.save(model.state_dict(), "out/my_experiment/pretrained_model.pt")
 ```
 
 ### Fine-Tune
@@ -100,7 +85,7 @@ RT-DETR training script by providing the path to the pretrained model:
 ```bash
 # Training on single-gpu
 export CUDA_VISIBLE_DEVICES=0
-python tools/train.py -c configs/rtdetr/rtdetr_r50vd_6x_coco.yml --resume out/my_experiment/pretrained_model.pt
+python tools/train.py -c configs/rtdetr/rtdetr_r50vd_6x_coco.yml --resume out/my_experiment/exported_models/exported_last.pt
 ```
 
 See the [RT-DETR repository](https://github.com/lyuwenyu/RT-DETR/tree/main/rtdetrv2_pytorch)

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -50,16 +50,11 @@ be executed from inside the `RT-DETR/rtdetrv2_pytorch` directory or the
 
 ```python
 # pretrain_rtdetr.py
-from typing import Dict
 
-import torch
-from torch import Tensor
-from torch.nn import AdaptiveAvgPool2d, Module
 
 import lightly_train
 from lightly_train.model_wrappers import RTDETRModelWrapper
 from src.core import YAMLConfig
-
 
 if __name__ == "__main__":
     # Load the RT-DETR model

--- a/src/lightly_train/_models/rtdetr/rtdetr.py
+++ b/src/lightly_train/_models/rtdetr/rtdetr.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from torch.nn import Module, AdaptiveAvgPool2d
+from torch import Tensor
+
+class RTDETRModelWrapper(Module):
+    def __init__(self, model: Module):
+        super().__init__()
+        self._model = model
+        self._pool = AdaptiveAvgPool2d((1, 1))
+
+    def get_model(self) -> Module:
+        return self._model
+
+    def forward_features(self, x: Tensor) -> dict[str, Tensor]:
+        features = self._model.backbone(x)[-1]
+        return {"features": features}
+
+    def forward_pool(self, x: dict[str, Tensor]) -> dict[str, Tensor]:
+        return {"pooled_features": self._pool(x["features"])}
+
+    def feature_dim(self) -> int:
+        return self._model.backbone.out_channels[-1]

--- a/src/lightly_train/_models/rtdetr/rtdetr.py
+++ b/src/lightly_train/_models/rtdetr/rtdetr.py
@@ -1,9 +1,23 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
 from __future__ import annotations
 
-from torch.nn import Module, AdaptiveAvgPool2d
 from torch import Tensor
+from torch.nn import AdaptiveAvgPool2d, Module
 
-class RTDETRModelWrapper(Module):
+from lightly_train._models.model_wrapper import (
+    ForwardFeaturesOutput,
+    ForwardPoolOutput,
+    ModelWrapper,
+)
+
+
+class RTDETRModelWrapper(Module, ModelWrapper):
     def __init__(self, model: Module):
         super().__init__()
         self._model = model
@@ -12,12 +26,14 @@ class RTDETRModelWrapper(Module):
     def get_model(self) -> Module:
         return self._model
 
-    def forward_features(self, x: Tensor) -> dict[str, Tensor]:
+    def forward_features(self, x: Tensor) -> ForwardFeaturesOutput:
         features = self._model.backbone(x)[-1]
         return {"features": features}
 
-    def forward_pool(self, x: dict[str, Tensor]) -> dict[str, Tensor]:
+    def forward_pool(self, x: ForwardFeaturesOutput) -> ForwardPoolOutput:
         return {"pooled_features": self._pool(x["features"])}
 
     def feature_dim(self) -> int:
-        return self._model.backbone.out_channels[-1]
+        feat_dim = self._model.backbone.out_channels[-1]
+        assert isinstance(feat_dim, int)
+        return feat_dim

--- a/src/lightly_train/_models/rtdetr/rtdetr.py
+++ b/src/lightly_train/_models/rtdetr/rtdetr.py
@@ -20,20 +20,21 @@ from lightly_train._models.model_wrapper import (
 class RTDETRModelWrapper(Module, ModelWrapper):
     def __init__(self, model: Module):
         super().__init__()
-        self._model = model
+        self._model = [model]
+        self._backbone = self._model[0].backbone
         self._pool = AdaptiveAvgPool2d((1, 1))
 
     def get_model(self) -> Module:
-        return self._model
+        return self._model[0]
 
     def forward_features(self, x: Tensor) -> ForwardFeaturesOutput:
-        features = self._model.backbone(x)[-1]
+        features = self._backbone(x)[-1]
         return {"features": features}
 
     def forward_pool(self, x: ForwardFeaturesOutput) -> ForwardPoolOutput:
         return {"pooled_features": self._pool(x["features"])}
 
     def feature_dim(self) -> int:
-        feat_dim = self._model.backbone.out_channels[-1]
+        feat_dim = self._backbone.out_channels[-1]
         assert isinstance(feat_dim, int)
         return feat_dim

--- a/src/lightly_train/model_wrappers.py
+++ b/src/lightly_train/model_wrappers.py
@@ -1,0 +1,1 @@
+from lightly_train._models.rtdetr.rtdetr import RTDETRModelWrapper

--- a/src/lightly_train/model_wrappers.py
+++ b/src/lightly_train/model_wrappers.py
@@ -1,1 +1,10 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
 from lightly_train._models.rtdetr.rtdetr import RTDETRModelWrapper
+
+__all__ = ["RTDETRModelWrapper"]


### PR DESCRIPTION
## What has changed and why?
- adds the custom wrapper for RT-DETR to a new module `lightly_train.model_wrappers`

## How has it been tested?
- was tested locally. unit tests make no sense since RT-DETR is not pip-installable

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
