### PR TITLE
Document that model argument accepts model instances

### DIFF
--- a/docs/source/models/index.md
+++ b/docs/source/models/index.md
@@ -33,12 +33,11 @@ import lightly_train
 from torchvision.models import resnet50
 
 if __name__ == "__main__":
-    model = resnet50()
-
+    model = resnet50()                  # Load the model.
     lightly_train.train(
         out="out/my_experiment",
         data="my_data_dir",
-        model=model,
+        model=model,                    # Pass the model.
     )
 ````
 

--- a/docs/source/models/rfdetr.md
+++ b/docs/source/models/rfdetr.md
@@ -55,7 +55,10 @@ lightly-train train out="out/my_experiment" data="my_data_dir" model="rfdetr/rf-
 
 ### Fine-tune
 
-You can fine-tune the exported model with `rfdetr` directly. For now, `rfdetr` only supports datasets in COCO JSON format. Below we will provide the minimum scripts for fine-tuning using the [Coconuts dataset from Roboflow](https://universe.roboflow.com/traindataset/coconuts-plj8h/dataset/1/download/coco) in COCO JSON format:
+After pretraining, you can load the exported model for fine-tuning with RF-DETR.
+For now, RF-DETR only supports datasets in COCO JSON format. Below we will provide
+the minimum scripts for fine-tuning using the [Coconuts dataset from Roboflow](https://universe.roboflow.com/traindataset/coconuts-plj8h/dataset/1/download/coco)
+in COCO JSON format:
 
 ```python
 # fine_tune.py
@@ -73,7 +76,7 @@ if __name__ == "__main__":
     model.train(dataset_dir=dataset.location)
 ```
 
-which can be run with `rfdetr`'s DDP training:
+which can be run with RF-DETR's DDP training:
 
 ```bash
 python -m torch.distributed.launch --nproc_per_node=8 --use_env fine_tune.py

--- a/docs/source/models/rfdetr.md
+++ b/docs/source/models/rfdetr.md
@@ -16,7 +16,9 @@ pip install "lightly-train[rfdetr]"
 
 ## Pretrain and Fine-tune an RF-DETR Model
 
-Pretraining RF-DETR models with LightlyTrain is straightforward. Below we will provide the minimum scripts for pretraining and fine-tuning using `rfdetr/rf-detr-base` as an example:
+Pretraining RF-DETR models with LightlyTrain is straightforward. Below we will provide
+the minimum scripts for pretraining and fine-tuning using `rfdetr/rf-detr-base` as an
+example:
 
 ### Pretrain
 
@@ -62,6 +64,7 @@ in COCO JSON format:
 
 ```python
 # fine_tune.py
+
 from rfdetr import RFDETRBase
 from roboflow import Roboflow
 

--- a/docs/source/models/rfdetr.md
+++ b/docs/source/models/rfdetr.md
@@ -30,8 +30,22 @@ if __name__ == "__main__":
         data="my_data_dir",                     # Directory with images.
         model="rfdetr/rf-detr-base",            # Pass the RF-DETR model.
     )
-
 ```
+
+Or alternatively, pass directly an RF-DETR model instance:
+
+```python
+from rfdetr import RFDETRBase
+
+import lightly_train
+
+if __name__ == "__main__":
+    model = RFDETRBase()                        # Load the RF-DETR model.
+    lightly_train.train(
+        out="out/my_experiment",                # Output directory.
+        data="my_data_dir",                     # Directory with images.
+        model=model,                            # Pass the RF-DETR model.
+    )
 ````
 
 ````{tab} Command Line

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -49,9 +49,6 @@ be executed from inside the `RT-DETR/rtdetrv2_pytorch` directory or the
 `RT-DETR/rtdetrv2_pytorch` directory must be added to the Python path.
 
 ```python
-# pretrain_rtdetr.py
-
-
 import lightly_train
 from lightly_train.model_wrappers import RTDETRModelWrapper
 from src.core import YAMLConfig
@@ -67,8 +64,8 @@ if __name__ == "__main__":
     wrapped_model = RTDETRModelWrapper(model)
     lightly_train.train(
         out="out/my_experiment",
-        model=wrapped_model,
         data="my_data_dir", # Replace with your dataset path.
+        model=wrapped_model,
     )
 ```
 

--- a/docs/source/models/supergradients.md
+++ b/docs/source/models/supergradients.md
@@ -12,7 +12,9 @@ SuperGradients support is still experimental. There might be unexpected warnings
 the logs.
 ```
 
-## Pretrain a SuperGradients Model
+## Pretrain and Fine-tune a SuperGradients Model
+
+### Pretrain
 
 Pretraining a SuperGradients models with LightlyTrain is straightforward. Below we will provide the minimum scripts for pretraining using `super_gradients/yolo_nas_s` as an example:
 
@@ -50,7 +52,7 @@ if __name__ == "__main__":
 lightly-train train out="out/my_experiment" data="my_data_dir" model="super_gradients/yolo_nas_s"
 ````
 
-## Fine-tune
+### Fine-tune
 
 After pretraining, you can load the exported model for fine-tuning with SuperGradients:
 

--- a/docs/source/models/supergradients.md
+++ b/docs/source/models/supergradients.md
@@ -28,6 +28,21 @@ if __name__ == "__main__":
     )
 
 ```
+
+Or alternatively, pass directly a SuperGradients model instance:
+
+```python
+from super_gradients.training import models
+
+import lightly_train
+
+if __name__ == "__main__":
+    model = models.get(model_name="yolo_nas_s", num_classes=3)  # Load the model.
+    lightly_train.train(
+        out="out/my_experiment",                # Output directory.
+        data="my_data_dir",                     # Directory with images.
+        model=model,                            # Pass the SuperGradients model.
+    )
 ````
 
 ````{tab} Command Line
@@ -35,7 +50,9 @@ if __name__ == "__main__":
 lightly-train train out="out/my_experiment" data="my_data_dir" model="super_gradients/yolo_nas_s"
 ````
 
-You can reload the exported model by `super_gradients` directly:
+## Fine-tune
+
+After pretraining, you can load the exported model for fine-tuning with SuperGradients:
 
 ```python
 from super_gradients.training import models

--- a/docs/source/models/supergradients.md
+++ b/docs/source/models/supergradients.md
@@ -16,7 +16,9 @@ the logs.
 
 ### Pretrain
 
-Pretraining a SuperGradients models with LightlyTrain is straightforward. Below we will provide the minimum scripts for pretraining using `super_gradients/yolo_nas_s` as an example:
+Pretraining a SuperGradients models with LightlyTrain is straightforward. Below we will
+provide the minimum scripts for pretraining using `super_gradients/yolo_nas_s` as an
+example:
 
 ````{tab} Python
 ```python

--- a/docs/source/models/timm.md
+++ b/docs/source/models/timm.md
@@ -9,9 +9,12 @@ This page describes how to use TIMM models with LightlyTrain.
 `pip install "lightly-train[timm]"`.
 ```
 
-## Pretrain a TIMM Model
+## Pretrain and Fine-tune a TIMM Model
 
-Pretraining TIMM models with LightlyTrain is straightforward. Below we will provide the minimum scripts for pretraining using `timm/resnet18` as an example:
+### Pretrain
+
+Pretraining TIMM models with LightlyTrain is straightforward. Below we will provide the
+minimum scripts for pretraining using `timm/resnet18` as an example:
 
 ````{tab} Python
 ```python
@@ -25,6 +28,21 @@ if __name__ == "__main__":
     )
 
 ```
+
+Or alternatively, pass directly a TIMM model instance:
+
+```python
+import timm
+
+import lightly_train
+
+if __name__ == "__main__":
+    model = timm.create_model("resnet18")       # Load the model.
+    lightly_train.train(
+        out="out/my_experiment",                # Output directory.
+        data="my_data_dir",                     # Directory with images.
+        model=model,                            # Pass the TIMM model.
+    )
 ````
 
 ````{tab} Command Line
@@ -32,7 +50,9 @@ if __name__ == "__main__":
 lightly-train train out="out/my_experiment" data="my_data_dir" model="timm/resnet18"
 ````
 
-You can reload the exported model by timm directly:
+### Fine-tune
+
+After pretraining, you can load the exported model for fine-tuning with TIMM:
 
 ```python
 import timm

--- a/docs/source/models/torchvision.md
+++ b/docs/source/models/torchvision.md
@@ -4,9 +4,12 @@
 
 This page describes how to use Torchvision models with LightlyTrain.
 
-## Pretrain a Torchvision Model
+## Pretrain and Fine-tune a Torchvision Model
 
-Pretraining Torchvision models with LightlyTrain is straightforward. Below we will provide the minimum scripts for pretraining using `torchvision/resnet18` as an example:
+### Pretrain
+
+Pretraining Torchvision models with LightlyTrain is straightforward. Below we will
+provide the minimum scripts for pretraining using `torchvision/resnet18` as an example:
 
 ````{tab} Python
 ```python
@@ -20,6 +23,21 @@ if __name__ == "__main__":
     )
 
 ```
+
+Or alternatively, pass directly a Torchvision model instance:
+
+```python
+from torchvision.models import resnet18
+
+import lightly_train
+
+if __name__ == "__main__":
+    model = resnet18()                        # Load the Torchvision model.
+    lightly_train.train(
+        out="out/my_experiment",              # Output directory.
+        data="my_data_dir",                   # Directory with images.
+        model=model,                          # Pass the Torchvision model.
+    )
 ````
 
 ````{tab} Command Line
@@ -27,7 +45,9 @@ if __name__ == "__main__":
 lightly-train train out="out/my_experiment" data="my_data_dir" model="torchvision/resnet18"
 ````
 
-You can reload the exported model by:
+### Fine-tune
+
+After pretraining, you can load the exported model for fine-tuning with Torchvision:
 
 ```python
 import torch
@@ -35,7 +55,7 @@ from torchvision.models import resnet18
 
 model = resnet18()
 state_dict = torch.load("out/my_experiment/exported_models/exported_last.pt")
-model.load_state_dict(state_dict)
+model.load_state_dict(state_dict, weights_only=True)
 ```
 
 ## Supported Models

--- a/docs/source/models/ultralytics.md
+++ b/docs/source/models/ultralytics.md
@@ -23,7 +23,9 @@ Models ending with `.pt` load pretrained weights by Ultralytics. Models ending w
 
 ## Pretrain and Fine-tune an Ultralytics Model
 
-Pretraining Ultralytics models with LightlyTrain is straightforward. Below we will provide the minimum scripts for pretraining and fine-tuning using `ultralytics/yolov8s` as an example:
+Pretraining Ultralytics models with LightlyTrain is straightforward. Below we will
+provide the minimum scripts for pretraining and fine-tuning using `ultralytics/yolov8s`
+as an example:
 
 ### Pretrain
 

--- a/docs/source/models/ultralytics.md
+++ b/docs/source/models/ultralytics.md
@@ -39,6 +39,21 @@ if __name__ == "__main__":
     )
 
 ```
+
+Or alternatively, pass directly a YOLO model instance:
+```python
+from ultralytics import YOLO
+
+import lightly_train
+
+if __name__ == "__main__":
+    model = YOLO("yolov8s.yaml")                # Load the YOLO model.
+    lightly_train.train(
+        out="out/my_experiment",                # Output directory.
+        data="my_data_dir",                     # Directory with images.
+        model=model,                            # Pass the YOLO model.
+    )
+```
 ````
 
 ````{tab} Command Line

--- a/docs/source/models/ultralytics.md
+++ b/docs/source/models/ultralytics.md
@@ -63,7 +63,7 @@ lightly-train train out="out/my_experiment" data="my_data_dir" model="ultralytic
 
 ### Fine-tune
 
-You can fine-tune the exported model with Ultralytics directly.
+After pretraining, you can load the exported model for fine-tuning with Ultralytics:
 
 ````{tab} Python
 ```python
@@ -72,18 +72,14 @@ from pathlib import Path
 from ultralytics import YOLO
 
 if __name__ == "__main__":
-    # Load the exported model.
     model = YOLO("out/my_experiment/exported_models/exported_last.pt")
-
-    # Fine-tune with ultralytics.
-    data = Path("my_data_dir/config.yaml").absolute()
-    model.train(data=data)
+    model.train(data="coco8.yaml")
 ```
 ````
 
 ````{tab} Command Line
 ```bash
-yolo detect train model=out/my_experiment/exported_models/exported_last.pt data="my_data_dir"
+yolo detect train model=out/my_experiment/exported_models/exported_last.pt data="coco8.yaml"
 ````
 
 ## Supported Models

--- a/docs/source/models/yolov12.md
+++ b/docs/source/models/yolov12.md
@@ -50,7 +50,9 @@ See [this GitHub issue](https://github.com/sunsmarterjie/yolov12/issues/66) for 
 
 ## Pretrain and Fine-tune a YOLOv12 Model
 
-Pretraining or fine-tuning a YOLOv12 model is the same as doing so with any supported Ultralytics model. The only difference is that the config file is named `yolov12.yaml` instead of `yolo12.yaml` in the official Ultralytics releases.
+Pretraining or fine-tuning a YOLOv12 model is the same as doing so with any supported
+Ultralytics model. The only difference is that the config file is named `yolov12.yaml`
+instead of `yolo12.yaml` in the official Ultralytics releases.
 
 Below we will provide the minimum scripts for pretraining and fine-tuning:
 

--- a/docs/source/models/yolov12.md
+++ b/docs/source/models/yolov12.md
@@ -68,6 +68,22 @@ if __name__ == "__main__":
     )
 
 ```
+
+Or alternatively, pass directly a YOLOv12 model instance:
+
+```python
+from ultralytics import YOLO
+
+import lightly_train
+
+if __name__ == "__main__":
+    model = YOLO("yolov12s.yaml")               # Load the YOLOv12 model.
+    lightly_train.train(
+        out="out/my_experiment",                # Output directory.
+        data="my_data_dir",                     # Directory with images.
+        model=model,                            # Pass the YOLOv12 model.
+    )
+```
 ````
 
 ````{tab} Command Line

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -223,8 +223,9 @@ def remove_excessive_args(
 
 def sanitize_config_dict(args: dict[str, Any]) -> dict[str, Any]:
     """Replace classes with their names in the train config dictionary."""
-    if not isinstance(args.get("model"), str):
-        args["model"] = args["model"].__class__.__name__
+    model = args.get("model")
+    if model is not None and not isinstance(model, str):
+        args["model"] = model.__class__.__name__
     if isinstance(args.get("accelerator"), Accelerator):
         args["accelerator"] = args["accelerator"].__class__.__name__
     if isinstance(args.get("strategy"), Strategy):

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -223,7 +223,7 @@ def remove_excessive_args(
 
 def sanitize_config_dict(args: dict[str, Any]) -> dict[str, Any]:
     """Replace classes with their names in the train config dictionary."""
-    if isinstance(args.get("model"), Module):
+    if not isinstance(args.get("model"), str):
         args["model"] = args["model"].__class__.__name__
     if isinstance(args.get("accelerator"), Accelerator):
         args["accelerator"] = args["accelerator"].__class__.__name__


### PR DESCRIPTION
## What has changed and why?

* Document that model instances can be passed as `model` argument to train function
* Update all model pages to include an example
* Cleanup model pages to always follow the same structure

## How has it been tested?

* Tested snippets manually

[Custom Models - LightlyTrain documentation 1.pdf](https://github.com/user-attachments/files/20588248/Custom.Models.-.LightlyTrain.documentation.1.pdf)
[SuperGradients - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20588249/SuperGradients.-.LightlyTrain.documentation.pdf)
[YOLOv12 - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20588250/YOLOv12.-.LightlyTrain.documentation.pdf)
[RF-DETR - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20588251/RF-DETR.-.LightlyTrain.documentation.pdf)
[RT-DETR - LightlyTrain documentation 1.pdf](https://github.com/user-attachments/files/20588252/RT-DETR.-.LightlyTrain.documentation.1.pdf)
[Ultralytics - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20588253/Ultralytics.-.LightlyTrain.documentation.pdf)
[TIMM - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20588255/TIMM.-.LightlyTrain.documentation.pdf)
[Torchvision - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/20588256/Torchvision.-.LightlyTrain.documentation.pdf)


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
