### PR TITLE
Add ChannelDrop augmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add channel drop transform.
+- Add option to load multi-channel images with `LIGHTLY_TRAIN_IMAGE_MODE="UNCHANGED"`.
+
 ### Changed
 
 ### Deprecated

--- a/docs/source/train/method_transform_args.md
+++ b/docs/source/train/method_transform_args.md
@@ -4,6 +4,7 @@
 
 Pretraining relies strongly on image transforms (augmentations) such as:
 
+- **Channel Drop**: Randomly drops channels from the image.
 - **Random Cropping and Resizing**: Crops random parts of images and resizes them to fixed
   resolutions.
 - **Random Horizontal and Vertical Flipping**: Mirrors images across horizontal or vertical
@@ -98,6 +99,21 @@ Interested in the default augmentation settings for each method? Check the metho
 ## Arguments available for all methods
 
 The following arguments are available for all methods.
+
+### Channel Drop
+
+Randomly drops channels from the image. Can be disabled by setting to `None`.
+Disabled by default. Only use if you have images with more than 3 channels. Requires
+`LIGHTLY_TRAIN_IMAGE_MODE="UNCHANGED"` to be set in the environment.
+
+```python skip_ruff
+"channel_drop": {
+    "num_channels_keep": int,                 # number of channels to keep in the image
+    "weight_drop": tuple[float, ...],         # weight for each channel to be dropped
+                                              # 0 means never dropped, higher values mean 
+                                              # higher probability of being dropped
+}
+```
 
 ### Random Cropping and Resizing
 

--- a/src/lightly_train/_env.py
+++ b/src/lightly_train/_env.py
@@ -79,6 +79,11 @@ class Env:
         default=180,
         type_=int,
     )
