### PR TITLE
Thomas trn 1368 fix mask annealing steps

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -137,7 +137,6 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
             float32_matmul_precision=config.float32_matmul_precision,
         )
     )
-    config.model_args = helpers.get_train_model_args(model_args=config.model_args)
     config.save_checkpoint_args = helpers.get_save_checkpoint_args(
         checkpoint_args=config.save_checkpoint_args
     )
@@ -171,6 +170,10 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
     config.num_workers = common_helpers.get_num_workers(
         num_workers=config.num_workers,
         num_devices_per_node=fabric.world_size // config.num_nodes,
+    )
+
+    config.model_args = helpers.get_train_model_args(
+        model_args=config.model_args, total_steps=no_auto(config.steps)
     )
 
     # TODO(Guarin, 07/25): Handle auto batch_size/num_workers.

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -282,12 +282,16 @@ def get_steps(steps: int | Literal["auto"]) -> int:
 
 def get_train_model_args(
     model_args: dict[str, Any] | TrainModelArgs | None,
+    total_steps: int,
 ) -> TrainModelArgs:
     if isinstance(model_args, TrainModelArgs):
         return model_args
     model_args = {} if model_args is None else model_args
     task_cls = DINOv2EoMTSemanticSegmentationTrainArgs
     args = validate.pydantic_model_validate(task_cls, model_args)
+    args.resolve_auto(
+        total_steps=total_steps,
+    )
     return args
 
 

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -19,6 +19,7 @@ from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import Optimizer
 
+from lightly_train._configs.validate import no_auto
 from lightly_train._data.mask_semantic_segmentation_dataset import (
     MaskSemanticSegmentationDataArgs,
 )
@@ -243,9 +244,9 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
         # Mask annealing.
         for i in range(len(self.model.attn_mask_probs)):
             self.model.attn_mask_probs[i] = self.mask_annealing(
-                start_iter=self.model_args.attn_mask_annealing_steps_start[i],
+                start_iter=no_auto(self.model_args.attn_mask_annealing_steps_start)[i],
                 current_iter=step,
-                final_iter=self.model_args.attn_mask_annealing_steps_end[i],
+                final_iter=no_auto(self.model_args.attn_mask_annealing_steps_end)[i],
             )
 
         return TaskStepResult(

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -85,8 +85,8 @@ class DINOv2EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
         ]
 
         # Set the start and stop of each phases.
-        self.attn_mask_annealing_steps_start: list[int] = phases[1:-2]
-        self.attn_mask_annealing_steps_end: list[int] = phases[2:-1]
+        self.attn_mask_annealing_steps_start = phases[1:-2]
+        self.attn_mask_annealing_steps_end = phases[2:-1]
 
         # Ensure the number of phases is correct.
         assert len(self.attn_mask_annealing_steps_start) == self.num_joint_blocks


### PR DESCRIPTION
## What has changed and why?

The mask annealing steps are automatically inferred such that it works for datasets other than ADE20K.

## How has it been tested?

Verified that the inferred steps are close to the original values for ADE20K.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
