### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.11.0] – 2025-08-15
+## [0.11.0] - 2025-08-15
 
 🚀 **New DINOv3 Support:** Pretrain your own model with [distillation](https://docs.lightly.ai/train/stable/methods/distillation.html#methods-distillation-dinov3) from DINOv3 weights. Or fine-tune our SOTA [EoMT semantic segmentation model](https://docs.lightly.ai/train/stable/semantic_segmentation.html#semantic-segmentation-eomt-dinov3) with a DINOv3 backbone! 🚀
 


### PR DESCRIPTION
## What has changed and why?

* Fix hyphen in changelog

A wrong type of hyphen was used in the changelog. This resulted in the link to the latests changelog being broken:
* https://docs.lightly.ai/train/stable/changelog.html#id2

With the fix it correctly includes the version number:
* https://docs.lightly.ai/train/stable/changelog.html#changelog-0-11-0


## How has it been tested?

* Built docs locally

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
