### PR TITLE
Test ModelWrapper move to device

### DIFF
--- a/src/lightly_train/_models/torchvision/shufflenet.py
+++ b/src/lightly_train/_models/torchvision/shufflenet.py
@@ -20,23 +20,23 @@ class ShuffleNetV2ModelWrapper(TorchvisionModelWrapper):
 
     def __init__(self, model: Module):
         super().__init__()
-        self._model = [model]
+        self._model = model
 
     def get_model(self) -> Module:
-        return self._model[0]
+        return self._model
 
     def forward_features(self, x: Tensor) -> ForwardFeaturesOutput:
-        x = self._model[0].conv1(x)
-        x = self._model[0].maxpool(x)
-        x = self._model[0].stage2(x)
-        x = self._model[0].stage3(x)
-        x = self._model[0].stage4(x)
-        x = self._model[0].conv5(x)
+        x = self._model.conv1(x)
+        x = self._model.maxpool(x)
+        x = self._model.stage2(x)
+        x = self._model.stage3(x)
+        x = self._model.stage4(x)
+        x = self._model.conv5(x)
         return {"features": x}
 
     def forward_pool(self, x: ForwardFeaturesOutput) -> ForwardPoolOutput:
         return {"pooled_features": x["features"].mean([2, 3], keepdim=True)}
 
     def feature_dim(self) -> int:
-        feature_dim: int = self._model[0].fc.in_features
+        feature_dim: int = self._model.fc.in_features
         return feature_dim

--- a/tests/_models/dinov2_vit/test_dinov2_vit.py
+++ b/tests/_models/dinov2_vit/test_dinov2_vit.py
@@ -96,3 +96,12 @@ class TestDINOv2ViTModelWrapper:
             assert isinstance(teacher_block.drop_path1, torch.nn.Identity)
             assert isinstance(teacher_block.drop_path2, torch.nn.Identity)
             assert teacher_block.sample_drop_ratio == 0.0
+
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = vit_small()
+        feature_extractor = DINOv2ViTModelWrapper(model=model)
+        feature_extractor.to("meta")
+        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/dinov2_vit/test_dinov2_vit.py
+++ b/tests/_models/dinov2_vit/test_dinov2_vit.py
@@ -102,6 +102,6 @@ class TestDINOv2ViTModelWrapper:
         # modules to the correct device. This happens if not all required modules
         # are registered as attributes of the class.
         model = vit_small()
-        feature_extractor = DINOv2ViTModelWrapper(model=model)
-        feature_extractor.to("meta")
-        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))
+        wrapped_model = DINOv2ViTModelWrapper(model=model)
+        wrapped_model.to("meta")
+        wrapped_model.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/rfdetr/test_rfdetr.py
+++ b/tests/_models/rfdetr/test_rfdetr.py
@@ -77,3 +77,12 @@ class TestRFDETRModelWrapper:
         wrapped_model = RFDETRModelWrapper(model=model)
         model_ = wrapped_model.get_model()
         assert model_ is model
+
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = RFDETRBase()  # type: ignore[no-untyped-call]
+        wrapped_model = RFDETRModelWrapper(model=model)
+        wrapped_model.to("meta")
+        wrapped_model.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/super_gradients/test_segmentation_module.py
+++ b/tests/_models/super_gradients/test_segmentation_module.py
@@ -48,3 +48,12 @@ class TestSegmentationModule:
         model = SUPER_GRADIENTS_PACKAGE.get_model("pp_lite_t_seg50")
         fe = SegmentationModuleModelWrapper(model)
         assert fe.get_model() is model
+
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = SUPER_GRADIENTS_PACKAGE.get_model("pp_lite_t_seg50")
+        fe = SegmentationModuleModelWrapper(model)
+        fe.to("meta")
+        fe.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/timm/test_timm.py
+++ b/tests/_models/timm/test_timm.py
@@ -68,6 +68,15 @@ class TestTIMMModelWrapper:
         y = extractor.forward_pool(extractor.forward_features(x))["pooled_features"]
         assert y.shape == (1, 384, 1, 1)
 
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = timm.create_model("resnet18")
+        extractor = TIMMModelWrapper(model=model)
+        extractor.to("meta")
+        extractor.forward_features(torch.rand(1, 3, 64, 64, device="meta"))
+
 
 # TODO: Do not skip if timm <1.0
 @pytest.mark.skip(reason="Requires timm <1.0")

--- a/tests/_models/torchvision/test_convnext.py
+++ b/tests/_models/torchvision/test_convnext.py
@@ -35,3 +35,12 @@ class TestConvNeXtModelWrapper:
         model = models.convnext_tiny()
         feature_extractor = ConvNeXtModelWrapper(model=model)
         assert feature_extractor.get_model() is model
+
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = models.convnext_tiny()
+        feature_extractor = ConvNeXtModelWrapper(model=model)
+        feature_extractor.to("meta")
+        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/torchvision/test_convnext.py
+++ b/tests/_models/torchvision/test_convnext.py
@@ -41,6 +41,6 @@ class TestConvNeXtModelWrapper:
         # modules to the correct device. This happens if not all required modules
         # are registered as attributes of the class.
         model = models.convnext_tiny()
