### PR TITLE
Update Documentation of RT-DETR Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented support for the [RT-DETRv2 models](https://docs.lightly.ai/train/stable/models/rtdetr.html).
+
 ### Changed
 
 - Allow loading pretrained DINOv2 teacher weights for distillation methods with an extra `teacher_weights` argument in `method_args`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ model.load_state_dict(torch.load("out/my_experiment/exported_models/exported_las
 | Torchvision | ResNet, ConvNext, ShuffleNetV2 | [🔗](https://docs.lightly.ai/train/stable/models/torchvision.html) |
 | TIMM | All models | [🔗](https://docs.lightly.ai/train/stable/models/timm.html) |
 | Ultralytics | YOLOv5, YOLOv6, YOLOv8, YOLO11, YOLO12 | [🔗](https://docs.lightly.ai/train/stable/models/ultralytics.html) |
-| RT-DETR | RT-DETRv2 | [🔗](https://docs.lightly.ai/train/stable/models/rtdetr.html) |
+| RT-DETR | RT-DETR & RT-DETRv2 | [🔗](https://docs.lightly.ai/train/stable/models/rtdetr.html) |
 | RF-DETR | RF-DETR | [🔗](https://docs.lightly.ai/train/stable/models/rfdetr.html) |
 | YOLOv12 | YOLOv12 | [🔗](https://docs.lightly.ai/train/stable/models/yolov12.html) |
 | SuperGradients | PP-LiteSeg, SSD, YOLO-NAS | [🔗](https://docs.lightly.ai/train/stable/models/supergradients.html) |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ model.load_state_dict(torch.load("out/my_experiment/exported_models/exported_las
 | Torchvision | ResNet, ConvNext, ShuffleNetV2 | [🔗](https://docs.lightly.ai/train/stable/models/torchvision.html) |
 | TIMM | All models | [🔗](https://docs.lightly.ai/train/stable/models/timm.html) |
 | Ultralytics | YOLOv5, YOLOv6, YOLOv8, YOLO11, YOLO12 | [🔗](https://docs.lightly.ai/train/stable/models/ultralytics.html) |
-| RT-DETR | RT-DETR | [🔗](https://docs.lightly.ai/train/stable/models/rtdetr.html) |
+| RT-DETR | RT-DETRv2 | [🔗](https://docs.lightly.ai/train/stable/models/rtdetr.html) |
 | RF-DETR | RF-DETR | [🔗](https://docs.lightly.ai/train/stable/models/rfdetr.html) |
 | YOLOv12 | YOLOv12 | [🔗](https://docs.lightly.ai/train/stable/models/yolov12.html) |
 | SuperGradients | PP-LiteSeg, SSD, YOLO-NAS | [🔗](https://docs.lightly.ai/train/stable/models/supergradients.html) |

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -48,7 +48,7 @@ a wide range of model architectures and use cases out of the box.
 :alt: benchmark results
 
 On COCO, YOLOv8-s models pretrained with LightlyTrain achieve high performance across all tested label fractions.
-These improvements hold for other architectures like YOLOv11, RT-DETRv2, and Faster R-CNN.
+These improvements hold for other architectures like YOLOv11, RT-DETR, and Faster R-CNN.
 See our [announcement post](https://www.lightly.ai/blog/introducing-lightly-train) for more details.
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -122,7 +122,7 @@ Want to use your model to generate image embeddings instead? Check out the {ref}
 | Torchvision | ResNet, ConvNext, ShuffleNetV2 | [🔗](#models-torchvision) |
 | TIMM | All models | [🔗](#models-timm) |
 | Ultralytics | YOLOv5, YOLOv6, YOLOv8, YOLO11, YOLO12 | [🔗](#models-ultralytics) |
-| RT-DETR | RT-DETRv2 | [🔗](#models-rtdetr) |
+| RT-DETR | RT-DETR & RT-DETRv2 | [🔗](#models-rtdetr) |
 | RF-DETR | RF-DETR | [🔗](#models-rfdetr) |
 | YOLOv12 | YOLOv12 | [🔗](#models-yolov12) |
 | SuperGradients | PP-LiteSeg, SSD, YOLO-NAS | [🔗](#models-supergradients) |

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -48,7 +48,7 @@ a wide range of model architectures and use cases out of the box.
 :alt: benchmark results
 
 On COCO, YOLOv8-s models pretrained with LightlyTrain achieve high performance across all tested label fractions.
-These improvements hold for other architectures like YOLOv11, RT-DETR, and Faster R-CNN.
+These improvements hold for other architectures like YOLOv11, RT-DETRv2, and Faster R-CNN.
 See our [announcement post](https://www.lightly.ai/blog/introducing-lightly-train) for more details.
 ```
 
@@ -122,7 +122,7 @@ Want to use your model to generate image embeddings instead? Check out the {ref}
 | Torchvision | ResNet, ConvNext, ShuffleNetV2 | [🔗](#models-torchvision) |
 | TIMM | All models | [🔗](#models-timm) |
 | Ultralytics | YOLOv5, YOLOv6, YOLOv8, YOLO11, YOLO12 | [🔗](#models-ultralytics) |
-| RT-DETR | RT-DETR | [🔗](#models-rtdetr) |
+| RT-DETR | RT-DETRv2 | [🔗](#models-rtdetr) |
 | RF-DETR | RF-DETR | [🔗](#models-rfdetr) |
 | YOLOv12 | YOLOv12 | [🔗](#models-yolov12) |
 | SuperGradients | PP-LiteSeg, SSD, YOLO-NAS | [🔗](#models-supergradients) |

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -13,7 +13,7 @@ installed manually, however LightlyTrain provides a model wrapper for the RT-DET
 
 ```{warning}
 Due to an incompatibility between the `torchvision` version requirements of RT-DETRv1 and 
-LightlyTrain, it is only possible to pretrain RT-DETRv2.
+LightlyTrain, it is only possible to pretrain the RT-DETRv2 implementation. Still, you are able to use the RT-DETR(v1) configs to pretrain RT-DETR models.
 ```
 
 ## RT-DETR Installation

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -95,22 +95,22 @@ for more information on how to fine-tune a model.
 The following RT-DETR model variants are supported:
 
 - RT-DETR
-    - `rtdetr/rtdetr_r18vd_6x_coco.yml`
-    - `rtdetr/rtdetr_r34vd_6x_coco.yml`
-    - `rtdetr/rtdetr_r50vd_6x_coco.yml`
-    - `rtdetr/rtdetr_r50vd_m_6x_coco.yml`
-    - `rtdetr/rtdetr_r101vd_6x_coco.yml`
+  - `rtdetr/rtdetr_r18vd_6x_coco.yml`
+  - `rtdetr/rtdetr_r34vd_6x_coco.yml`
+  - `rtdetr/rtdetr_r50vd_6x_coco.yml`
+  - `rtdetr/rtdetr_r50vd_m_6x_coco.yml`
+  - `rtdetr/rtdetr_r101vd_6x_coco.yml`
 - RT-DETRv2
-    - `rtdetrv2/rtdetrv2_r18vd_120e_coco.yml`
-    - `rtdetrv2/rtdetrv2_r18vd_120e_voc.yml`
-    - `rtdetrv2/rtdetrv2_r18vd_dsp_3x_coco.yml`
-    - `rtdetrv2/rtdetrv2_r18vd_sp1_120e_coco.yml`
-    - `rtdetrv2/rtdetrv2_r18vd_sp2_120e_coco.yml`
-    - `rtdetrv2/rtdetrv2_r18vd_sp3_120e_coco.yml`
-    - `rtdetrv2/rtdetrv2_r34vd_120e_coco.yml`
-    - `rtdetrv2/rtdetrv2_r34vd_dsp_1x_coco.yml`
-    - `rtdetrv2/rtdetrv2_r50vd_6x_coco.yml`
-    - `rtdetrv2/rtdetrv2_r50vd_dsp_1x_coco.yml`
-    - `rtdetrv2/rtdetrv2_r50vd_m_7x_coco.yml`
-    - `rtdetrv2/rtdetrv2_r50vd_m_dsp_3x_coco.yml`
-    - `rtdetrv2/rtdetrv2_r101vd_6x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r18vd_120e_coco.yml`
+  - `rtdetrv2/rtdetrv2_r18vd_120e_voc.yml`
+  - `rtdetrv2/rtdetrv2_r18vd_dsp_3x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r18vd_sp1_120e_coco.yml`
+  - `rtdetrv2/rtdetrv2_r18vd_sp2_120e_coco.yml`
+  - `rtdetrv2/rtdetrv2_r18vd_sp3_120e_coco.yml`
+  - `rtdetrv2/rtdetrv2_r34vd_120e_coco.yml`
+  - `rtdetrv2/rtdetrv2_r34vd_dsp_1x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r50vd_6x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r50vd_dsp_1x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r50vd_m_7x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r50vd_m_dsp_3x_coco.yml`
+  - `rtdetrv2/rtdetrv2_r101vd_6x_coco.yml`

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -8,7 +8,12 @@ with LightlyTrain.
 ```{note}
 RT-DETR is not a pip-installable Python package. For this reason,
 RT-DETR is not fully integrated with LightlyTrain and has to be
-installed manually.
+installed manually, however LightlyTrain provides a model wrapper for the RT-DETR models.
+```
+
+```{warning}
+Due to an incompatibility between the `torchvision` version requirements of RT-DETRv1 and 
+LightlyTrain, it is only possible to pretrain RT-DETRv2.
 ```
 
 ## RT-DETR Installation
@@ -89,8 +94,23 @@ for more information on how to fine-tune a model.
 
 The following RT-DETR model variants are supported:
 
-- `rtdetr_r18vd`
-- `rtdetr_r34vd`
-- `rtdetr_r50vd`
-- `rtdetr_r50vd_m`
-- `rtdetr_r101vd`
+- RT-DETR
+    - `rtdetr/rtdetr_r18vd_6x_coco.yml`
+    - `rtdetr/rtdetr_r34vd_6x_coco.yml`
+    - `rtdetr/rtdetr_r50vd_6x_coco.yml`
+    - `rtdetr/rtdetr_r50vd_m_6x_coco.yml`
+    - `rtdetr/rtdetr_r101vd_6x_coco.yml`
+- RT-DETRv2
+    - `rtdetrv2/rtdetrv2_r18vd_120e_coco.yml`
+    - `rtdetrv2/rtdetrv2_r18vd_120e_voc.yml`
+    - `rtdetrv2/rtdetrv2_r18vd_dsp_3x_coco.yml`
+    - `rtdetrv2/rtdetrv2_r18vd_sp1_120e_coco.yml`
+    - `rtdetrv2/rtdetrv2_r18vd_sp2_120e_coco.yml`
+    - `rtdetrv2/rtdetrv2_r18vd_sp3_120e_coco.yml`
+    - `rtdetrv2/rtdetrv2_r34vd_120e_coco.yml`
+    - `rtdetrv2/rtdetrv2_r34vd_dsp_1x_coco.yml`
+    - `rtdetrv2/rtdetrv2_r50vd_6x_coco.yml`
+    - `rtdetrv2/rtdetrv2_r50vd_dsp_1x_coco.yml`
+    - `rtdetrv2/rtdetrv2_r50vd_m_7x_coco.yml`
+    - `rtdetrv2/rtdetrv2_r50vd_m_dsp_3x_coco.yml`
+    - `rtdetrv2/rtdetrv2_r101vd_6x_coco.yml`

--- a/docs/source/models/rtdetr.md
+++ b/docs/source/models/rtdetr.md
@@ -12,8 +12,7 @@ installed manually, however LightlyTrain provides a model wrapper for the RT-DET
 ```
 
 ```{warning}
-Due to an incompatibility between the `torchvision` version requirements of RT-DETRv1 and 
-LightlyTrain, it is only possible to pretrain the RT-DETRv2 implementation. Still, you are able to use the RT-DETR(v1) configs to pretrain RT-DETR models.
+Due to an incompatibility between the torchvision version requirements of RT-DETRv1, we support the RT-DETRv2 implementation that is backward compatible and allows the training of both RT-DETR(v1) and RT-DETRv2 models.
 ```
 
 ## RT-DETR Installation


### PR DESCRIPTION
## What has changed and why?
- We are actually only supporting the RT-DETRv2 package, however this can also be used with the RT-DETRv1 configs.
- This PR streamlines the naming as follows: The package is always called RT-DETR, the model is always called RT-DETRv2
- I additionally included all the v2 configs that had previously not been in the documentation
- I excluded all the `hgnetv2` models, e.g. https://github.com/lyuwenyu/RT-DETR/blob/main/rtdetrv2_pytorch/configs/rtdetrv2/rtdetrv2_hgnetv2_h_6x_coco.yml, since they don't run with LightlyTrain.

@yutong-xiang-97 update: makes explicit that users can train v1 models with v2 package.

## How has it been tested?
- manually ran all the supported models once locally
- I would not implement unit tests for all the models, this would take forever

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
