### PR TITLE
Disable FFmpeg install in CI

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -67,12 +67,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Set Up FFmpeg
-        # FFMPEG is not installable on Windows using the setup-ffmpeg action.
-        if: ${{ matrix.runners == 'ubuntu-latest' }}
-        uses: FedericoCarboni/setup-ffmpeg@v3
-        with:
-          ffmpeg-version: 4.3.1
+      # Disabled because FFmpeg install fails too often in CI. See https://github.com/federicocarboni/setup-ffmpeg/issues/29
+      # - name: Set Up FFmpeg
+      #   # FFMPEG is not installable on Windows using the setup-ffmpeg action.
+      #   if: ${{ matrix.runners == 'ubuntu-latest' }}
+      #   uses: FedericoCarboni/setup-ffmpeg@v3
+      #   with:
+      #     ffmpeg-version: 4.3.1
       - name: Set Up Environment
         run: |
           make install-pinned-${{ matrix.python }}              # Install the dependencies

--- a/.github/workflows/test_unit_minimal_dependencies.yml
+++ b/.github/workflows/test_unit_minimal_dependencies.yml
@@ -58,11 +58,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Set Up FFmpeg
-        if: ${{ matrix.dependencies == 'minimal-extras' }}
-        uses: FedericoCarboni/setup-ffmpeg@v3
-        with:
-          ffmpeg-version: 4.3.1
+      # Disabled because FFmpeg install fails too often in CI. See https://github.com/federicocarboni/setup-ffmpeg/issues/29
+      # - name: Set Up FFmpeg
+      #   if: ${{ matrix.dependencies == 'minimal-extras' }}
+      #   uses: FedericoCarboni/setup-ffmpeg@v3
+      #   with:
+      #     ffmpeg-version: 4.3.1
       - name: Set Up Environment
         run: |
           make install-${{ matrix.dependencies }}


### PR DESCRIPTION
## What has changed and why?

* Disable FFmpeg install in CI

Disabled because it fails too often and is only used for `extract_video_frames` which is not really used. 

## How has it been tested?


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
