### PR TITLE
Add log dict to TrainingStepResult

### DIFF
--- a/src/lightly_train/_methods/dinov2/dinov2.py
+++ b/src/lightly_train/_methods/dinov2/dinov2.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import copy
 import logging
 import math
-from dataclasses import dataclass
 from functools import partial
 from typing import Any, Literal, Mapping
 
@@ -65,14 +64,6 @@ def freeze_eval_module(module: Module) -> None:
     for param in module.parameters():
         param.requires_grad = False
     module.eval()
-
-
-@dataclass
-class DINOv2TrainingStepResult(TrainingStepResult):
-    dino_global_loss: Tensor
-    dino_local_loss: Tensor
-    ibot_loss: Tensor
-    koleo_loss: Tensor
 
 
 class DINOv2Args(MethodArgs):
@@ -254,42 +245,7 @@ class DINOv2(Method):
         )
         self.koleo_loss = KoLeoLoss()
 
-    def training_step(self, batch: Batch, batch_idx: int) -> Tensor:
-        training_step_log: DINOv2TrainingStepResult = self.training_step_impl(
-            batch, batch_idx
-        )
-
-        train_loss = training_step_log.loss
-        dino_global_loss = training_step_log.dino_global_loss
-        dino_local_loss = training_step_log.dino_local_loss
-        ibot_loss = training_step_log.ibot_loss
-        koleo_loss = training_step_log.koleo_loss
-
-        log_dict = {
-            "train_loss": train_loss,
-            "dino_global_loss": dino_global_loss,
-            "dino_local_loss": dino_local_loss,
-            "ibot_loss": ibot_loss,
-            "koleo_loss": koleo_loss,
-        }
-
-        views = batch["views"]
-        self.log_dict(
-            log_dict,
-            prog_bar=True,
-            sync_dist=True,
-            batch_size=len(views[0]),
-        )
-
-        if self.global_step == 0:
-            # Show example views of the images in the first batch only.
-            self._log_example_views(train_batch=batch)
-
-        return train_loss
-
-    def training_step_impl(
-        self, batch: Batch, batch_idx: int
-    ) -> DINOv2TrainingStepResult:
+    def training_step_impl(self, batch: Batch, batch_idx: int) -> TrainingStepResult:
         # Teacher temperature scheduling
         teacher_temp = linear_warmup_schedule(
             step=self.trainer.global_step,
@@ -414,12 +370,14 @@ class DINOv2(Method):
             + self.method_args.koleo_loss_weight * koleo_loss
         )
 
-        return DINOv2TrainingStepResult(
+        return TrainingStepResult(
             loss=loss,
-            dino_global_loss=dino_global_loss,
-            dino_local_loss=dino_local_loss,
-            ibot_loss=ibot_loss,
-            koleo_loss=koleo_loss,
+            log_dict={
+                "train_loss/dino_global_loss": dino_global_loss,
+                "train_loss/dino_local_loss": dino_local_loss,
+                "train_loss/ibot_loss": ibot_loss,
+                "train_loss/koleo_loss": koleo_loss,
+            },
         )
 
     @torch.no_grad()

--- a/src/lightly_train/_methods/method.py
+++ b/src/lightly_train/_methods/method.py
@@ -37,6 +37,7 @@ from lightly_train.types import Batch
 @dataclass
 class TrainingStepResult:
     loss: Tensor
+    log_dict: Mapping[str, Any] | None = None
 
 
 @dataclass
@@ -124,6 +125,13 @@ class Method(LightningModule):
         self.log(
             "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(views[0])
         )
+        if training_step_log.log_dict is not None:
+            self.log_dict(
+                training_step_log.log_dict,
+                prog_bar=False,
+                sync_dist=True,
+                batch_size=len(views[0]),
+            )
         if self.global_step == 0:
             # Show example views of the images in the first batch only.
             self._log_example_views(train_batch=batch)

--- a/tests/_methods/dinov2/test_dinov2.py
+++ b/tests/_methods/dinov2/test_dinov2.py
@@ -130,13 +130,14 @@ class TestDINOv2:
                 assert param_dino.dtype == param_ibot.dtype
                 assert param_dino.requires_grad == param_ibot.requires_grad
                 assert torch.allclose(param_dino, param_ibot, rtol=1e-3, atol=1e-4)
+        assert out.log_dict is not None
         if n_local_crops == 0:
-            assert out.dino_local_loss == torch.tensor(0.0)
+            assert out.log_dict["train_loss/dino_local_loss"] == torch.tensor(0.0)
         assert out.loss.shape == Size([])
-        assert out.dino_global_loss.shape == Size([])
-        assert out.dino_local_loss.shape == Size([])
-        assert out.ibot_loss.shape == Size([])
-        assert out.koleo_loss.shape == Size([])
+        assert out.log_dict["train_loss/dino_global_loss"].shape == Size([])
+        assert out.log_dict["train_loss/dino_local_loss"].shape == Size([])
+        assert out.log_dict["train_loss/ibot_loss"].shape == Size([])
+        assert out.log_dict["train_loss/koleo_loss"].shape == Size([])
 
     def test_layerwise_decay_optimizer(self, mocker: MockerFixture) -> None:
         emb_model = EmbeddingModel(wrapped_model=dummy_vit_model())


### PR DESCRIPTION
## What has changed and why?

* Add log dict to training step result
* Remove `training_step` implementation from DINOv2

This PR structures the loss logs for DINOv2 and puts them into a single `train_loss` group. This avoids that we create a mess in the logging tools of our users.

## How has it been tested?

* Manually

TensorBoard:
<img width="1211" alt="Screenshot 2025-06-09 at 16 13 13" src="https://github.com/user-attachments/assets/40bd982d-13cb-41b0-b0de-f613c75c2018" />

WandB
<img width="1383" alt="Screenshot 2025-06-09 at 16 12 57" src="https://github.com/user-attachments/assets/2b6e294c-1cfa-4701-b2cc-cd53122cb2d3" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
