### PR TITLE
Fix DINOv2 local loss initialization

### DIFF
--- a/src/lightly_train/_methods/dinov2/dinov2.py
+++ b/src/lightly_train/_methods/dinov2/dinov2.py
@@ -343,7 +343,7 @@ class DINOv2(Method):
         )
 
         # Process local views through student network if they exist
-        dino_local_loss = torch.tensor(0.0)
+        dino_local_loss = torch.zeros_like(dino_global_loss)
         # TODO(Jonas 06/25): since n_local_crops is known on instantiation, we could avoid the check and instead instantiate a get_local_views depending on the attribute, similar the forward local could be instantiated like that
         if n_local_crops > 0:
             local_views = torch.cat(


### PR DESCRIPTION
## What has changed and why?

The DINOv2 local loss was not correctly initialized which caused an error if the number of local crops was set to zero.

## How has it been tested?

Dummy runs.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
