### PR TITLE
VIT fix reshape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed VIT output reshape.
+
 ### Security
 
 ## [0.7.0] - 2025-05-26

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit.py
@@ -31,12 +31,13 @@ class DINOv2ViTModelWrapper(Module, ModelWrapper):
     def forward_features(self, x: Tensor) -> ForwardFeaturesOutput:
         rt = self._model(x, is_training=True)  # forcing to return all patches
         if rt["x_norm_patchtokens"].dim() == 3:
-            features_reshaped = rt["x_norm_patchtokens"].reshape(
-                rt["x_norm_patchtokens"].shape[0],
-                rt["x_norm_patchtokens"].shape[2],
-                x.shape[2] // self._model.patch_size,
-                x.shape[3] // self._model.patch_size,
-            )
+            x_norm_patchtokens = rt["x_norm_patchtokens"]
+            b = x_norm_patchtokens.shape[0]
+            d = x_norm_patchtokens.shape[2]
+            h = x.shape[2] // self._model.patch_size
+            w = x.shape[3] // self._model.patch_size
+
+            features_reshaped = x_norm_patchtokens.permute(0, 2, 1).reshape(b, d, h, w)
         elif rt["x_norm_patchtokens"].dim() == 4:
             features_reshaped = rt["x_norm_patchtokens"]
         else:


### PR DESCRIPTION
## What has changed and why?

In reshaping the vit output was a bug. this PR fixes the reshape


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
