### PR TITLE
Allow training on mixed number of channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow loading pretrained DINOv2 teacher weights for distillation methods with an extra
+  `teacher_weights` argument in `method_args`.
+- Support images with different number of channels in the channel drop transform.
 - Documented support for the [RT-DETRv2 models](https://docs.lightly.ai/train/stable/models/rtdetr.html).
 
 ### Changed
 
 - The callback `DeviceStatsMonitor` is now disabled by default.
-- Allow loading pretrained DINOv2 teacher weights for distillation methods with an extra `teacher_weights` argument in `method_args`.
 
 ### Deprecated
 
@@ -35,14 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add channel drop transform.
 - Add option to load multi-channel images with `LIGHTLY_TRAIN_IMAGE_MODE="UNCHANGED"`.
 - Add option to reuse memmap dataset file via environment variable: `LIGHTLY_TRAIN_MMAP_REUSE_FILE=True`.
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
 
 ### Security
 

--- a/src/lightly_train/_transforms/channel_drop.py
+++ b/src/lightly_train/_transforms/channel_drop.py
@@ -70,14 +70,19 @@ class ChannelDrop(ImageOnlyTransform):  # type: ignore[misc]
         """
         num_channels = img.shape[2]
 
+        if self.num_channels_keep == num_channels:
+            return img
+        elif self.num_channels_keep > num_channels:
+            raise ValueError(
+                f"num_channels_keep ({self.num_channels_keep}) cannot be greater "
+                f"than the number of channels in the image ({num_channels})."
+            )
+
         if len(self.weight_drop) != num_channels:
             raise RuntimeError(
                 f"Length of weight_drop ({len(self.weight_drop)}) must match "
                 f"number of image channels ({num_channels})"
             )
-
-        if self.num_channels_keep >= num_channels:
-            return img
 
         channels_to_drop = np.random.choice(
             num_channels,

--- a/tests/_transforms/test_channel_drop.py
+++ b/tests/_transforms/test_channel_drop.py
@@ -37,26 +37,30 @@ class TestChannelDrop:
             ChannelDrop(num_channels_keep=num_channels_keep, weight_drop=weight_drop)
 
     @pytest.mark.parametrize(
-        "num_channels_keep, weight_drop, expected_channels",
+        "num_channels, num_channels_keep, weight_drop, expected_channels",
         [
-            (1, (0.0, 1.0), (0,)),
-            (1, (1.0, 0.0), (1,)),
-            (1, (1.0, 1.0), (None,)),
-            (1, (0.0, 1.0, 1.0), (0,)),
-            (2, (0.0, 0.0, 1.0), (0, 1)),
-            (2, (1.0, 1.0, 0.0), (None, 2)),
-            (3, (1.0, 1.0, 0.0, 0.0), (None, 2, 3)),  # NRGB to NGB or RGB
-            (3, (0.0, 1.0, 1.0, 1.0), (0, None, None)),
-            (3, (0.0, 1.0, 1.0, 0.0), (0, None, 3)),
+            (1, 1, (0.0, 1.0), (0,)),  # No drop
+            (2, 1, (0.0, 1.0), (0,)),
+            (2, 1, (1.0, 0.0), (1,)),
+            (2, 1, (1.0, 1.0), (None,)),
+            (3, 1, (0.0, 1.0, 1.0), (0,)),
+            (2, 2, (0.0, 0.0, 1.0), (0, 1)),  # No drop
+            (3, 2, (0.0, 0.0, 1.0), (0, 1)),
+            (3, 2, (1.0, 1.0, 0.0), (None, 2)),
+            (3, 3, (1.0, 1.0, 0.0, 0.0), (0, 1, 2)),  # No drop
+            (4, 3, (1.0, 1.0, 0.0, 0.0), (None, 2, 3)),  # NRGB to NGB or RGB
+            (4, 3, (0.0, 1.0, 1.0, 1.0), (0, None, None)),
+            (4, 3, (0.0, 1.0, 1.0, 0.0), (0, None, 3)),
         ],
     )
     def test__call__(
         self,
+        num_channels: int,
         num_channels_keep: int,
         weight_drop: tuple[float, ...],
         expected_channels: tuple[int, ...],
     ) -> None:
-        image = np.random.randint(0, 255, size=(3, 3, len(weight_drop)), dtype=np.uint8)
+        image = np.random.randint(0, 255, size=(3, 3, num_channels), dtype=np.uint8)
 
         transform = ChannelDrop(
             num_channels_keep=num_channels_keep, weight_drop=weight_drop


### PR DESCRIPTION
## What has changed and why?

* Allow training on mixed number of channels

This allows for example training on 3- and 4-channel images at the same time. The ChannelDrop augmentation now ignores images that already have the correct number of channels. 

## How has it been tested?

* Unit tests
* Manually tested on mixed dataset with 3- and 4-channel images. 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
