### PR TITLE
Use ModelWrapper in `get_method_args`

### DIFF
--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -379,7 +379,7 @@ def train_from_config(config: TrainConfig) -> None:
             method_args=config.method_args,
             scaling_info=scaling_info,
             optimizer_args=config.optim_args,
-            model=wrapped_model.get_model(),
+            wrapped_model=wrapped_model,
         )
         method_instance = train_helpers.get_method(
             method_cls=method_cls,

--- a/src/lightly_train/_commands/train_helpers.py
+++ b/src/lightly_train/_commands/train_helpers.py
@@ -352,7 +352,7 @@ def get_method_args(
     method_args: dict[str, Any] | MethodArgs | None,
     scaling_info: ScalingInfo,
     optimizer_args: OptimizerArgs,
-    model: Module,
+    wrapped_model: ModelWrapper,
 ) -> MethodArgs:
     logger.debug(f"Getting method args for '{method_cls.__name__}'")
     if isinstance(method_args, MethodArgs):
@@ -361,7 +361,9 @@ def get_method_args(
     method_args_cls = method_cls.method_args_cls()
     args = validate.pydantic_model_validate(method_args_cls, method_args)
     args.resolve_auto(
-        scaling_info=scaling_info, optimizer_args=optimizer_args, model=model
+        scaling_info=scaling_info,
+        optimizer_args=optimizer_args,
+        wrapped_model=wrapped_model,
     )
     return args
 

--- a/src/lightly_train/_methods/densecl/densecl.py
+++ b/src/lightly_train/_methods/densecl/densecl.py
@@ -38,6 +38,7 @@ from lightly_train._methods.densecl.densecl_transform import (
 from lightly_train._methods.method import Method, TrainingStepResult
 from lightly_train._methods.method_args import MethodArgs
 from lightly_train._models.embedding_model import EmbeddingModel
+from lightly_train._models.model_wrapper import ModelWrapper
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
 from lightly_train._optim.sgd_args import SGDArgs
@@ -73,7 +74,10 @@ class DenseCLArgs(MethodArgs):
     momentum_end: float = 0.999
 
     def resolve_auto(
-        self, scaling_info: ScalingInfo, optimizer_args: OptimizerArgs, model: Module
+        self,
+        scaling_info: ScalingInfo,
+        optimizer_args: OptimizerArgs,
+        wrapped_model: ModelWrapper,
     ) -> None:
         if self.memory_bank_size == "auto":
             # Reduce memory bank size for smaller datasets, otherwise training is

--- a/src/lightly_train/_methods/dino/dino.py
+++ b/src/lightly_train/_methods/dino/dino.py
@@ -17,7 +17,7 @@ from lightly.models.utils import update_momentum
 from lightly.utils import optim
 from lightly.utils.scheduler import cosine_schedule
 from torch import Tensor
-from torch.nn import Flatten, Module
+from torch.nn import Flatten
 from torch.optim.optimizer import Optimizer
 
 from lightly_train import _scaling
@@ -28,6 +28,7 @@ from lightly_train._methods.dino.dino_transform import (
 from lightly_train._methods.method import Method, TrainingStepResult
 from lightly_train._methods.method_args import MethodArgs
 from lightly_train._models.embedding_model import EmbeddingModel
+from lightly_train._models.model_wrapper import ModelWrapper
 from lightly_train._optim.adamw_args import AdamWArgs
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
@@ -64,7 +65,10 @@ class DINOArgs(MethodArgs):
     weight_decay_end: float | Literal["auto"] = "auto"
 
     def resolve_auto(
-        self, scaling_info: ScalingInfo, optimizer_args: OptimizerArgs, model: Module
+        self,
+        scaling_info: ScalingInfo,
+        optimizer_args: OptimizerArgs,
+        wrapped_model: ModelWrapper,
     ) -> None:
         dataset_size = scaling_info.dataset_size
 

--- a/src/lightly_train/_methods/dinov2/dinov2.py
+++ b/src/lightly_train/_methods/dinov2/dinov2.py
@@ -765,8 +765,8 @@ class DINOv2(Method):
             end_value=self.method_args.momentum_end,
         )
         update_momentum(
-            self.student_embedding_model_wrapper.get_model(),
-            self.teacher_embedding_model_wrapper.get_model(),
+            self.student_embedding_model_wrapper._model,
+            self.teacher_embedding_model_wrapper._model,
             m=momentum,
         )
         update_momentum(self.student_dino_head, self.teacher_dino_head, m=momentum)

--- a/src/lightly_train/_methods/distillation/distillation.py
+++ b/src/lightly_train/_methods/distillation/distillation.py
@@ -27,6 +27,7 @@ from lightly_train._methods.method import Method, TrainingStepResult
 from lightly_train._methods.method_args import MethodArgs
 from lightly_train._models import package_helpers
 from lightly_train._models.embedding_model import EmbeddingModel
+from lightly_train._models.model_wrapper import ModelWrapper
 from lightly_train._optim.lars_args import LARSArgs
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
@@ -61,7 +62,10 @@ class DistillationArgs(MethodArgs):
     teacher: str = "dinov2_vit/vitb14_pretrain"
 
     def resolve_auto(
-        self, scaling_info: ScalingInfo, optimizer_args: OptimizerArgs, model: Module
+        self,
+        scaling_info: ScalingInfo,
+        optimizer_args: OptimizerArgs,
+        wrapped_model: ModelWrapper,
     ) -> None:
         if self.queue_size == "auto":
             # Reduce the queue size for smaller datasets.

--- a/src/lightly_train/_methods/method_args.py
+++ b/src/lightly_train/_methods/method_args.py
@@ -5,9 +5,9 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 #
-from torch.nn import Module
 
 from lightly_train._configs.config import PydanticConfig
+from lightly_train._models.model_wrapper import ModelWrapper
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._scaling import ScalingInfo
 
@@ -21,7 +21,10 @@ class MethodArgs(PydanticConfig):
     pass
 
     def resolve_auto(
-        self, scaling_info: ScalingInfo, optimizer_args: OptimizerArgs, model: Module
+        self,
+        scaling_info: ScalingInfo,
+        optimizer_args: OptimizerArgs,
+        wrapped_model: ModelWrapper,
     ) -> None:
         """Resolves all fields with the value 'auto' to their actual value."""
         pass

--- a/tests/_commands/test_train.py
+++ b/tests/_commands/test_train.py
@@ -18,7 +18,6 @@ from omegaconf import OmegaConf
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
 from pytorch_lightning.accelerators.cpu import CPUAccelerator
-from torch.nn import Module
 
 from lightly_train._checkpoint import Checkpoint
 from lightly_train._commands import train
@@ -33,6 +32,7 @@ from lightly_train._methods.dino.dino import DINOAdamWArgs, DINOArgs
 from lightly_train._scaling import ScalingInfo
 
 from .. import helpers
+from ..helpers import DummyCustomModel
 
 
 def test_train__cpu(tmp_path: Path) -> None:
@@ -341,7 +341,7 @@ def test_train__TrainConfig__model_dump(tmp_path: Path) -> None:
     method_args.resolve_auto(
         scaling_info=ScalingInfo(dataset_size=20_000, epochs=100),
         optimizer_args=optim_args,
-        model=Module(),
+        wrapped_model=DummyCustomModel(),
     )
     config = TrainConfig(
         out=out,

--- a/tests/_commands/test_train_helpers.py
+++ b/tests/_commands/test_train_helpers.py
@@ -16,7 +16,6 @@ import torch
 from pytest_mock import MockerFixture
 from pytorch_lightning.strategies.ddp import DDPStrategy
 from torch import Tensor
-from torch.nn import Module
 from torch.testing import assert_close
 from torch.utils.data import Dataset
 from torchvision.datasets import FakeData
@@ -406,7 +405,7 @@ def test_get_method_args(
         method_args=args,
         scaling_info=scaling_info,
         optimizer_args=AdamWArgs(),
-        model=Module(),
+        wrapped_model=DummyCustomModel(),
     )
     assert resolved_args == expected
 

--- a/tests/_methods/densecl/__init__.py
+++ b/tests/_methods/densecl/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_methods/densecl/test_densecl.py
+++ b/tests/_methods/densecl/test_densecl.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import Literal
 
 import pytest
-from torch.nn import Module
 
 from lightly_train._methods.densecl.densecl import DenseCL, DenseCLArgs, DenseCLSGDArgs
 from lightly_train._optim.adamw_args import AdamWArgs
@@ -18,13 +17,17 @@ from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
 from lightly_train._scaling import ScalingInfo
 
+from ...helpers import DummyCustomModel
+
 
 class TestDenseCLArgs:
     def test_resolve_auto(self) -> None:
         args = DenseCLArgs()
         scaling_info = ScalingInfo(dataset_size=20_000, epochs=100)
         args.resolve_auto(
-            scaling_info=scaling_info, optimizer_args=AdamWArgs(), model=Module()
+            scaling_info=scaling_info,
+            optimizer_args=AdamWArgs(),
+            wrapped_model=DummyCustomModel(),
         )
         assert args.memory_bank_size == 8192
         assert not args.has_auto()

--- a/tests/_methods/dino/__init__.py
+++ b/tests/_methods/dino/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_methods/dino/test_dino.py
+++ b/tests/_methods/dino/test_dino.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import Literal
 
 import pytest
-from torch.nn import Module
 
 from lightly_train._methods.dino.dino import (
     DINO,
@@ -22,13 +21,17 @@ from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
 from lightly_train._scaling import IMAGENET_SIZE, ScalingInfo
 
+from ...helpers import DummyCustomModel
+
 
 class TestDINOArgs:
     def test_resolve_auto__default_scaling_info(self) -> None:
         args = DINOArgs()
         scaling_info = ScalingInfo(dataset_size=IMAGENET_SIZE, epochs=100)
         args.resolve_auto(
-            scaling_info=scaling_info, optimizer_args=DINOAdamWArgs(), model=Module()
+            scaling_info=scaling_info,
+            optimizer_args=DINOAdamWArgs(),
+            wrapped_model=DummyCustomModel(),
         )
         assert args.output_dim == 65536
         assert args.teacher_temp == 0.07
@@ -41,7 +44,9 @@ class TestDINOArgs:
         args = DINOArgs()
         scaling_info = ScalingInfo(dataset_size=20_000, epochs=100)
         args.resolve_auto(
-            scaling_info=scaling_info, optimizer_args=DINOAdamWArgs(), model=Module()
+            scaling_info=scaling_info,
+            optimizer_args=DINOAdamWArgs(),
+            wrapped_model=DummyCustomModel(),
         )
         assert args.output_dim == 2048
         assert args.teacher_temp == 0.02
@@ -54,7 +59,9 @@ class TestDINOArgs:
         args = DINOArgs()
         scaling_info = ScalingInfo(dataset_size=IMAGENET_SIZE, epochs=10)
         args.resolve_auto(
-            scaling_info=scaling_info, optimizer_args=DINOAdamWArgs(), model=Module()
+            scaling_info=scaling_info,
+            optimizer_args=DINOAdamWArgs(),
+            wrapped_model=DummyCustomModel(),
         )
         assert args.output_dim == 65536
         assert args.teacher_temp == 0.07

--- a/tests/_methods/dinov2/test_dinov2.py
+++ b/tests/_methods/dinov2/test_dinov2.py
@@ -328,9 +328,9 @@ class TestDINOv2Args:
         model_scaling_result: ModelVariantScalingResult,
     ) -> None:
         dummy_vit_model_variant = dummy_vit_model()
-        dummy_vit_model_variant.get_model().n_blocks = model_params.n_blocks  # type: ignore[assignment]
-        dummy_vit_model_variant.get_model().embed_dim = model_params.embed_dim  # type: ignore[assignment]
-        dummy_vit_model_variant.get_model().num_heads = model_params.num_heads  # type: ignore[assignment]
+        dummy_vit_model_variant._model.n_blocks = model_params.n_blocks  # type: ignore[assignment]
+        dummy_vit_model_variant._model.embed_dim = model_params.embed_dim  # type: ignore[assignment]
+        dummy_vit_model_variant._model.num_heads = model_params.num_heads  # type: ignore[assignment]
 
         args = DINOv2Args()
         args.resolve_auto(

--- a/tests/_methods/dinov2/test_dinov2.py
+++ b/tests/_methods/dinov2/test_dinov2.py
@@ -94,7 +94,7 @@ def setup_dinov2_helper(
     dinov2_args.resolve_auto(
         scaling_info=scaling_info,
         optimizer_args=optimizer_args,
-        model=emb_model.wrapped_model.get_model(),
+        wrapped_model=emb_model.wrapped_model,
     )
 
     dinov2 = DINOv2(
@@ -328,15 +328,15 @@ class TestDINOv2Args:
         model_scaling_result: ModelVariantScalingResult,
     ) -> None:
         dummy_vit_model_variant = dummy_vit_model()
-        dummy_vit_model_variant._model.n_blocks = model_params.n_blocks  # type: ignore[assignment]
-        dummy_vit_model_variant._model.embed_dim = model_params.embed_dim  # type: ignore[assignment]
-        dummy_vit_model_variant._model.num_heads = model_params.num_heads  # type: ignore[assignment]
+        dummy_vit_model_variant.get_model().n_blocks = model_params.n_blocks  # type: ignore[assignment]
+        dummy_vit_model_variant.get_model().embed_dim = model_params.embed_dim  # type: ignore[assignment]
+        dummy_vit_model_variant.get_model().num_heads = model_params.num_heads  # type: ignore[assignment]
 
         args = DINOv2Args()
         args.resolve_auto(
             scaling_info=scaling,
             optimizer_args=DINOv2AdamWViTSBArgs(),
-            model=dummy_vit_model_variant.get_model(),
+            wrapped_model=dummy_vit_model_variant,
         )
         assert args.ibot_separate_head == model_scaling_result.ibot_separate_head
         assert args.bottleneck_dim == model_scaling_result.bottleneck_dim

--- a/tests/_methods/distillation/test_distillation.py
+++ b/tests/_methods/distillation/test_distillation.py
@@ -13,7 +13,6 @@ import pytest
 import torch
 import torch.nn.functional as F
 from pytest_mock import MockerFixture
-from torch.nn import Module
 
 from lightly_train._methods.distillation.distillation import (
     Distillation,
@@ -40,7 +39,7 @@ class TestDistillationArgs:
         args.resolve_auto(
             scaling_info=scaling_info,
             optimizer_args=DistillationLARSArgs(),
-            model=Module(),
+            wrapped_model=DummyCustomModel(),
         )
 
         # The expected queue size is 128 and it is expected to be an int.
@@ -59,7 +58,7 @@ class TestDistillationArgs:
         args.resolve_auto(
             scaling_info=scaling_info,
             optimizer_args=DistillationLARSArgs(),
-            model=Module(),
+            wrapped_model=DummyCustomModel(),
         )
 
         # The expected queue size is 8192 and it is expected to be an int.
@@ -80,7 +79,7 @@ class TestDistillationArgs:
             args.resolve_auto(
                 scaling_info=scaling_info,
                 optimizer_args=DistillationLARSArgs(),
-                model=Module(),
+                wrapped_model=DummyCustomModel(),
             )
 
     def test_resolve_auto_does_not_change_explicit_queue_size(self) -> None:
@@ -95,7 +94,7 @@ class TestDistillationArgs:
         args.resolve_auto(
             scaling_info=scaling_info,
             optimizer_args=DistillationLARSArgs(),
-            model=Module(),
+            wrapped_model=DummyCustomModel(),
         )
 
         # Verify that the queue size is unchanged.

--- a/tests/_methods/simclr/__init__.py
+++ b/tests/_methods/simclr/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_methods/simclr/test_simclr.py
+++ b/tests/_methods/simclr/test_simclr.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import Literal
 
 import pytest
-from torch.nn import Module
 
 from lightly_train._methods.simclr.simclr import SimCLR, SimCLRArgs, SimCLRSGDArgs
 from lightly_train._optim.adamw_args import AdamWArgs
@@ -18,13 +17,17 @@ from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
 from lightly_train._scaling import ScalingInfo
 
+from ...helpers import DummyCustomModel
+
 
 class TestSimCLRArgs:
     def test_resolve_auto(self) -> None:
         args = SimCLRArgs()
         scaling_info = ScalingInfo(dataset_size=20_000, epochs=100)
         args.resolve_auto(
-            scaling_info=scaling_info, optimizer_args=AdamWArgs(), model=Module()
+            scaling_info=scaling_info,
+            optimizer_args=AdamWArgs(),
+            wrapped_model=DummyCustomModel(),
         )
         assert not args.has_auto()
 


### PR DESCRIPTION
## What has changed and why?

Change the interface of `train_helpers.get_method_args` and `MethodArgs.resolve_auto` to use ModelWrapper as input and adjust the unit tests accordingly.

## How has it been tested?

Passed unit test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
