### PR TITLE
Ignore Lightning srun warning

### DIFF
--- a/src/lightly_train/_commands/_warnings.py
+++ b/src/lightly_train/_commands/_warnings.py
@@ -84,6 +84,9 @@ def filter_warnings() -> None:
             "torch.nn.utils.parametrizations.weight_norm."
         ),
     )
+    warnings.filterwarnings(
+        "ignore", message="The `srun` command is available on your system"
+    )
 
     # Torch ConvNext warning
     warnings.filterwarnings(


### PR DESCRIPTION
## What has changed and why?

* Ignore Lightning srun warning

Avoids this warning:
```
/home/lightly/guarin/lightly-train/.venv/lib/python3.11/site-packages/lightning_fabric/plugins/environments/slurm.py:204: The `srun` command is available on your system but is not used. HINT: If your intention is to run Lightning on SLURM, prepend your python command with `srun` like so: srun python run_train.py ...
```

The warning is not helpful as it points the user in the wrong direction. Instead of just adding `srun` in front of the script they should follow https://docs.lightly.ai/train/stable/performance/multi_gpu.html#slurm

## How has it been tested?

* Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
