### PR TITLE
Allow custom filenames for checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - DINOv2 pre-trained models with registers to supported models.
+- Pretraining allows now custom filenames for checkpoints.
 
 ### Changed
 

--- a/src/lightly_train/_callbacks/checkpoint.py
+++ b/src/lightly_train/_callbacks/checkpoint.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class ModelCheckpointArgs(PydanticConfig):
+    filename: str | None = None
     save_last: bool = True
     enable_version_counter: bool = False
     save_top_k: int = 1


### PR DESCRIPTION
## What has changed and why?
- solves https://github.com/lightly-ai/lightly-train/issues/174
- exposes the filename for the checkpoints and lets users customize it

## How has it been tested?
- tested with a local training run

```python
import lightly_train

if __name__ == "__main__":
    lightly_train.train(
        out="out/my_experiment",            # Output directory
        data="my_data_dir",                 # Directory with images
        model="torchvision/resnet18",       # Model to train
        epochs=10,                          # Number of epochs to train
        batch_size=32,                      # Batch size
        accelerator="cpu",
        overwrite=True,
        callbacks={
            "model_checkpoint": {
                "filename": "some_custom_name_{epoch}_{train_loss:.2f}",
            },
        }
    )
```
and the resulting checkpoint was at `out/my_experiment/checkpoints/some_custom_name_epoch=1_train_loss=3.12.ckpt`.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (I don't think we should document this right now)
