### PR TITLE
Fix Unit Tests

### DIFF
--- a/src/lightly_train/_commands/export_task.py
+++ b/src/lightly_train/_commands/export_task.py
@@ -79,7 +79,6 @@ def export_task_from_config(config: ExportTaskConfig) -> None:
     checkpoint_path = common_helpers.get_checkpoint_path(checkpoint=config.checkpoint)
 
     # Load the model
-    torch.use_deterministic_algorithms(True)
     checkpoint = torch.load(checkpoint_path)
     model = DINOv2SemanticSegmentation(
         model_name="vits14",  # TODO(Yutong, 07/25): use checkpoint["model_name"],

--- a/tests/_methods/dinov2/test_dinov2.py
+++ b/tests/_methods/dinov2/test_dinov2.py
@@ -206,13 +206,16 @@ class TestDINOv2:
         )
         check_param_groups()
 
+        optim.step()
         scheduler.step()
 
         # Second batch
         target_lr = lr_neutral
         check_param_groups()
 
+        optim.step()
         scheduler.step()
+        optim.step()
         scheduler.step()
 
         # Last Batch


### PR DESCRIPTION
## What has changed and why?

Fix unit test:

- remove `torch.use_deterministic_algorithms(True)` in `export_task` to fix failures
- add `optim.step()` in `test_dinov2::test_layerwise_decay_optimizer` to fix the warning: 

```
UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. 
```

## How has it been tested?

Successful checks.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
