### PR TITLE
Thomas trn 479 change lr scaling in distillation methods

### DIFF
--- a/src/lightly_train/_methods/distillation/distillation.py
+++ b/src/lightly_train/_methods/distillation/distillation.py
@@ -8,10 +8,13 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any, Literal, Mapping, cast
 
 import torch
 import torch.nn.functional as F
+from lightly.utils.scheduler import CosineWarmupScheduler
+from pytorch_lightning.utilities.types import OptimizerLRScheduler
 from torch import Tensor
 from torch.nn import Flatten, Linear, Module, init
 from torch.nn.modules.module import _IncompatibleKeys
@@ -28,6 +31,7 @@ from lightly_train._methods.method_args import MethodArgs
 from lightly_train._models import package_helpers
 from lightly_train._models.embedding_model import EmbeddingModel
 from lightly_train._models.model_wrapper import ModelWrapper
+from lightly_train._optim import optimizer_helpers
 from lightly_train._optim.lars_args import LARSArgs
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
@@ -95,7 +99,7 @@ class DistillationArgs(MethodArgs):
 
 
 class DistillationLARSArgs(LARSArgs):
-    lr: float = 0.3
+    lr: float = 1.8  # 1.8 = 0.3 * 1536 / 256
     momentum: float = 0.9
     dampening: float = 0
     weight_decay: float = 1e-6
@@ -245,6 +249,36 @@ class Distillation(Method):
         return TrainableModules(
             modules=[self.student_embedding_model, self.student_projection_head]
         )
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        lr_scale = math.sqrt(self.global_batch_size / 1536)  # type: ignore[attr-defined]
+        optim = optimizer_helpers.get_optimizer(
+            optim_args=self.optimizer_args,
+            trainable_modules=self.trainable_modules(),
+            lr_scale=lr_scale,
+        )
+
+        if self.trainer.max_epochs is None:
+            raise RuntimeError("Max epochs is not set.")
+
+        max_epochs = max(1, self.trainer.max_epochs)
+
+        # Warmup for 10 epochs or 10% of the total number of epochs if max_epochs < 100
+        warmup_epochs = min(10, max_epochs / 10)
+        warmup_steps = min(
+            int(self.trainer.estimated_stepping_batches),
+            int(self.trainer.estimated_stepping_batches / max_epochs * warmup_epochs),
+        )
+        scheduler = {
+            "scheduler": CosineWarmupScheduler(
+                optimizer=optim,
+                # The arguments are called "epochs" but they can also be steps.
+                warmup_epochs=warmup_steps,
+                max_epochs=int(self.trainer.estimated_stepping_batches),
+            ),
+            "interval": "step",
+        }
+        return [optim], [scheduler]  # type: ignore[return-value]
 
     def configure_gradient_clipping(
         self,

--- a/tests/_commands/test_train.py
+++ b/tests/_commands/test_train.py
@@ -107,7 +107,8 @@ def test_train(
         f"Restoring states from the checkpoint path at {last_ckpt_path}" in caplog.text
     )
     # Epochs in checkpoint are 0-indexed. Epoch 1 is therefore the second epoch.
-    assert torch.load(last_ckpt_path, weights_only=True)["epoch"] == 1
+    # weights_only=True does not work here.
+    assert torch.load(last_ckpt_path, weights_only=False)["epoch"] == 1
 
     # Check that exported checkpoint weights changed between first and second run.
     second_ckpt = Checkpoint.from_path(checkpoint=last_ckpt_path)


### PR DESCRIPTION
## What has changed and why?

The scaling of the learning is changed from linear to "square root" to prevent too small learning with small batches.

## How has it been tested?

Tests will be added to verify that the resulting learning rate is unchanged for the recommended batchsize.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
