### PR TITLE
Thomas trn 625 allow arbitrary input size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Patch embedding in ViT to support image resolution that is not a multiple of the patch size.
+- Augmentations plotting function to support odd-sized images.
+- DistillationV2 to work with image resolution that is not a multiple of the patch size.
+
 ### Deprecated
 
 ### Removed

--- a/src/lightly_train/_methods/distillationv2/distillationv2.py
+++ b/src/lightly_train/_methods/distillationv2/distillationv2.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 from typing import Any, Literal, Mapping, cast
 
@@ -204,8 +205,12 @@ class DistillationV2(Method):
         b, _, image_h, image_w = x.shape
 
         # Infer the spatial size of the teacher features.
-        teacher_features_h = image_h // self.teacher_embedding_model.patch_size
-        teacher_features_w = image_w // self.teacher_embedding_model.patch_size
+        teacher_features_h = math.ceil(
+            image_h / self.teacher_embedding_model.patch_size
+        )
+        teacher_features_w = math.ceil(
+            image_w / self.teacher_embedding_model.patch_size
+        )
 
         # Forward the images through the student model.
         x = self.student_embedding_model(x, pool=False)

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/layers/patch_embed.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/layers/patch_embed.py
@@ -71,7 +71,7 @@ class PatchEmbed(nn.Module):
         )
         self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor) -> Tuple[Tensor, int, int]:
         _, _, H, W = x.shape
         patch_H, patch_W = self.patch_size
 

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/layers/patch_embed.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/layers/patch_embed.py
@@ -9,9 +9,11 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
 
+import math
 from typing import Callable, Optional, Tuple, Union
 
 import torch.nn as nn
+import torch.nn.functional as F
 from torch import Tensor
 
 
@@ -73,6 +75,17 @@ class PatchEmbed(nn.Module):
         _, _, H, W = x.shape
         patch_H, patch_W = self.patch_size
 
+        # Find the next multiple of patch size for height & width.
+        new_H = math.ceil(H / patch_H) * patch_H
+        new_W = math.ceil(W / patch_W) * patch_W
+
+        if new_H != H or new_W != W:
+            # Resize image to nearest valid resolution
+            x = F.interpolate(
+                x, size=(new_H, new_W), mode="bicubic", align_corners=False
+            )
+            H, W = new_H, new_W
+
         assert H % patch_H == 0, (
             f"Input image height {H} is not a multiple of patch height {patch_H}"
         )
@@ -86,7 +99,7 @@ class PatchEmbed(nn.Module):
         x = self.norm(x)
         if not self.flatten_embedding:
             x = x.reshape(-1, H, W, self.embed_dim)  # B H W C
-        return x
+        return x, new_H, new_W
 
     def flops(self) -> float:
         Ho, Wo = self.patches_resolution

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
@@ -258,8 +258,9 @@ class DinoVisionTransformer(nn.Module):
         )
 
     def prepare_tokens_with_masks(self, x, masks=None):
-        B, nc, w, h = x.shape
-        x = self.patch_embed(x)
+        # TODO(Thomas, 07/25): Fix swapped h and w.
+        B, nc, _, _ = x.shape
+        x, w, h = self.patch_embed(x)
         if masks is not None:
             x = torch.where(
                 masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x

--- a/src/lightly_train/_plot.py
+++ b/src/lightly_train/_plot.py
@@ -47,12 +47,15 @@ def plot_example_augmentations(train_batch: Batch, max_examples: int = 10) -> PI
         for i_row, image_tensor in enumerate(batch):
             if i_row >= n_examples:
                 break
+            # TODO(Thomas,07/25): Fix swapped x and y.
             x_mid = header_height + i_row * grid_height + grid_height // 2
             x_start = x_mid - image_tensor.shape[1] // 2
             x_end = x_mid + image_tensor.shape[1] // 2
+            x_end += image_tensor.shape[1] % 2  # Ensure working with odd sizes
             y_mid = header_width + i_column * grid_width + grid_width // 2
             y_start = y_mid - image_tensor.shape[2] // 2
             y_end = y_mid + image_tensor.shape[2] // 2
+            y_end += image_tensor.shape[2] % 2  # Ensure working with odd sizes
             combined_aug_tensor[
                 :,
                 x_start:x_end,


### PR DESCRIPTION
## What has changed and why?

Update the DINOv2 ViT to support square images with resolution that is not a multiple of the patch size.
Update the plotting of augmentations for odd size image resolutions

## How has it been tested?

Dummy runs with various resolutions (square only).

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
