### PR TITLE
Add test to verify that the teacher is not saved.

### DIFF
--- a/tests/_methods/distillation/test_distillation.py
+++ b/tests/_methods/distillation/test_distillation.py
@@ -421,7 +421,7 @@ class TestDistillation:
             if k.startswith("teacher_embedding_model.")
         ]
         assert len(teacher_keys) > 0, (
-            "Teacher weights should not be saved in the checkpoint."
+            "Teacher weights should initially be in the checkpoint."
         )
 
         # Strip teacher keys from the checkpoint.
@@ -434,5 +434,5 @@ class TestDistillation:
             if k.startswith("teacher_embedding_model.")
         ]
         assert len(teacher_keys) == 0, (
-            "Teacher weights should not be saved in the checkpoint."
+            "Teacher weights should not be saved in the final checkpoint."
         )

--- a/tests/_methods/distillationv2/test_distillationv2.py
+++ b/tests/_methods/distillationv2/test_distillationv2.py
@@ -295,7 +295,7 @@ class TestDistillationV2:
             if k.startswith("teacher_embedding_model.")
         ]
         assert len(teacher_keys) > 0, (
-            "Teacher weights should not be saved in the checkpoint."
+            "Teacher weights should initially be in the checkpoint."
         )
 
         # Strip teacher keys from the checkpoint.
@@ -308,5 +308,5 @@ class TestDistillationV2:
             if k.startswith("teacher_embedding_model.")
         ]
         assert len(teacher_keys) == 0, (
-            "Teacher weights should not be saved in the checkpoint."
+            "Teacher weights should not be saved in the final checkpoint."
         )

--- a/tests/_methods/distillationv2/test_distillationv2.py
+++ b/tests/_methods/distillationv2/test_distillationv2.py
@@ -251,3 +251,62 @@ class TestDistillationV2:
         # Assert that a RuntimeError is raised due to unexpected missing keys
         with pytest.raises(RuntimeError, match="Missing keys in state_dict"):
             distill.load_state_dict(state_dict, strict=True)
+
+    def test_teacher_not_saved_in_checkpoint(self, mocker: MockerFixture) -> None:
+        """Test that the teacher model is not saved in the checkpoint."""
+
+        # Setup constants.
+        batch_size = 2
+        student_embed_dim = 32
+        teacher_embed_dim = 48
+
+        # Dummy student model with real params.
+        student_model = EmbeddingModel(
+            wrapped_model=DummyCustomModel(student_embed_dim)
+        )
+
+        # Dummy teacher model with real params.
+        teacher_model = EmbeddingModel(
+            wrapped_model=DummyCustomModel(teacher_embed_dim)
+        )
+
+        # Patch get_teacher.
+        mock_get_teacher = mocker.patch(
+            "lightly_train._methods.distillationv2.distillationv2.get_teacher"
+        )
+        mock_get_teacher.return_value = teacher_model
+
+        # Create distillation instance
+        distill = DistillationV2(
+            method_args=DistillationV2Args(),
+            optimizer_args=DistillationV2LARSArgs(),
+            embedding_model=student_model,
+            global_batch_size=batch_size,
+        )
+        mock_get_teacher.assert_called_once()
+
+        # Simulate saving the checkpoint
+        checkpoint = {"state_dict": distill.state_dict()}
+
+        # Check that teacher keys are initially present in the checkpoint.
+        teacher_keys = [
+            k
+            for k in checkpoint["state_dict"]
+            if k.startswith("teacher_embedding_model.")
+        ]
+        assert len(teacher_keys) > 0, (
+            "Teacher weights should not be saved in the checkpoint."
+        )
+
+        # Strip teacher keys from the checkpoint.
+        distill.on_save_checkpoint(checkpoint)
+
+        # Assert that no teacher weights are in the checkpoint
+        teacher_keys = [
+            k
+            for k in checkpoint["state_dict"]
+            if k.startswith("teacher_embedding_model.")
+        ]
+        assert len(teacher_keys) == 0, (
+            "Teacher weights should not be saved in the checkpoint."
+        )


### PR DESCRIPTION
## What has changed and why?

Added tests to verify that the teacher model is not saved in distillation methods.

## How has it been tested?

The tests pass.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
