### PR TITLE
add custom template for GTM

### DIFF
--- a/docs/source/_templates/gtm/body.html
+++ b/docs/source/_templates/gtm/body.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W8QM8M3"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/docs/source/_templates/gtm/head.html
+++ b/docs/source/_templates/gtm/head.html
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-W8QM8M3');</script>
+<!-- End Google Tag Manager -->

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,0 +1,13 @@
+{% extends "furo/page.html" %}
+
+{# Include GTM head code in the HTML head section #}
+{% block extrahead %}
+{% include "gtm/head.html" %}
+{{ super() }}
+{% endblock %}
+
+{# Include GTM body code right after the opening body tag (Furo provides the `body` block) #}
+{% block body %}
+{% include "gtm/body.html" %}
+{{ super() }}
+{% endblock %}


### PR DESCRIPTION
## What has changed and why?
1. adds custom template for Google Tag Manager (GTM), for this it does the following:
  - extends [Furo's page.html](https://github.com/pradyunsg/furo/blob/main/src/furo/theme/furo/page.html), which corresponds to the `layout.html` in the base theme
  - adds `head.html` to the `extrahead` block (this block is defined in above file and inherited; `super()` makes sure to include inherited content as well)
  - adds `body.html` to the `body` block (also defined in above file and inherited)
2. For now, it leaves the Google Analytics extension untouched. This will be removed in a follow-up issue, once GTM properly works and is verified.

## How has it been tested?
- not tested

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
