### PR TITLE
Allow DINOv2 weights loading for Distillation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow loading pretrained DINOv2 teacher weights for distillation methods with an extra `teacher_weights` argument in `method_args`.
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow loading pretrained DINOv2 teacher weights for distillation methods with an extra `teacher_weights` argument in `method_args`.
+
 ### Deprecated
 
 ### Removed
@@ -31,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to load multi-channel images with `LIGHTLY_TRAIN_IMAGE_MODE="UNCHANGED"`.
 
 ### Changed
-
-- Allow loading pretrained DINOv2 teacher weights for distillation methods with an extra `teacher_weights` argument in `method_args`.
 
 ### Deprecated
 

--- a/src/lightly_train/_methods/distillation/distillation.py
+++ b/src/lightly_train/_methods/distillation/distillation.py
@@ -47,8 +47,10 @@ def get_teacher(teacher_name: str, teacher_weights: str | Path | None = None) ->
     teacher_embedding_model = wrapped_model.get_model()
     assert isinstance(teacher_embedding_model, Module)
 
-    # If a path to the teacher weights is provided, load them.
-    if teacher_weights is not None:
+    # If a path to the pretrained teacher weights is provided, load them.
+    # Ignore the weights when the pretrained teacher is provided so as to prevent loading
+    # the weights twice.
+    if (not teacher_name.endswith("_pretrain")) and (teacher_weights is not None):
         if not Path(teacher_weights).exists():
             raise FileNotFoundError(
                 f"Teacher weights file {teacher_weights} does not exist."

--- a/src/lightly_train/_methods/distillation/distillation.py
+++ b/src/lightly_train/_methods/distillation/distillation.py
@@ -47,10 +47,8 @@ def get_teacher(teacher_name: str, teacher_weights: str | Path | None = None) ->
     teacher_embedding_model = wrapped_model.get_model()
     assert isinstance(teacher_embedding_model, Module)
 
-    # If a path to the pretrained teacher weights is provided, load them.
-    # Ignore the weights when the pretrained teacher is provided so as to prevent loading
-    # the weights twice.
-    if (not teacher_name.endswith("_pretrain")) and (teacher_weights is not None):
+    # If a path to the teacher weights is provided, load them.
+    if teacher_weights is not None:
         if not Path(teacher_weights).exists():
             raise FileNotFoundError(
                 f"Teacher weights file {teacher_weights} does not exist."

--- a/src/lightly_train/_methods/distillation/distillation.py
+++ b/src/lightly_train/_methods/distillation/distillation.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Literal, Mapping, cast
 
 import torch
@@ -41,11 +42,24 @@ from lightly_train.types import Batch
 logger = logging.getLogger(__name__)
 
 
-def get_teacher(teacher_name: str) -> Module:
+def get_teacher(teacher_name: str, teacher_weights: str | Path | None = None) -> Module:
     wrapped_model = package_helpers.get_wrapped_model(model=teacher_name)
     teacher_embedding_model = wrapped_model.get_model()
     assert isinstance(teacher_embedding_model, Module)
+
+    # If a path to the teacher weights is provided, load them.
+    if teacher_weights is not None:
+        if not Path(teacher_weights).exists():
+            raise FileNotFoundError(
+                f"Teacher weights file {teacher_weights} does not exist."
+            )
+
+        state_dict = torch.load(teacher_weights, weights_only=True)
+        teacher_embedding_model.load_state_dict(state_dict)
+        logger.debug(f"Loaded teacher weights from {teacher_weights}.")
+
     teacher_embedding_model.eval()
+
     return teacher_embedding_model
 
 
@@ -60,6 +74,9 @@ class DistillationArgs(MethodArgs):
 
     # Default teacher.
     teacher: str = "dinov2_vit/vitb14_pretrain"
+
+    # Optional teacher weight path.
+    teacher_weights: str | Path | None = None
 
     # Scaling method for the learning rate.
     lr_scale_method: Literal["linear", "sqrt"] = "sqrt"
@@ -123,7 +140,9 @@ class Distillation(Method):
             global_batch_size=global_batch_size,
         )
         # Get the teacher model.
-        self.teacher_embedding_model = get_teacher(method_args.teacher)
+        self.teacher_embedding_model = get_teacher(
+            method_args.teacher, method_args.teacher_weights
+        )
 
         # Store the student model.
         self.student_embedding_model = embedding_model

--- a/src/lightly_train/_methods/distillationv2/distillationv2.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2.py
@@ -43,10 +43,8 @@ def get_teacher(teacher_name: str, teacher_weights: str | Path | None = None) ->
     teacher_embedding_model = wrapped_model.get_model()
     assert isinstance(teacher_embedding_model, Module)
 
-    # If a path to the pretrained teacher weights is provided, load them.
-    # Ignore the weights when the pretrained teacher is provided so as to prevent loading
-    # the weights twice.
-    if (not teacher_name.endswith("_pretrain")) and (teacher_weights is not None):
+    # If a path to the teacher weights is provided, load them.
+    if teacher_weights is not None:
         if not Path(teacher_weights).exists():
             raise FileNotFoundError(
                 f"Teacher weights file {teacher_weights} does not exist."

--- a/src/lightly_train/_methods/distillationv2/distillationv2.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2.py
@@ -43,8 +43,10 @@ def get_teacher(teacher_name: str, teacher_weights: str | Path | None = None) ->
     teacher_embedding_model = wrapped_model.get_model()
     assert isinstance(teacher_embedding_model, Module)
 
-    # If a path to the teacher weights is provided, load them.
-    if teacher_weights is not None:
+    # If a path to the pretrained teacher weights is provided, load them.
+    # Ignore the weights when the pretrained teacher is provided so as to prevent loading
+    # the weights twice.
+    if (not teacher_name.endswith("_pretrain")) and (teacher_weights is not None):
         if not Path(teacher_weights).exists():
             raise FileNotFoundError(
                 f"Teacher weights file {teacher_weights} does not exist."

--- a/src/lightly_train/_methods/distillationv2/distillationv2.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Literal, Mapping, cast
 
 import torch
@@ -37,11 +38,24 @@ from lightly_train.types import Batch
 logger = logging.getLogger(__name__)
 
 
-def get_teacher(teacher_name: str) -> Module:
+def get_teacher(teacher_name: str, teacher_weights: str | Path | None = None) -> Module:
     wrapped_model = package_helpers.get_wrapped_model(model=teacher_name)
     teacher_embedding_model = wrapped_model.get_model()
-    teacher_embedding_model.eval()
     assert isinstance(teacher_embedding_model, Module)
+
+    # If a path to the teacher weights is provided, load them.
+    if teacher_weights is not None:
+        if not Path(teacher_weights).exists():
+            raise FileNotFoundError(
+                f"Teacher weights file {teacher_weights} does not exist."
+            )
+
+        state_dict = torch.load(teacher_weights, weights_only=True)
+        teacher_embedding_model.load_state_dict(state_dict)
+        logger.debug(f"Loaded teacher weights from {teacher_weights}.")
+
+    teacher_embedding_model.eval()
+
     return teacher_embedding_model
 
 
@@ -53,6 +67,9 @@ class DistillationV2Args(MethodArgs):
 
     # Default teacher
     teacher: str = "dinov2_vit/vitb14_pretrain"
+
+    # Optional teacher weight path.
+    teacher_weights: str | Path | None = None
 
     # Number of projection layers in the projection head.
     n_projection_layers: int = 1
@@ -129,7 +146,9 @@ class DistillationV2(Method):
             global_batch_size=global_batch_size,
         )
         # Get the teacher model.
-        self.teacher_embedding_model = get_teacher(method_args.teacher)
+        self.teacher_embedding_model = get_teacher(
+            method_args.teacher, method_args.teacher_weights
+        )
         self.teacher_embedding_dim = (
             method_args.n_teacher_blocks * self.teacher_embedding_model.embed_dim
         )

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_package.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_package.py
@@ -69,6 +69,7 @@ class DINOv2ViTPackage(Package):
 
         # Build the model using the cfg
         model_builders = {
+            "_vit_test": vits._vit_test,
             "vit_small": vits.vit_small,
             "vit_base": vits.vit_base,
             "vit_large": vits.vit_large,

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/__init__.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/__init__.py
@@ -14,6 +14,10 @@ import pathlib
 from omegaconf import OmegaConf
 
 MODELS = {
+    "_vit_test14": {
+        "url": "",
+        "config": "train/_vit_test14",
+    },  # This is a test model for development purposes only.
     "vits14": {
         "url": "",
         "config": "train/vits14",

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/_vit_test14.yaml
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/configs/train/_vit_test14.yaml
@@ -1,0 +1,7 @@
+student:
+  arch: _vit_test
+  patch_size: 14
+  embed_dim: 8
+  depth: 2
+  num_heads: 2
+  mlp_ratio: 1

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
@@ -458,9 +458,7 @@ def vit_giant2(patch_size=16, num_register_tokens=0, **kwargs) -> DinoVisionTran
     return model
 
 
-def vit_tiny__testing(
-    patch_size=16, num_register_tokens=0, **kwargs
-) -> DinoVisionTransformer:
+def _vit_test(patch_size=16, num_register_tokens=0, **kwargs) -> DinoVisionTransformer:
     model = DinoVisionTransformer(
         patch_size=patch_size,
         embed_dim=8,

--- a/tests/_methods/dinov2/test_dinov2.py
+++ b/tests/_methods/dinov2/test_dinov2.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Literal
+from typing import Literal
 
 import pytest
 import torch
@@ -20,19 +20,13 @@ from lightly_train._methods.dinov2.dinov2 import (
     DINOv2AdamWViTArgs,
     DINOv2Args,
 )
-from lightly_train._models.dinov2_vit.dinov2_vit import DINOv2ViTModelWrapper
-from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
-    vit_tiny__testing,
-)
 from lightly_train._models.embedding_model import EmbeddingModel
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
 from lightly_train._scaling import IMAGENET_SIZE, ScalingInfo
 from lightly_train.types import Batch
 
-
-def dummy_vit_model(patch_size: int = 2, **kwargs: Any) -> DINOv2ViTModelWrapper:
-    return DINOv2ViTModelWrapper(model=vit_tiny__testing(patch_size, **kwargs))
+from ...helpers import dummy_vit_model
 
 
 def setup_dinov2_helper(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,6 +31,10 @@ from lightly_train._configs.config import PydanticConfig
 from lightly_train._methods.method import Method
 from lightly_train._methods.method_args import MethodArgs
 from lightly_train._methods.simclr.simclr import SimCLR, SimCLRArgs
+from lightly_train._models.dinov2_vit.dinov2_vit import DINOv2ViTModelWrapper
+from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
+    _vit_test,
+)
 from lightly_train._models.embedding_model import EmbeddingModel
 from lightly_train._models.model_wrapper import (
     ForwardFeaturesOutput,
@@ -254,3 +258,7 @@ def assert_same_params(
         a_defaults = {a.name: a.default for a in a_params.values() if not a.required}
         b_defaults = {b.name: b.default for b in b_params.values() if not b.required}
         assert a_defaults == b_defaults
+
+
+def dummy_vit_model(patch_size: int = 2, **kwargs: Any) -> DINOv2ViTModelWrapper:
+    return DINOv2ViTModelWrapper(model=_vit_test(patch_size, **kwargs))


### PR DESCRIPTION
## What has changed and why?

Support loading DINOv2 teacher weights from a pretrained checkpoint by allowing such input

```
lightly_train.train(
  ...,
  method="distillation",
  method_args={
    "teacher": "dinov2_vit/vitb14",
    "teacher_weights": "out/dinov2/exported_models/exported_last.pt", # pretrained `dinov2_vit/vitb14` weights 
  }
)
```

Also added unit tests for this. More specifically, to enable the test, we

- renamed `vit_tiny__testing` to `_vit_test` and added it to the available model list so that it can be loaded via `lightly_train.train(model="dinov2_vit/_vit_test")
- moved `dummy_vit_model` to `helpers` so that it can be used across all the tests

## How has it been tested?

By running the unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
