### PR TITLE
Add tensorboard logger for train_task

### DIFF
--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -47,6 +47,7 @@ from lightly_train._task_models.task_train_model import (
 from lightly_train._train_task_state import TrainTaskState
 from lightly_train._transforms.task_transform import TaskTransform
 from lightly_train.types import PathLike, TaskDatasetItem
+from src.lightly_train._loggers.tensorboard import TensorBoardLogger
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +139,11 @@ def get_loggers(logger_args: TaskLoggerArgs, out: Path) -> list[FabricLogger]:
     if logger_args.mlflow is not None:
         logger.debug(f"Using mlflow logger with args {logger_args.mlflow}")
         loggers.append(MLFlowLogger(save_dir=out, **logger_args.mlflow.model_dump()))
+    if logger_args.tensorboard is not None:
+        logger.debug(f"Using tensorboard logger with args {logger_args.tensorboard}")
+        loggers.append(
+            TensorBoardLogger(save_dir=out, **logger_args.tensorboard.model_dump())
+        )
 
     logger.debug(f"Using loggers {[log.__class__.__name__ for log in loggers]}.")
     return loggers

--- a/src/lightly_train/_loggers/task_logger_args.py
+++ b/src/lightly_train/_loggers/task_logger_args.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import Field
+
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._loggers.mlflow import MLFlowLoggerArgs
+from src.lightly_train._loggers.tensorboard import TensorBoardLoggerArgs
 
 
 class TaskLoggerArgs(PydanticConfig):
@@ -19,6 +22,9 @@ class TaskLoggerArgs(PydanticConfig):
     val_log_every_num_steps: int | Literal["auto"] = "auto"
 
     mlflow: MLFlowLoggerArgs | None = None
+    tensorboard: TensorBoardLoggerArgs | None = Field(
+        default_factory=TensorBoardLoggerArgs
+    )
 
     def resolve_auto(self, steps: int, val_steps: int) -> None:
         if self.log_every_num_steps == "auto":


### PR DESCRIPTION
## What has changed and why?

* Add tensorboard logger for train_task 

Tensorboard logger is by default enabled. This mirrors `train.py`

## How has it been tested?

* Manually
<img width="1163" height="651" alt="Screenshot 2025-07-22 at 13 55 39" src="https://github.com/user-attachments/assets/8a3cdc97-cf76-40ca-81bf-cfdcfb9d3555" />



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