+    LIGHTLY_TRAIN_IMAGE_MODE: EnvVar[str] = EnvVar(
+        name="LIGHTLY_TRAIN_IMAGE_MODE",
+        default="RGB",
+        type_=str,
+    )
     LIGHTLY_TRAIN_MASK_DIR: EnvVar[Path | None] = EnvVar(
         name="LIGHTLY_TRAIN_MASK_DIR",
         default=None,

--- a/src/lightly_train/_loggers/mlflow.py
+++ b/src/lightly_train/_loggers/mlflow.py
@@ -22,11 +22,13 @@ from lightly_train._env import Env
 
 logger = logging.getLogger(__name__)
 
-PYTORCH_LIGHTNING_BUG_VERSIONS = ["2.5.1","2.5.1.post0"]
-PL_BUG_VERSION_INSTALLED = any([
-    RequirementCache(f"pytorch-lightning=={version}")
-    for version in PYTORCH_LIGHTNING_BUG_VERSIONS
-])
+PYTORCH_LIGHTNING_BUG_VERSIONS = ["2.5.1", "2.5.1.post0"]
+PL_BUG_VERSION_INSTALLED = any(
+    [
+        RequirementCache(f"pytorch-lightning=={version}")
+        for version in PYTORCH_LIGHTNING_BUG_VERSIONS
+    ]
+)
 
 
 class MLFlowLoggerArgs(PydanticConfig):

--- a/src/lightly_train/_methods/densecl/densecl_transform.py
+++ b/src/lightly_train/_methods/densecl/densecl_transform.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     MethodTransform,
@@ -53,6 +54,7 @@ class DenseCLGaussianBlurArgs(GaussianBlurArgs):
 
 class DenseCLTransformArgs(MethodTransformArgs):
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: DenseCLRandomResizeArgs | None = Field(
         default_factory=DenseCLRandomResizeArgs
     )
@@ -76,6 +78,7 @@ class DenseCLTransform(MethodTransform):
         # Defaults from https://github.com/lightly-ai/lightly/blob/98756fcffeaef6d3b9a57f311468d8ee755aa26c/lightly/transforms/moco_transform.py#L109-L113
         view_transform = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,

--- a/src/lightly_train/_methods/detcon/detcon_transform.py
+++ b/src/lightly_train/_methods/detcon/detcon_transform.py
@@ -11,6 +11,7 @@ from pydantic import Field
 
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     MethodTransform,
@@ -56,6 +57,7 @@ class DetConSView1TransformArgs(PydanticConfig):
 
 class DetConSTransformArgs(MethodTransformArgs):
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: RandomResizeArgs | None = Field(default_factory=RandomResizeArgs)
     random_flip: RandomFlipArgs | None = Field(default_factory=RandomFlipArgs)
     random_rotation: RandomRotationArgs | None = None
@@ -106,6 +108,7 @@ class DetConBView1TransformArgs(PydanticConfig):
 
 class DetConBTransformArgs(MethodTransformArgs):
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: RandomResizeArgs | None = Field(default_factory=RandomResizeArgs)
     random_flip: RandomFlipArgs | None = Field(default_factory=RandomFlipArgs)
     random_rotation: RandomRotationArgs | None = None
@@ -129,6 +132,7 @@ class DetConSTransform(MethodTransform):
         # and min from where to sample the (quadratic) size of the kernel
         view_transform_0 = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,
@@ -145,6 +149,7 @@ class DetConSTransform(MethodTransform):
 
         view_transform_1 = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,
@@ -175,6 +180,7 @@ class DetConBTransform(MethodTransform):
 
         view_transform_0 = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,
@@ -191,6 +197,7 @@ class DetConBTransform(MethodTransform):
 
         view_transform_1 = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,

--- a/src/lightly_train/_methods/dino/dino_transform.py
+++ b/src/lightly_train/_methods/dino/dino_transform.py
@@ -11,6 +11,7 @@ from pydantic import Field
 
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     MethodTransform,
@@ -97,6 +98,7 @@ class DINOTransformArgs(MethodTransformArgs):
     # scales accordingly.
     # https://github.com/facebookresearch/dino#resnet-50-and-other-convnets-trainings
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: DINORandomResizeArgs | None = Field(
         default_factory=DINORandomResizeArgs
     )
@@ -131,6 +133,7 @@ class DINOTransform(MethodTransform):
 
         global_transform_0 = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,
@@ -147,6 +150,7 @@ class DINOTransform(MethodTransform):
 
         global_transform_1 = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,
@@ -167,6 +171,7 @@ class DINOTransform(MethodTransform):
         if transform_args.local_view is not None:
             local_transform = ViewTransform(
                 ViewTransformArgs(
+                    channel_drop=transform_args.channel_drop,
                     random_resized_crop=RandomResizedCropArgs(
                         size=transform_args.local_view.view_size,
                         scale=transform_args.local_view.random_resize,

--- a/src/lightly_train/_methods/distillation/distillation_transform.py
+++ b/src/lightly_train/_methods/distillation/distillation_transform.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     MethodTransform,
@@ -52,6 +53,7 @@ class DistillationGaussianBlurArgs(GaussianBlurArgs):
 
 class DistillationTransformArgs(MethodTransformArgs):
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: DistillationRandomResizeArgs | None = Field(
         default_factory=DistillationRandomResizeArgs
     )
@@ -74,6 +76,7 @@ class DistillationTransform(MethodTransform):
 
         self.transform = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,

--- a/src/lightly_train/_methods/distillationv2/distillationv2_transform.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2_transform.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     MethodTransform,
@@ -54,6 +55,7 @@ class DistillationV2GaussianBlurArgs(GaussianBlurArgs):
 
 class DistillationV2TransformArgs(MethodTransformArgs):
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: DistillationV2RandomResizeArgs | None = Field(
         default_factory=DistillationV2RandomResizeArgs
     )
@@ -76,6 +78,7 @@ class DistillationV2Transform(MethodTransform):
 
         self.transform = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,

--- a/src/lightly_train/_methods/simclr/simclr_transform.py
+++ b/src/lightly_train/_methods/simclr/simclr_transform.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     MethodTransform,
@@ -48,6 +49,7 @@ class SimCLRGaussianBlurArgs(GaussianBlurArgs):
 
 class SimCLRTransformArgs(MethodTransformArgs):
     image_size: tuple[int, int] = Field(default=(224, 224), strict=False)
+    channel_drop: ChannelDropArgs | None = None
     random_resize: RandomResizeArgs | None = Field(default_factory=RandomResizeArgs)
     random_flip: RandomFlipArgs | None = Field(default_factory=RandomFlipArgs)
     random_rotation: RandomRotationArgs | None = None
@@ -68,6 +70,7 @@ class SimCLRTransform(MethodTransform):
         # Defaults from https://github.com/lightly-ai/lightly/blob/fac3dcb56745d8e5edcc59307866060cf7530bfa/lightly/transforms/simclr_transform.py#L130-L149
         view_transform = ViewTransform(
             ViewTransformArgs(
+                channel_drop=transform_args.channel_drop,
                 random_resized_crop=RandomResizedCropArgs(
                     size=transform_args.image_size,
                     scale=transform_args.random_resize,

--- a/src/lightly_train/_transforms/channel_drop.py
+++ b/src/lightly_train/_transforms/channel_drop.py
@@ -15,8 +15,8 @@ from numpy.typing import NDArray
 class ChannelDrop(ImageOnlyTransform):  # type: ignore[misc]
     def __init__(
         self,
-        num_channels_keep: int = 3,
-        weight_drop: Sequence[float] = (0.0, 0.0, 0.0),
+        num_channels_keep: int,
+        weight_drop: Sequence[float],
         p: float = 1.0,
     ):
         """

--- a/src/lightly_train/_transforms/channel_drop.py
+++ b/src/lightly_train/_transforms/channel_drop.py
@@ -1,0 +1,92 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from typing import Any, Sequence
+
+import numpy as np
+from albumentations import ImageOnlyTransform
+from numpy.typing import NDArray
+
+
+class ChannelDrop(ImageOnlyTransform):  # type: ignore[misc]
+    def __init__(
+        self,
+        num_channels_keep: int = 3,
+        prob_keep: Sequence[float] = (1.0, 1.0, 1.0),
+        p: float = 1.0,
+    ):
+        """
+        Randomly drops channels from an image. Different from Albumentations
+        ChannelDropout as it does not set channels to zero but removes them completely.
+
+        Args:
+            num_channels_keep:
+                Number of channels to keep in the image.
+            prob_keep:
+                Probability for each channel to be kept.
+            p:
+                Probability of applying the transform.
+        """
+        super().__init__(p=p)
+        self.num_channels_keep = num_channels_keep
+        self.prob_keep = list(prob_keep)
+
+        if num_channels_keep < 1:
+            raise ValueError(
+                f"num_channels_keep must be at least 1, got {num_channels_keep}."
+            )
+        if any(p < 0 for p in self.prob_keep):
+            raise ValueError(
+                f"All probabilities in prob_keep must be non-negative, got {self.prob_keep}."
+            )
+        if sum(p > 0 for p in self.prob_keep) < self.num_channels_keep:
+            raise ValueError(
+                "At least num_channels_keep channels must have a non-zero probability "
+                f"to be kept, got {self.num_channels_keep} and {self.prob_keep}."
+            )
+
+    def apply(
+        self, img: NDArray[np.uint8], **params: dict[str, Any]
+    ) -> NDArray[np.uint8]:
+        """Apply the channel drop transform to the image.
+
+        Args:
+            img: Input image as numpy array with shape (H, W, C).
+
+        Returns:
+            Image with selected channels kept, dropped channels removed completely.
+        """
+        num_channels = img.shape[2]
+
+        if len(self.prob_keep) != num_channels:
+            raise RuntimeError(
+                f"Length of prob_keep ({len(self.prob_keep)}) must match "
+                f"number of image channels ({num_channels})"
+            )
+
+        if self.num_channels_keep >= num_channels:
+            return img
+
+        prob_keep = np.array(self.prob_keep)
+        prob_keep = prob_keep / prob_keep.sum()  # Normalize
+
+        # Select channels to keep based on probabilities
+        channels_to_keep = np.random.choice(
+            num_channels, size=self.num_channels_keep, replace=False, p=prob_keep
+        )
+
+        # Sort the channels to maintain order
+        channels_to_keep = np.sort(channels_to_keep)
+
+        # Return only the selected channels (remove dropped channels completely)
+        result = img[:, :, channels_to_keep]
+
+        return result
+
+    def get_transform_init_args_names(self) -> tuple[str, ...]:
+        """Return list of arguments used in __init__ for serialization."""
+        return ("num_channels_keep", "prob_keep")

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -23,7 +23,7 @@ from lightly_train.types import TransformInput, TransformOutput
 
 class ChannelDropArgs(PydanticConfig):
     num_channels_keep: int
-    prob_keep: tuple[float, ...]
+    weight_drop: tuple[float, ...]
 
 
 class RandomResizeArgs(PydanticConfig):

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -21,6 +21,11 @@ from lightly_train._configs.config import PydanticConfig
 from lightly_train.types import TransformInput, TransformOutput
 
 
+class ChannelDropArgs(PydanticConfig):
+    num_channels_keep: int
+    prob_keep: tuple[float, ...]
+
+
 class RandomResizeArgs(PydanticConfig):
     min_scale: float = 0.08
     max_scale: float = 1.0
@@ -121,6 +126,7 @@ class MethodTransformArgs(PydanticConfig):
     # Strict is set to False because OmegaConf does not support parsing tuples from the
     # CLI. Setting strict to False allows Pydantic to convert lists to tuples.
     image_size: tuple[int, int]
+    channel_drop: ChannelDropArgs | None
     random_resize: RandomResizeArgs | None
     random_flip: RandomFlipArgs | None
     random_rotation: RandomRotationArgs | None

--- a/src/lightly_train/_transforms/view_transform.py
+++ b/src/lightly_train/_transforms/view_transform.py
@@ -102,7 +102,7 @@ class ViewTransform:
             transform += [
                 ChannelDrop(
                     num_channels_keep=args.channel_drop.num_channels_keep,
-                    prob_keep=args.channel_drop.prob_keep,
+                    weight_drop=args.channel_drop.weight_drop,
                 )
             ]
 

--- a/src/lightly_train/_transforms/view_transform.py
+++ b/src/lightly_train/_transforms/view_transform.py
@@ -25,7 +25,9 @@ from albumentations.pytorch.transforms import ToTensorV2
 from lightning_utilities.core.imports import RequirementCache
 
 from lightly_train._configs.config import PydanticConfig
+from lightly_train._transforms.channel_drop import ChannelDrop
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     NormalizeArgs,
@@ -42,6 +44,7 @@ ALBUMENTATIONS_VERSION_GREATER_EQUAL_1_4_22 = RequirementCache("albumentations>=
 
 
 class ViewTransformArgs(PydanticConfig):
+    channel_drop: ChannelDropArgs | None
     random_resized_crop: RandomResizedCropArgs  # only its .scale attribute can be None
     random_flip: RandomFlipArgs | None
     random_rotation: RandomRotationArgs | None
@@ -94,6 +97,14 @@ class ViewTransform:
         args: ViewTransformArgs,
     ) -> None:
         transform: list[BasicTransform] = []
+
+        if args.channel_drop is not None:
+            transform += [
+                ChannelDrop(
+                    num_channels_keep=args.channel_drop.num_channels_keep,
+                    prob_keep=args.channel_drop.prob_keep,
+                )
+            ]
 
         # .scale here corresponds to MethodTransformArgs.random_resize and may be None
         # .size here corresponds to MethodTransformArgs.image_size and may not be None

--- a/tests/_transforms/test_channel_drop.py
+++ b/tests/_transforms/test_channel_drop.py
@@ -15,57 +15,62 @@ from lightly_train._transforms.channel_drop import ChannelDrop
 
 class TestChannelDrop:
     @pytest.mark.parametrize(
-        "num_channels_keep, prob_keep, error",
+        "num_channels_keep, weight_drop, error",
         [
             (-1, tuple(), "num_channels_keep must be at least 1, got -1"),
             (0, tuple(), "num_channels_keep must be at least 1, got 0"),
-            (1, (-1.0, 0.0), "All probabilities in prob_keep must be non-negative"),
+            (1, (-1.0, 0.0), "All weights in weight_drop must be non-negative"),
             (
-                2,
-                (1.0, 0.0),
+                1,
+                (0.0, 0.0),
                 (
-                    "At least num_channels_keep channels must have a non-zero "
-                    "probability to be kept"
+                    "At most num_channels_keep channels can have zero weight "
+                    "to guarantee they can be kept"
                 ),
             ),
         ],
     )
     def test__init__(
-        self, num_channels_keep: int, prob_keep: tuple[float, ...], error: str
+        self, num_channels_keep: int, weight_drop: tuple[float, ...], error: str
     ) -> None:
         with pytest.raises(ValueError, match=error):
-            ChannelDrop(num_channels_keep=num_channels_keep, prob_keep=prob_keep)
+            ChannelDrop(num_channels_keep=num_channels_keep, weight_drop=weight_drop)
 
     @pytest.mark.parametrize(
-        "num_channels_keep, prob_keep, expected_channels",
+        "num_channels_keep, weight_drop, expected_channels",
         [
-            (1, (1.0, 0.0, 0.0, 0.0), (0,)),
-            (1, (0.0, 1.0, 0.0, 0.0), (1,)),
-            (2, (1.0, 1.0, 0.0, 0.0), (0, 1)),
-            (2, (0.0, 0.0, 1.0, 1.0), (2, 3)),
-            (2, (0.1, 0.2, 0.0, 0.0), (0, 1)),
-            (2, (0.0, 0.1, 0.2, 0.1), None),
-            (4, (1.0, 1.0, 1.0, 1.0), (0, 1, 2, 3)),
+            (1, (0.0, 1.0), (0,)),
+            (1, (1.0, 0.0), (1,)),
+            (1, (1.0, 1.0), (None,)),
+            (1, (0.0, 1.0, 1.0), (0,)),
+            (2, (0.0, 0.0, 1.0), (0, 1)),
+            (2, (1.0, 1.0, 0.0), (None, 2)),
+            (3, (1.0, 1.0, 0.0, 0.0), (None, 2, 3)),  # NRGB to NGB or RGB
+            (3, (0.0, 1.0, 1.0, 1.0), (0, None, None)),
+            (3, (0.0, 1.0, 1.0, 0.0), (0, None, 3)),
         ],
     )
     def test__call__(
         self,
         num_channels_keep: int,
-        prob_keep: tuple[float, ...],
-        expected_channels: tuple[int, ...] | None,
+        weight_drop: tuple[float, ...],
+        expected_channels: tuple[int, ...],
     ) -> None:
-        image = np.random.randint(0, 255, size=(10, 10, 4), dtype=np.uint8)
+        image = np.random.randint(0, 255, size=(3, 3, len(weight_drop)), dtype=np.uint8)
 
         transform = ChannelDrop(
-            num_channels_keep=num_channels_keep, prob_keep=prob_keep
+            num_channels_keep=num_channels_keep, weight_drop=weight_drop
         )
         result = transform(image=image)["image"]
 
+        assert result.dtype == image.dtype  # dtype unchanged
         assert result.shape[0] == image.shape[0]  # Height unchanged
         assert result.shape[1] == image.shape[1]  # Width unchanged
         assert result.shape[2] == num_channels_keep  # Channels reduced
-        if expected_channels is not None:
-            for i, channel in enumerate(expected_channels):
-                assert np.array_equal(result[:, :, i], image[:, :, channel]), (
-                    f"Channel {i} does not match expected channel {channel}."
-                )
+        assert len(expected_channels) == num_channels_keep
+        for i, channel in enumerate(expected_channels):
+            if channel is None:
+                continue
+            assert np.array_equal(result[:, :, i], image[:, :, channel]), (
+                f"Channel {i} does not match expected channel {channel}."
+            )

--- a/tests/_transforms/test_channel_drop.py
+++ b/tests/_transforms/test_channel_drop.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lightly_train._transforms.channel_drop import ChannelDrop
+
+
+class TestChannelDrop:
+    @pytest.mark.parametrize(
+        "num_channels_keep, prob_keep, error",
+        [
+            (-1, tuple(), "num_channels_keep must be at least 1, got -1"),
+            (0, tuple(), "num_channels_keep must be at least 1, got 0"),
+            (1, (-1.0, 0.0), "All probabilities in prob_keep must be non-negative"),
+            (
+                2,
+                (1.0, 0.0),
+                (
+                    "At least num_channels_keep channels must have a non-zero "
+                    "probability to be kept"
+                ),
+            ),
+        ],
+    )
+    def test__init__(
+        self, num_channels_keep: int, prob_keep: tuple[float, ...], error: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error):
+            ChannelDrop(num_channels_keep=num_channels_keep, prob_keep=prob_keep)
+
+    @pytest.mark.parametrize(
+        "num_channels_keep, prob_keep, expected_channels",
+        [
+            (1, (1.0, 0.0, 0.0, 0.0), (0,)),
+            (1, (0.0, 1.0, 0.0, 0.0), (1,)),
+            (2, (1.0, 1.0, 0.0, 0.0), (0, 1)),
+            (2, (0.0, 0.0, 1.0, 1.0), (2, 3)),
+            (2, (0.1, 0.2, 0.0, 0.0), (0, 1)),
+            (2, (0.0, 0.1, 0.2, 0.1), None),
+            (4, (1.0, 1.0, 1.0, 1.0), (0, 1, 2, 3)),
+        ],
+    )
+    def test__call__(
+        self,
+        num_channels_keep: int,
+        prob_keep: tuple[float, ...],
+        expected_channels: tuple[int, ...] | None,
+    ) -> None:
+        image = np.random.randint(0, 255, size=(10, 10, 4), dtype=np.uint8)
+
+        transform = ChannelDrop(
+            num_channels_keep=num_channels_keep, prob_keep=prob_keep
+        )
+        result = transform(image=image)["image"]
+
+        assert result.shape[0] == image.shape[0]  # Height unchanged
+        assert result.shape[1] == image.shape[1]  # Width unchanged
+        assert result.shape[2] == num_channels_keep  # Channels reduced
+        if expected_channels is not None:
+            for i, channel in enumerate(expected_channels):
+                assert np.array_equal(result[:, :, i], image[:, :, channel]), (
+                    f"Channel {i} does not match expected channel {channel}."
+                )

--- a/tests/_transforms/test_view_transform.py
+++ b/tests/_transforms/test_view_transform.py
@@ -33,7 +33,7 @@ from lightly_train.types import TransformInput
 def _get_channel_drop_args() -> ChannelDropArgs:
     return ChannelDropArgs(
         num_channels_keep=3,
-        prob_keep=(0.1, 0.0, 0.8, 0.1),
+        weight_drop=(1.0, 1.0, 0.0, 0.0),
     )
 
 

--- a/tests/_transforms/test_view_transform.py
+++ b/tests/_transforms/test_view_transform.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 from lightly_train._transforms.transform import (
+    ChannelDropArgs,
     ColorJitterArgs,
     GaussianBlurArgs,
     NormalizeArgs,
@@ -27,6 +28,13 @@ from lightly_train._transforms.transform import (
 )
 from lightly_train._transforms.view_transform import ViewTransform, ViewTransformArgs
 from lightly_train.types import TransformInput
+
+
+def _get_channel_drop_args() -> ChannelDropArgs:
+    return ChannelDropArgs(
+        num_channels_keep=3,
+        prob_keep=(0.1, 0.0, 0.8, 0.1),
+    )
 
 
 def _get_random_resized_crop_args() -> RandomResizedCropArgs:
@@ -76,6 +84,7 @@ def _get_normalize_args() -> NormalizeArgs:
 
 
 PossibleArgsTuple = Tuple[
+    Union[ChannelDropArgs, None],
     RandomResizedCropArgs,
     Union[RandomFlipArgs, None],
     Union[RandomRotationArgs, None],
@@ -88,6 +97,7 @@ PossibleArgsTuple = Tuple[
 
 
 def _get_possible_view_transform_args_combinations() -> list[PossibleArgsTuple]:
+    channel_drop = [_get_channel_drop_args(), None]
     random_resized_crop = [_get_random_resized_crop_args()] * 2
     random_flip = [_get_random_flip_args(), None]
     random_rotation = [_get_random_rotation_args(), None]
@@ -98,6 +108,7 @@ def _get_possible_view_transform_args_combinations() -> list[PossibleArgsTuple]:
     normalize = [_get_normalize_args()] * 2
     return list(
         itertools.product(
+            channel_drop,
             random_resized_crop,
             random_flip,
             random_rotation,
@@ -115,11 +126,12 @@ possible_tuples = _get_possible_view_transform_args_combinations()
 
 class TestViewTransform:
     @pytest.mark.parametrize(
-        "random_resized_crop, random_flip, random_rotation, color_jitter, random_gray_scale, gaussian_blur, solarize, normalize",
+        "channel_drop, random_resized_crop, random_flip, random_rotation, color_jitter, random_gray_scale, gaussian_blur, solarize, normalize",
         possible_tuples,
     )
     def test_view_transform_all_args_combinations(
         self,
+        channel_drop: ChannelDropArgs | None,
         random_resized_crop: RandomResizedCropArgs,
         random_flip: RandomFlipArgs | None,
         random_rotation: RandomRotationArgs | None,
@@ -131,6 +143,7 @@ class TestViewTransform:
     ) -> None:
         view_transform = ViewTransform(
             ViewTransformArgs(
+                channel_drop=channel_drop,
                 random_resized_crop=random_resized_crop,
                 random_flip=random_flip,
                 random_rotation=random_rotation,
@@ -141,8 +154,9 @@ class TestViewTransform:
                 normalize=normalize,
             )
         )
+        num_channels = 3 if channel_drop is None else 4
         tr_input: TransformInput = {
-            "image": np.random.rand(224, 224, 3).astype(np.float32),
+            "image": np.random.rand(224, 224, num_channels).astype(np.float32),
         }
         tr_output = view_transform(tr_input)
         assert isinstance(tr_output, dict)


### PR DESCRIPTION
## What has changed and why?

* Add channel drop augmentation
* Add option to load multi-channel images with LIGHTLY_TRAIN_IMAGE_MODE="UNCHANGED"

Note that we still assume that all images have 3-channels for the augmentations. So `LIGHTLY_TRAIN_IMAGE_MODE="UNCHANGED"` must be used in combination with `channel_drop=dict(num_channels_keep=3, weight_drop=(...))`. To make sure that only 3 channels are kept. 

Will add proper support for multi-channel later. 

## How has it been tested?

* Added unit tests
* Ran training with NRGB images and the two new options

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
