### PR TITLE
VFMF Add MLflow Logger

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -70,7 +70,6 @@ def train_task_from_config(config: TrainTaskConfig) -> None:
     # have to initialize the output directory and some other things. Fabric doesn't
     # expose a method to add callbacks and loggers later but it should be safe to do
     # so anyways.
-
     # TODO(Guarin, 07/25): Validate and initialize arguments passed to Fabric properly.
     fabric = Fabric(
         accelerator=config.accelerator,

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -189,6 +189,10 @@ def train_task_from_config(config: TrainTaskConfig) -> None:
         f"Resolved Args: {helpers.pretty_format_args(args=config.model_dump())}"
     )
 
+    hyperparams = common_helpers.sanitize_config_dict(config.model_dump())
+    for logger_instance in fabric.loggers:
+        logger_instance.log_hyperparams(hyperparams)
+
     state = TrainTaskState(
         model=model,
         optimizer=optimizer,

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Any, Literal
 
 import torch
@@ -72,14 +71,6 @@ def train_task_from_config(config: TrainTaskConfig) -> None:
     # expose a method to add callbacks and loggers later but it should be safe to do
     # so anyways.
 
-    config.logger_args = helpers.get_logger_args(
-        logger_args=config.logger_args,
-    )
-    logger_instances = helpers.get_loggers(
-        logger_args=config.logger_args,
-        out=Path(config.out),
-    )
-
     # TODO(Guarin, 07/25): Validate and initialize arguments passed to Fabric properly.
     fabric = Fabric(
         accelerator=config.accelerator,
@@ -87,7 +78,6 @@ def train_task_from_config(config: TrainTaskConfig) -> None:
         devices=config.devices,
         num_nodes=config.num_nodes,
         precision=config.precision,
-        loggers=logger_instances,
     )
     fabric.launch()
     config.accelerator = fabric.accelerator
@@ -174,7 +164,16 @@ def train_task_from_config(config: TrainTaskConfig) -> None:
         loader_args=config.loader_args,
     )
 
