### PR TITLE
Allow uniform masks for semantic segmentation

### DIFF
--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -51,10 +51,6 @@ class MaskSemanticSegmentationDataset(Dataset[MaskSemanticSegmentationDatasetIte
         # Get unique values in the mask.
         unique_values = np.unique(mask)
 
-        # Uniform masks are discarded.
-        if len(unique_values) == 1:
-            return False
-
         # Check if at least one value in the mask is in the valid classes.
         return bool(np.isin(unique_values, self.valid_classes).any())
 


### PR DESCRIPTION
## What has changed and why?

* Allow uniform masks for semantic segmentation

This avoids issues with validation datasets that have uniform masks. This shouldn't be a big issue for training as the model should be able to handle such masks. 

## How has it been tested?

* CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
