### PR TITLE
Infer num_joint_blocks from model name

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -260,6 +260,7 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
         model_args=config.model_args,
         model_args_cls=model_args_cls,
         total_steps=no_auto(config.steps),
+        model_name=config.model,
     )
 
     # TODO(Guarin, 07/25): Handle auto batch_size/num_workers.

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -294,12 +294,13 @@ def get_train_model_args(
     model_args: dict[str, Any] | TrainModelArgs | None,
     model_args_cls: type[TrainModelArgs],
     total_steps: int,
+    model_name: str,
 ) -> TrainModelArgs:
     if isinstance(model_args, TrainModelArgs):
         return model_args
     model_args = {} if model_args is None else model_args
     args = validate.pydantic_model_validate(model_args_cls, model_args)
-    args.resolve_auto(total_steps=total_steps)
+    args.resolve_auto(total_steps=total_steps, model_name=model_name)
     return args
 
 

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -78,11 +78,7 @@ class DINOv2EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
     metric_log_classwise: bool = True
     metric_log_debug: bool = False
 
-    def resolve_auto(self, total_steps: int, **kwargs: Any) -> None:
-        # Get the model name.
-        model_name = kwargs["model_name"]
-        assert model_name is not None
-
+    def resolve_auto(self, total_steps: int, model_name: str) -> None:
         if self.num_joint_blocks == "auto":
             match = re.match(r"(dinov2(?:_vit)?)/(vit[slbg]).*", model_name)
             assert match is not None, (

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -85,7 +85,9 @@ class DINOv2EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
 
         if self.num_joint_blocks == "auto":
             match = re.match(r"(dinov2(?:_vit)?)/(vit[slbg]).*", model_name)
-            assert match is not None, f"Could not parse model size from model_name='{model_name}'"
+            assert match is not None, (
+                f"Could not parse model size from model_name='{model_name}'"
+            )
             model_size = match.group(1)
             self.num_joint_blocks = {
                 "vits": 3,

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -81,9 +81,12 @@ class DINOv2EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
     def resolve_auto(self, total_steps: int, model_name: str) -> None:
         if self.num_joint_blocks == "auto":
             match = re.match(r"(dinov2(?:_vit)?)/(vit[slbg]).*", model_name)
-            assert match is not None, (
-                f"Could not parse model size from model_name='{model_name}'"
-            )
+            if match is None:
+                raise ValueError(
+                    f"Unknown model name '{model_name}', "
+                    "see https://docs.lightly.ai/train/stable/semantic_segmentation.html#model "
+                    "for all supported models."
+                )
             model_size = match.group(1)
             self.num_joint_blocks = {
                 "vits": 3,

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -151,7 +151,7 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
                 data_args.ignore_index if data_args.ignore_classes else None
             ),
             num_queries=model_args.num_queries,
-            num_joint_blocks=model_args.num_joint_blocks,
+            num_joint_blocks=no_auto(model_args.num_joint_blocks),
             backbone_weights=model_args.backbone_weights,
             backbone_args={
                 "drop_path_rate": model_args.drop_path_rate,

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -77,7 +77,10 @@ class DINOv2EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
     metric_log_classwise: bool = True
     metric_log_debug: bool = False
 
-    def resolve_auto(self, total_steps: int, model_name: str) -> None:
+    def resolve_auto(self, total_steps: int, **kwargs: Any) -> None:
+        # Get the model name.
+        model_name = kwargs["model_name"]
+
         if self.num_joint_blocks == "auto":
             # Set the dict to match scale to num_joint_blocks.
             scale_to_num_joint_blocks = {
@@ -89,7 +92,7 @@ class DINOv2EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
 
             # Set the num_joint_blocks based on the scale.
             model_name = model_name.split("/", maxsplit=1)[-1]
-            scale_index = model_name.find("vit")
+            scale_index = model_name.lower().find("vit")
             assert scale_index != -1, (
                 "The model name is expected to contain the string 'vit'."
             )

--- a/src/lightly_train/_task_models/train_model.py
+++ b/src/lightly_train/_task_models/train_model.py
@@ -27,7 +27,7 @@ class TrainModelArgs(PydanticConfig):
     default_batch_size: ClassVar[int]
     default_steps: ClassVar[int]
 
-    def resolve_auto(self, total_steps: int) -> None:
+    def resolve_auto(self, **kwargs: Any) -> None:
         pass
 
 

--- a/src/lightly_train/_task_models/train_model.py
+++ b/src/lightly_train/_task_models/train_model.py
@@ -27,7 +27,7 @@ class TrainModelArgs(PydanticConfig):
     default_batch_size: ClassVar[int]
     default_steps: ClassVar[int]
 
-    def resolve_auto(self, **kwargs: Any) -> None:
+    def resolve_auto(self, total_steps: int, **kwargs: Any) -> None:
         pass
 
 

--- a/src/lightly_train/_task_models/train_model.py
+++ b/src/lightly_train/_task_models/train_model.py
@@ -27,7 +27,7 @@ class TrainModelArgs(PydanticConfig):
     default_batch_size: ClassVar[int]
     default_steps: ClassVar[int]
 
-    def resolve_auto(self, total_steps: int, **kwargs: Any) -> None:
+    def resolve_auto(self, total_steps: int, model_name: str) -> None:
         pass
 
 


### PR DESCRIPTION
## What has changed and why?

The number joint blocks is automatically inferred in EoMT to accommodate other models than the ViT-L

## How has it been tested?

-

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