-        feature_extractor = ConvNeXtModelWrapper(model=model)
-        feature_extractor.to("meta")
-        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))
+        wrapped_model = ConvNeXtModelWrapper(model=model)
+        wrapped_model.to("meta")
+        wrapped_model.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/torchvision/test_resnet.py
+++ b/tests/_models/torchvision/test_resnet.py
@@ -35,3 +35,12 @@ class TestResNetModelWrapper:
         model = models.resnet18()
         feature_extractor = ResNetModelWrapper(model=model)
         assert feature_extractor.get_model() is model
+
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = models.resnet18()
+        feature_extractor = ResNetModelWrapper(model=model)
+        feature_extractor.to("meta")
+        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/torchvision/test_resnet.py
+++ b/tests/_models/torchvision/test_resnet.py
@@ -41,6 +41,6 @@ class TestResNetModelWrapper:
         # modules to the correct device. This happens if not all required modules
         # are registered as attributes of the class.
         model = models.resnet18()
-        feature_extractor = ResNetModelWrapper(model=model)
-        feature_extractor.to("meta")
-        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))
+        wrapped_model = ResNetModelWrapper(model=model)
+        wrapped_model.to("meta")
+        wrapped_model.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/torchvision/test_shufflenet.py
+++ b/tests/_models/torchvision/test_shufflenet.py
@@ -14,24 +14,33 @@ from lightly_train._models.torchvision.shufflenet import ShuffleNetV2ModelWrappe
 class TestShuffleNetV2ModelWrapper:
     def test_feature_dim(self) -> None:
         model = models.shufflenet_v2_x0_5()
-        feature_extractor = ShuffleNetV2ModelWrapper(model=model)
-        assert feature_extractor.feature_dim() == 1024
+        wrapped_model = ShuffleNetV2ModelWrapper(model=model)
+        assert wrapped_model.feature_dim() == 1024
 
     def test_forward_features(self) -> None:
         model = models.shufflenet_v2_x0_5()
-        feature_extractor = ShuffleNetV2ModelWrapper(model=model)
+        wrapped_model = ShuffleNetV2ModelWrapper(model=model)
         x = torch.rand(1, 3, 224, 224)
-        features = feature_extractor.forward_features(x)["features"]
+        features = wrapped_model.forward_features(x)["features"]
         assert features.shape == (1, 1024, 7, 7)
 
     def test_forward_pool(self) -> None:
         model = models.shufflenet_v2_x0_5()
-        feature_extractor = ShuffleNetV2ModelWrapper(model=model)
+        wrapped_model = ShuffleNetV2ModelWrapper(model=model)
         x = torch.rand(1, 1024, 7, 7)
-        pool = feature_extractor.forward_pool({"features": x})["pooled_features"]
+        pool = wrapped_model.forward_pool({"features": x})["pooled_features"]
         assert pool.shape == (1, 1024, 1, 1)
 
     def test_get_model(self) -> None:
         model = models.shufflenet_v2_x0_5()
-        feature_extractor = ShuffleNetV2ModelWrapper(model=model)
-        assert feature_extractor.get_model() is model
+        wrapped_model = ShuffleNetV2ModelWrapper(model=model)
+        assert wrapped_model.get_model() is model
+
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = models.shufflenet_v2_x0_5()
+        wrapped_model = ShuffleNetV2ModelWrapper(model=model)
+        wrapped_model.to("meta")
+        wrapped_model.forward_features(torch.rand(1, 3, 224, 224, device="meta"))

--- a/tests/_models/ultralytics/test_ultralytics.py
+++ b/tests/_models/ultralytics/test_ultralytics.py
@@ -104,6 +104,15 @@ class TestUltralyticsModelWrapper:
         feature_extractor = UltralyticsModelWrapper(model=model)
         assert feature_extractor.get_model() is model
 
+    def test__device(self) -> None:
+        # If this test fails it means the wrapped model doesn't move all required
+        # modules to the correct device. This happens if not all required modules
+        # are registered as attributes of the class.
+        model = YOLO("yolov8s.yaml")
+        feature_extractor = UltralyticsModelWrapper(model=model)
+        feature_extractor.to("meta")
+        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))
+
 
 def test__sppf_skip_cv2_bn_act() -> None:
     sppf = SPPF(128, 5)

--- a/tests/_models/ultralytics/test_ultralytics.py
+++ b/tests/_models/ultralytics/test_ultralytics.py
@@ -109,9 +109,9 @@ class TestUltralyticsModelWrapper:
         # modules to the correct device. This happens if not all required modules
         # are registered as attributes of the class.
         model = YOLO("yolov8s.yaml")
-        feature_extractor = UltralyticsModelWrapper(model=model)
-        feature_extractor.to("meta")
-        feature_extractor.forward_features(torch.rand(1, 3, 224, 224, device="meta"))
+        wrapped_model = UltralyticsModelWrapper(model=model)
+        wrapped_model.to("meta")
+        wrapped_model.forward_features(torch.rand(1, 3, 224, 224, device="meta"))
 
 
 def test__sppf_skip_cv2_bn_act() -> None:


### PR DESCRIPTION
## What has changed and why?

* Add test that model wrappers register all modules correctly

I noticed that I introduced a bug for shufflenet in #128 which doesn't register the module correctly. This PR fixes the bug and adds tests for all other wrappers as well. I used the "meta" device because it is always available. It raises an error if any of the parameters is still on a "cpu" or "cuda" device. 


## How has it been tested?

* Add unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