-    config.logger_args.resolve_auto(steps=config.steps, val_steps=len(val_dataloader))
+    config.logger_args = helpers.get_logger_args(
+        steps=config.steps,
+        val_steps=len(val_dataloader),
+        logger_args=config.logger_args,
+    )
+    logger_instances = helpers.get_loggers(
+        logger_args=config.logger_args,
+        out=out_dir,
+    )
+    fabric.loggers.extend(logger_instances)
 
     model = helpers.get_task_train_model(
         model_name=config.model,

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 from lightning_fabric import Fabric
 from lightning_fabric import utilities as fabric_utilities
+from lightning_fabric.loggers.logger import Logger as FabricLogger
 from torch.utils.data import DataLoader, Dataset
 from torchmetrics import Metric
 
@@ -25,6 +26,7 @@ from lightly_train._data.mask_semantic_segmentation_dataset import (
     MaskSemanticSegmentationDatasetArgs,
 )
 from lightly_train._env import Env
+from lightly_train._loggers.mlflow import MLFlowLogger
 from lightly_train._loggers.task_logger_args import TaskLoggerArgs
 from lightly_train._task_checkpoint import TaskCheckpointArgs
 from lightly_train._task_models.dinov2_semantic_segmentation.dinov2_semantic_segmentation_train import (
@@ -104,16 +106,36 @@ def get_out_dir(
 
 
 def get_logger_args(
-    steps: int,
-    val_steps: int,
     logger_args: dict[str, Any] | TaskLoggerArgs | None = None,
 ) -> TaskLoggerArgs:
     if isinstance(logger_args, TaskLoggerArgs):
         return logger_args
     logger_args = {} if logger_args is None else logger_args
-    args = validate.pydantic_model_validate(TaskLoggerArgs, logger_args)
-    args.resolve_auto(steps=steps, val_steps=val_steps)
-    return args
+    return validate.pydantic_model_validate(TaskLoggerArgs, logger_args)
+
+
+def get_loggers(logger_args: TaskLoggerArgs, out: Path) -> list[FabricLogger]:
+    """Get logger instances based on the provided configuration.
+
+    All loggers are configured with the same output directory 'out'.
+
+    Args:
+        logger_args:
+            Configuration for the loggers.
+        out:
+            Path to the output directory.
+
+    Returns:
+        List of loggers.
+    """
+    loggers: list[FabricLogger] = []
+
+    if logger_args.mlflow is not None:
+        logger.debug(f"Using mlflow logger with args {logger_args.mlflow}")
+        loggers.append(MLFlowLogger(save_dir=out, **logger_args.mlflow.model_dump()))
+
+    logger.debug(f"Using loggers {[log.__class__.__name__ for log in loggers]}.")
+    return loggers
 
 
 class PrettyFormatArgsJSONEncoder(JSONEncoder):

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -106,12 +106,16 @@ def get_out_dir(
 
 
 def get_logger_args(
+    steps: int,
+    val_steps: int,
     logger_args: dict[str, Any] | TaskLoggerArgs | None = None,
 ) -> TaskLoggerArgs:
     if isinstance(logger_args, TaskLoggerArgs):
         return logger_args
     logger_args = {} if logger_args is None else logger_args
-    return validate.pydantic_model_validate(TaskLoggerArgs, logger_args)
+    args = validate.pydantic_model_validate(TaskLoggerArgs, logger_args)
+    args.resolve_auto(steps=steps, val_steps=val_steps)
+    return args
 
 
 def get_loggers(logger_args: TaskLoggerArgs, out: Path) -> list[FabricLogger]:

--- a/src/lightly_train/_loggers/task_logger_args.py
+++ b/src/lightly_train/_loggers/task_logger_args.py
@@ -12,11 +12,12 @@ from typing import Literal
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._loggers.mlflow import MLFlowLoggerArgs
 
+
 class TaskLoggerArgs(PydanticConfig):
     log_every_num_steps: int | Literal["auto"] = "auto"
     val_every_num_steps: int | Literal["auto"] = "auto"
     val_log_every_num_steps: int | Literal["auto"] = "auto"
-    
+
     mlflow: MLFlowLoggerArgs | None = None
 
     def resolve_auto(self, steps: int, val_steps: int) -> None:

--- a/src/lightly_train/_loggers/task_logger_args.py
+++ b/src/lightly_train/_loggers/task_logger_args.py
@@ -13,11 +13,11 @@ from lightly_train._configs.config import PydanticConfig
 from lightly_train._loggers.mlflow import MLFlowLoggerArgs
 
 class TaskLoggerArgs(PydanticConfig):
-    mlflow: MLFlowLoggerArgs | None = None
-    
     log_every_num_steps: int | Literal["auto"] = "auto"
     val_every_num_steps: int | Literal["auto"] = "auto"
     val_log_every_num_steps: int | Literal["auto"] = "auto"
+    
+    mlflow: MLFlowLoggerArgs | None = None
 
     def resolve_auto(self, steps: int, val_steps: int) -> None:
         if self.log_every_num_steps == "auto":

--- a/src/lightly_train/_loggers/task_logger_args.py
+++ b/src/lightly_train/_loggers/task_logger_args.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 from typing import Literal
 
 from lightly_train._configs.config import PydanticConfig
-
+from lightly_train._loggers.mlflow import MLFlowLoggerArgs
 
 class TaskLoggerArgs(PydanticConfig):
+    mlflow: MLFlowLoggerArgs | None = None
+    
     log_every_num_steps: int | Literal["auto"] = "auto"
     val_every_num_steps: int | Literal["auto"] = "auto"
     val_log_every_num_steps: int | Literal["auto"] = "auto"


### PR DESCRIPTION
## What has changed and why?

Use Lightning's MLflow logger for logging.

Note that:

1. The resolution of the accelerator and strategy does not work for now
2. We didn't add the corresponding unit test because the settings will be too cumbersome.

## How has it been tested?

run `test_train_task` with a script using the MLflow service.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
