### PR TITLE
Trn 617 reuse memory mapped file

### DIFF
--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -375,12 +375,14 @@ def _get_package(model: Module) -> BasePackage:
 
 
 @contextlib.contextmanager
-def get_dataset_temp_mmap_path(data: PathLike | Sequence[PathLike]) -> Generator[Path, Any, Any]:
+def get_dataset_temp_mmap_path(
+    data: PathLike | Sequence[PathLike],
+) -> Generator[Path, Any, Any]:
     """Generate file in temporary directory to be used for memory-mapping the dataset.
 
     Creates a unique filename for the memory-mapped file based on the data arg.
     We use the data arg as a deterministic value that is consistent across all ranks
-    on the same node. Additionally, we can cache the file if required, since the hash 
+    on the same node. Additionally, we can cache the file if required, since the hash
     directly reflects the used config.
 
     We need a deterministic value from "outside" at this point in the code as the
@@ -424,7 +426,7 @@ def get_dataset_mmap_filenames(
         return memory_mapped_sequence.memory_mapped_sequence_from_file(
             mmap_filepath=mmap_filepath
         )
-    
+
     tmp_path = mmap_filepath.with_suffix(".temp")
     try:
         if distributed_helpers.is_local_rank_zero():

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -130,7 +130,7 @@ def embed_from_config(config: EmbedConfig) -> None:
     # file has to exist while the dataset is used.
     with common_helpers.verify_out_dir_equal_on_all_local_ranks(
         out=out_path
-    ), common_helpers.get_dataset_temp_mmap_path(out=out_path) as mmap_filepath:
+    ), common_helpers.get_dataset_temp_mmap_path(data=config.data) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
             transform=transform,

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -286,7 +286,7 @@ def train_from_config(config: TrainConfig) -> None:
     with common_helpers.verify_out_dir_equal_on_all_local_ranks(
         out=out_dir
     ), common_helpers.get_dataset_temp_mmap_path(
-        out=out_dir
+        data=config.data
     ) as mmap_filepath, _float32_matmul_precision.float32_matmul_precision(
         float32_matmul_precision=config.float32_matmul_precision
     ):

--- a/src/lightly_train/_env.py
+++ b/src/lightly_train/_env.py
@@ -109,6 +109,11 @@ class Env:
         default=300,
         type_=float,
     )
+    LIGHTLY_TRAIN_MMAP_REUSE_FILE: EnvVar[bool] = EnvVar(
+        name="LIGHTLY_TRAIN_MMAP_REUSE_FILE",
+        default=False,
+        type_=lambda x: x.lower() in ("true", "t", "1", "yes", "y"),
+    )
     LIGHTLY_TRAIN_VERIFY_OUT_DIR_TIMEOUT_SEC: EnvVar[float] = EnvVar(
         name="LIGHTLY_TRAIN_VERIFY_OUT_DIR_TIMEOUT_SEC",
         default=30,

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -537,7 +537,7 @@ def test_get_num_workers__slurm(
 
 
 def test_get_dataset_temp_mmap_path(tmp_path: Path) -> None:
-    with common_helpers.get_dataset_temp_mmap_path(out=tmp_path) as mmap_path:
+    with common_helpers.get_dataset_temp_mmap_path(data=tmp_path) as mmap_path:
         mmap_path.touch()
     # Make sure file is deleted after exiting the context manager.
     assert not mmap_path.exists()
@@ -548,12 +548,12 @@ def test_get_dataset_temp_mmap_path__rank(
 ) -> None:
     # Simulate calling the function from rank 0
     mocker.patch.dict(os.environ, {"LOCAL_RANK": "0"})
-    with common_helpers.get_dataset_temp_mmap_path(out=tmp_path) as mmap_path_rank0:
+    with common_helpers.get_dataset_temp_mmap_path(data=tmp_path) as mmap_path_rank0:
         pass
 
     # Simulate calling the function from rank 1
     mocker.patch.dict(os.environ, {"LOCAL_RANK": "1"})
-    with common_helpers.get_dataset_temp_mmap_path(out=tmp_path) as mmap_path_rank1:
+    with common_helpers.get_dataset_temp_mmap_path(data=tmp_path) as mmap_path_rank1:
         pass
 
     assert mmap_path_rank0 == mmap_path_rank1


### PR DESCRIPTION
## What has changed and why?

For large detests reusing the mmap file can mean a high speed up for the dataset initialization. #151 

This PR brings the required changes. Usage:
To enable the permanent saving of the mmap file, the environment variable LIGHTLY_TRAIN_MMAP_REUSE_FILE is introduced. If this is true, an existing mmap file for the same input data_arg will be reused if it exists, else it will be created.
`os.environ["LIGHTLY_TRAIN_MMAP_REUSE_FILE"] = "1"`

## How has it been tested?

Unit tests are introduced.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)
