### PR TITLE
Add fine-tune transform arg customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `model="dinov2/vits14-linear"` in the `train_semantic_segmentation` command. Those
   models are trained with a linear head on top of a frozen backbone and are useful
   to evaluate the quality of pretrained DINOv2 models.
+- Make fine-tune transform arguments configurable in the `train_semantic_segmentation`
+  command. You can now use the `transform_args` argument like this
+  ```python
+  transform_args={
+    "image_size": (height, width),
+    "normalize": {"mean": (r, g, b), "std": (r, g, b)},
+  }
+  ```
+  to customize the image augmentations used during training and validation.
 
 ### Changed
 

--- a/docs/prebuild.py
+++ b/docs/prebuild.py
@@ -6,12 +6,17 @@ from argparse import ArgumentParser
 from pathlib import Path
 from re import Match
 
-from lightly_train._commands import common_helpers, train_helpers
+from lightly_train._commands import common_helpers, train_helpers, train_task_helpers
+from lightly_train._commands.train_task_helpers import TASK_TRAIN_MODEL_CLASSES
 from lightly_train._methods import method_helpers
+from lightly_train._task_models.dinov2_linear_semantic_segmentation.train_model import (
+    DINOv2LinearSemanticSegmentationTrain,
+)
 
 THIS_DIR = Path(__file__).parent.resolve()
 DOCS_DIR = THIS_DIR / "source"
 PROJECT_ROOT = THIS_DIR.parent
+SOURCE_AUTO_DIR = DOCS_DIR / "_auto"
 METHODS_AUTO_ARGS_DIR = DOCS_DIR / "methods" / "_auto"
 
 
@@ -81,6 +86,23 @@ def dump_transform_args_for_methods(dest_dir: Path) -> None:
             f.write("```\n")
 
 
+def dump_transform_args_for_tasks(dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for train_model_cls in TASK_TRAIN_MODEL_CLASSES:
+        if train_model_cls in {DINOv2LinearSemanticSegmentationTrain}:
+            continue
+        train_transform_args = train_model_cls.train_transform_cls.transform_args_cls(
+            ignore_index=-100
+        )
+        args = train_task_helpers.pretty_format_args(train_transform_args.model_dump())
+        name = train_model_cls.__name__.lower()
+        # write to file
+        with open(dest_dir / f"{name}_train_transform_args.md", "w") as f:
+            f.write("```json\n")
+            f.write(args + "\n")
+            f.write("```\n")
+
+
 def dump_method_args(dest_dir: Path) -> None:
     dest_dir.mkdir(parents=True, exist_ok=True)
     # dump transform args for all methods
@@ -98,8 +120,11 @@ def dump_method_args(dest_dir: Path) -> None:
 
 def main(source_dir: Path) -> None:
     build_changelog_html(source_dir=source_dir)
+    # Methods
     dump_transform_args_for_methods(dest_dir=METHODS_AUTO_ARGS_DIR)
     dump_method_args(dest_dir=METHODS_AUTO_ARGS_DIR)
+    # Tasks
+    dump_transform_args_for_tasks(dest_dir=SOURCE_AUTO_DIR)
 
 
 if __name__ == "__main__":

--- a/docs/source/_auto/dinov2eomtsemanticsegmentationtrain_train_transform_args.md
+++ b/docs/source/_auto/dinov2eomtsemanticsegmentationtrain_train_transform_args.md
@@ -1,0 +1,48 @@
+```json
+{
+    "color_jitter": {
+        "brightness": 0.12549019607843137,
+        "contrast": 0.5,
+        "hue": 0.05,
+        "prob": 0.5,
+        "saturation": 0.5,
+        "strength": 1.0
+    },
+    "ignore_index": -100,
+    "image_size": [
+        518,
+        518
+    ],
+    "normalize": {
+        "mean": [
+            0.485,
+            0.456,
+            0.406
+        ],
+        "std": [
+            0.229,
+            0.224,
+            0.225
+        ]
+    },
+    "random_crop": {
+        "fill": 0,
+        "height": "auto",
+        "pad_if_needed": true,
+        "pad_position": "center",
+        "prob": 1.0,
+        "width": "auto"
+    },
+    "random_flip": {
+        "horizontal_prob": 0.5,
+        "vertical_prob": 0.0
+    },
+    "scale_jitter": {
+        "max_scale": 2.0,
+        "min_scale": 0.5,
+        "num_scales": 20,
+        "prob": 1.0
+    },
+    "smallest_max_size": null
+}
+```

--- a/docs/source/_auto/dinov3eomtsemanticsegmentationtrain_train_transform_args.md
+++ b/docs/source/_auto/dinov3eomtsemanticsegmentationtrain_train_transform_args.md
@@ -1,0 +1,48 @@
+```json
+{
+    "color_jitter": {
+        "brightness": 0.12549019607843137,
+        "contrast": 0.5,
+        "hue": 0.05,
+        "prob": 0.5,
+        "saturation": 0.5,
+        "strength": 1.0
+    },
+    "ignore_index": -100,
+    "image_size": [
+        518,
+        518
+    ],
+    "normalize": {
+        "mean": [
+            0.485,
+            0.456,
+            0.406
+        ],
+        "std": [
+            0.229,
+            0.224,
+            0.225
+        ]
+    },
+    "random_crop": {
+        "fill": 0,
+        "height": "auto",
+        "pad_if_needed": true,
+        "pad_position": "center",
+        "prob": 1.0,
+        "width": "auto"
+    },
+    "random_flip": {
+        "horizontal_prob": 0.5,
+        "vertical_prob": 0.0
+    },
+    "scale_jitter": {
+        "max_scale": 2.0,
+        "min_scale": 0.5,
+        "num_scales": 20,
+        "prob": 1.0
+    },
+    "smallest_max_size": null
+}
+```

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -367,3 +367,59 @@ if __name__ == "__main__":
     )
 ```
 ````
+
+(semantic-segmentation-transform-arguments)=
+
+## Default Image Transform Arguments
+
+The following are the default train transform arguments for EoMT. The validation
+arguments are automatically inferred from the train arguments. Specifically the
+image size and normalization are shared between train and validation.
+
+You can configure the image size and normalization like this:
+
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.train_semantic_segmentation(
+        out="out/my_experiment",
+        model="dinov2/vitl14-eomt",
+        data={
+            "train": {
+                "images": "my_data_dir/train/images",   # Path to training images
+                "masks": "my_data_dir/train/masks",     # Path to training masks
+            },
+            "val": {
+                "images": "my_data_dir/val/images",     # Path to validation images
+                "masks": "my_data_dir/val/masks",       # Path to validation masks
+            },
+            "classes": {                                # Classes in the dataset                    
+                0: "background",
+                1: "car",
+                2: "bicycle",
+                # ...
+            },
+            # Optional, classes that are in the dataset but should be ignored during
+            # training.
+            "ignore_classes": [0], 
+        },
+        transform_args={
+            "image_size": (518, 518), # (height, width)
+            "normalize": {
+                "mean": [0.485, 0.456, 0.406],
+                "std": [0.229, 0.224, 0.225],
+            },
+        },
+    )
+```
+
+````{dropdown} EoMT DINOv2 Default Train Transform Arguments
+```{include} _auto/dinov2eomtsemanticsegmentationtrain_train_transform_args.md
+```
+````
+
+````{dropdown} EoMT DINOv3 Default Train Transform Arguments
+```{include} _auto/dinov3eomtsemanticsegmentationtrain_train_transform_args.md
+```
+````

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -55,6 +55,7 @@ def train_semantic_segmentation(
     seed: int | None = 0,
     logger_args: dict[str, Any] | None = None,
     model_args: dict[str, Any] | None = None,
+    transform_args: dict[str, Any] | None = None,
     loader_args: dict[str, Any] | None = None,
     save_checkpoint_args: dict[str, Any] | None = None,
 ) -> None:
@@ -129,6 +130,10 @@ def train_semantic_segmentation(
             for more information.
         model_args:
             Model training arguments. Either None or a dictionary of model arguments.
+        transform_args:
+            Transform arguments. Either None or a dictionary of transform arguments.
+            The image size and normalization parameters can be set with
+            ``transform_args={"image_size": (height, width), "normalize": {"mean": (r, g, b), "std": (r, g, b)}}``
         loader_args:
             Arguments for the PyTorch DataLoader. Should only be used in special cases
             as default values are automatically set. Prefer to use the `batch_size` and
@@ -161,6 +166,7 @@ def _train_task(
     seed: int | None = 0,
     logger_args: dict[str, Any] | None = None,
     model_args: dict[str, Any] | None = None,
+    transform_args: dict[str, Any] | None = None,
     loader_args: dict[str, Any] | None = None,
     save_checkpoint_args: dict[str, Any] | None = None,
 ) -> None:
@@ -223,9 +229,11 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
     train_model_cls = helpers.get_train_model_cls(
         model_name=config.model,
     )
-    # TODO(Guarin, 07/25): Allow passing transform args.
+
     train_transform_args, val_transform_args = helpers.get_transform_args(
-        train_model_cls=train_model_cls, ignore_index=config.data.ignore_index
+        train_model_cls=train_model_cls,
+        transform_args=config.transform_args,
+        ignore_index=config.data.ignore_index,
     )
     train_transform = helpers.get_train_transform(
         train_model_cls=train_model_cls, train_transform_args=train_transform_args
@@ -462,6 +470,7 @@ class TrainTaskConfig(PydanticConfig):
     seed: int | None = 0
     logger_args: dict[str, Any] | TaskLoggerArgs | None = None
     model_args: dict[str, Any] | TrainModelArgs | None = None
+    transform_args: dict[str, Any] | None = None
     loader_args: dict[str, Any] | None = None
     save_checkpoint_args: dict[str, Any] | TaskSaveCheckpointArgs | None = None
 

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -50,7 +50,10 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._train_task_state import TrainTaskState
-from lightly_train._transforms.task_transform import TaskTransform, TaskTransformArgs
+from lightly_train._transforms.task_transform import (
+    TaskTransform,
+    TaskTransformArgs,
+)
 from lightly_train.types import (
     MaskSemanticSegmentationBatch,
     MaskSemanticSegmentationDatasetItem,
@@ -192,25 +195,42 @@ def pretty_format_args_dict(args: dict[str, Any]) -> dict[str, Any]:
 
 def get_transform_args(
     train_model_cls: type[TrainModel],
+    transform_args: dict[str, Any] | None,
     ignore_index: int | None,
 ) -> tuple[TaskTransformArgs, TaskTransformArgs]:
     if train_model_cls.task != "semantic_segmentation" and ignore_index is not None:
         raise ValueError(
             "`ignore_index` is only supported for semantic segmentation tasks."
         )
+    transform_args = {} if transform_args is None else transform_args
+    if ignore_index is not None:
+        transform_args["ignore_index"] = ignore_index
 
     train_transform_args_cls = train_model_cls.train_transform_cls.transform_args_cls
     val_transform_args_cls = train_model_cls.val_transform_cls.transform_args_cls
+    train_transform_args: TaskTransformArgs
+    val_transform_args: TaskTransformArgs
 
-    if ignore_index is None:
-        return (
-            train_transform_args_cls(),
-            val_transform_args_cls(),
-        )
-
-    return train_transform_args_cls(ignore_index=ignore_index), val_transform_args_cls(  # type: ignore[call-arg]
-        ignore_index=ignore_index
+    train_transform_args = validate.pydantic_model_validate(
+        train_transform_args_cls, transform_args
     )
+    train_transform_args.resolve_auto()
+
+    val_transform_args = validate.pydantic_model_validate(
+        val_transform_args_cls,
+        train_transform_args.model_dump(
+            include={"image_size": True, "normalize": True, "ignore_index": True}
+        ),
+    )
+    val_transform_args.resolve_auto()
+
+    logger.debug(
+        f"Resolved train transform args {pretty_format_args(train_transform_args.model_dump())}"
+    )
+    logger.debug(
+        f"Resolved val transform args {pretty_format_args(val_transform_args.model_dump())}"
+    )
+    return train_transform_args, val_transform_args
 
 
 def get_train_transform(

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/transforms.py
@@ -7,6 +7,8 @@
 #
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 
 from lightly_train._transforms.semantic_segmentation_transform import (
@@ -14,9 +16,7 @@ from lightly_train._transforms.semantic_segmentation_transform import (
     SemanticSegmentationTransformArgs,
 )
 from lightly_train._transforms.transform import (
-    CenterCropArgs,
     ColorJitterArgs,
-    LongestMaxSizeArgs,
     NormalizeArgs,
     RandomCropArgs,
     RandomFlipArgs,
@@ -46,30 +46,16 @@ class DINOv2EoMTSemanticSegmentationScaleJitterArgs(ScaleJitterArgs):
 
 
 class DINOv2EoMTSemanticSegmentationSmallestMaxSizeArgs(SmallestMaxSizeArgs):
-    max_size: list[int] = [518]
+    max_size: int | list[int] | Literal["auto"] = "auto"
     prob: float = 1.0
 
 
 class DINOv2EoMTSemanticSegmentationRandomCropArgs(RandomCropArgs):
-    height: int = 518
-    width: int = 518
+    height: int | Literal["auto"] = "auto"
+    width: int | Literal["auto"] = "auto"
     pad_if_needed: bool = True
     pad_position: str = "center"
     fill: int = 0
-    prob: float = 1.0
-
-
-class DINOv2EoMTSemanticSegmentationCenterCropArgs(CenterCropArgs):
-    height: int = 518
-    width: int = 518
-    pad_if_needed: bool = True
-    pad_position: str = "center"
-    fill: int = 0
-    prob: float = 1.0
-
-
-class DINOv2EoMTSemanticSegmentationLongestMaxSizeArgs(LongestMaxSizeArgs):
-    max_size: int = 518
     prob: float = 1.0
 
 
@@ -93,8 +79,6 @@ class DINOv2EoMTSemanticSegmentationTrainTransformArgs(
     random_crop: RandomCropArgs = Field(
         default_factory=DINOv2EoMTSemanticSegmentationRandomCropArgs
     )
-    longest_max_size: LongestMaxSizeArgs | None = None
-    center_crop: CenterCropArgs | None = None
 
 
 class DINOv2EoMTSemanticSegmentationValTransformArgs(SemanticSegmentationTransformArgs):
@@ -111,23 +95,11 @@ class DINOv2EoMTSemanticSegmentationValTransformArgs(SemanticSegmentationTransfo
         default_factory=DINOv2EoMTSemanticSegmentationSmallestMaxSizeArgs
     )
     random_crop: RandomCropArgs | None = None
-    longest_max_size: LongestMaxSizeArgs | None = None
-    center_crop: CenterCropArgs | None = None
 
 
 class DINOv2EoMTSemanticSegmentationTrainTransform(SemanticSegmentationTransform):
     transform_args_cls = DINOv2EoMTSemanticSegmentationTrainTransformArgs
 
-    def __init__(
-        self, transform_args: DINOv2EoMTSemanticSegmentationTrainTransformArgs
-    ) -> None:
-        super().__init__(transform_args=transform_args)
-
 
 class DINOv2EoMTSemanticSegmentationValTransform(SemanticSegmentationTransform):
     transform_args_cls = DINOv2EoMTSemanticSegmentationValTransformArgs
-
-    def __init__(
-        self, transform_args: DINOv2EoMTSemanticSegmentationValTransformArgs
-    ) -> None:
-        super().__init__(transform_args=transform_args)

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/transforms.py
@@ -7,6 +7,8 @@
 #
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 
 from lightly_train._transforms.semantic_segmentation_transform import (
@@ -14,9 +16,7 @@ from lightly_train._transforms.semantic_segmentation_transform import (
     SemanticSegmentationTransformArgs,
 )
 from lightly_train._transforms.transform import (
-    CenterCropArgs,
     ColorJitterArgs,
-    LongestMaxSizeArgs,
     NormalizeArgs,
     RandomCropArgs,
     RandomFlipArgs,
@@ -51,25 +51,11 @@ class DINOv2LinearSemanticSegmentationSmallestMaxSizeArgs(SmallestMaxSizeArgs):
 
 
 class DINOv2LinearSemanticSegmentationRandomCropArgs(RandomCropArgs):
-    height: int = 518
-    width: int = 518
+    height: int | Literal["auto"] = "auto"
+    width: int | Literal["auto"] = "auto"
     pad_if_needed: bool = True
     pad_position: str = "center"
     fill: int = 0
-    prob: float = 1.0
-
-
-class DINOv2LinearSemanticSegmentationCenterCropArgs(CenterCropArgs):
-    height: int = 518
-    width: int = 518
-    pad_if_needed: bool = True
-    pad_position: str = "center"
-    fill: int = 0
-    prob: float = 1.0
-
-
-class DINOv2LinearSemanticSegmentationLongestMaxSizeArgs(LongestMaxSizeArgs):
-    max_size: int = 518
     prob: float = 1.0
 
 
@@ -93,8 +79,6 @@ class DINOv2LinearSemanticSegmentationTrainTransformArgs(
     random_crop: RandomCropArgs = Field(
         default_factory=DINOv2LinearSemanticSegmentationRandomCropArgs
     )
-    longest_max_size: LongestMaxSizeArgs | None = None
-    center_crop: CenterCropArgs | None = None
 
 
 class DINOv2LinearSemanticSegmentationValTransformArgs(
@@ -113,23 +97,11 @@ class DINOv2LinearSemanticSegmentationValTransformArgs(
         default_factory=DINOv2LinearSemanticSegmentationSmallestMaxSizeArgs
     )
     random_crop: RandomCropArgs | None = None
-    longest_max_size: LongestMaxSizeArgs | None = None
-    center_crop: CenterCropArgs | None = None
 
 
 class DINOv2LinearSemanticSegmentationTrainTransform(SemanticSegmentationTransform):
     transform_args_cls = DINOv2LinearSemanticSegmentationTrainTransformArgs
 
-    def __init__(
-        self, transform_args: DINOv2LinearSemanticSegmentationTrainTransformArgs
-    ) -> None:
-        super().__init__(transform_args=transform_args)
-
 
 class DINOv2LinearSemanticSegmentationValTransform(SemanticSegmentationTransform):
     transform_args_cls = DINOv2LinearSemanticSegmentationValTransformArgs
-
-    def __init__(
-        self, transform_args: DINOv2LinearSemanticSegmentationValTransformArgs
-    ) -> None:
-        super().__init__(transform_args=transform_args)

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/transforms.py
@@ -7,6 +7,8 @@
 #
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 
 from lightly_train._transforms.semantic_segmentation_transform import (
@@ -14,9 +16,7 @@ from lightly_train._transforms.semantic_segmentation_transform import (
     SemanticSegmentationTransformArgs,
 )
 from lightly_train._transforms.transform import (
-    CenterCropArgs,
     ColorJitterArgs,
-    LongestMaxSizeArgs,
     NormalizeArgs,
     RandomCropArgs,
     RandomFlipArgs,
@@ -46,30 +46,16 @@ class DINOv3EoMTSemanticSegmentationScaleJitterArgs(ScaleJitterArgs):
 
 
 class DINOv3EoMTSemanticSegmentationSmallestMaxSizeArgs(SmallestMaxSizeArgs):
-    max_size: list[int] = [518]
+    max_size: int | list[int] | Literal["auto"] = "auto"
     prob: float = 1.0
 
 
 class DINOv3EoMTSemanticSegmentationRandomCropArgs(RandomCropArgs):
-    height: int = 518
-    width: int = 518
+    height: int | Literal["auto"] = "auto"
+    width: int | Literal["auto"] = "auto"
     pad_if_needed: bool = True
     pad_position: str = "center"
     fill: int = 0
-    prob: float = 1.0
-
-
-class DINOv3EoMTSemanticSegmentationCenterCropArgs(CenterCropArgs):
-    height: int = 518
-    width: int = 518
-    pad_if_needed: bool = True
-    pad_position: str = "center"
-    fill: int = 0
-    prob: float = 1.0
-
-
-class DINOv3EoMTSemanticSegmentationLongestMaxSizeArgs(LongestMaxSizeArgs):
-    max_size: int = 518
     prob: float = 1.0
 
 
@@ -94,8 +80,6 @@ class DINOv3EoMTSemanticSegmentationTrainTransformArgs(
     random_crop: RandomCropArgs = Field(
         default_factory=DINOv3EoMTSemanticSegmentationRandomCropArgs
     )
-    longest_max_size: LongestMaxSizeArgs | None = None
-    center_crop: CenterCropArgs | None = None
 
 
 class DINOv3EoMTSemanticSegmentationValTransformArgs(SemanticSegmentationTransformArgs):
@@ -112,23 +96,11 @@ class DINOv3EoMTSemanticSegmentationValTransformArgs(SemanticSegmentationTransfo
         default_factory=DINOv3EoMTSemanticSegmentationSmallestMaxSizeArgs
     )
     random_crop: RandomCropArgs | None = None
-    longest_max_size: LongestMaxSizeArgs | None = None
-    center_crop: CenterCropArgs | None = None
 
 
 class DINOv3EoMTSemanticSegmentationTrainTransform(SemanticSegmentationTransform):
     transform_args_cls = DINOv3EoMTSemanticSegmentationTrainTransformArgs
 
-    def __init__(
-        self, transform_args: DINOv3EoMTSemanticSegmentationTrainTransformArgs
-    ) -> None:
-        super().__init__(transform_args=transform_args)
-
 
 class DINOv3EoMTSemanticSegmentationValTransform(SemanticSegmentationTransform):
     transform_args_cls = DINOv3EoMTSemanticSegmentationValTransformArgs
-
-    def __init__(
-        self, transform_args: DINOv3EoMTSemanticSegmentationValTransformArgs
-    ) -> None:
-        super().__init__(transform_args=transform_args)

--- a/src/lightly_train/_transforms/semantic_segmentation_transform.py
+++ b/src/lightly_train/_transforms/semantic_segmentation_transform.py
@@ -11,11 +11,9 @@ from __future__ import annotations
 import numpy as np
 from albumentations import (
     BasicTransform,
-    CenterCrop,
     ColorJitter,
     Compose,
     HorizontalFlip,
-    LongestMaxSize,
     Normalize,
     OneOf,
     RandomCrop,
@@ -24,6 +22,7 @@ from albumentations import (
 )
 from albumentations.pytorch import ToTensorV2
 
+from lightly_train._configs.validate import no_auto
 from lightly_train._transforms.task_transform import (
     TaskTransform,
     TaskTransformArgs,
@@ -31,9 +30,7 @@ from lightly_train._transforms.task_transform import (
     TaskTransformOutput,
 )
 from lightly_train._transforms.transform import (
-    CenterCropArgs,
     ColorJitterArgs,
-    LongestMaxSizeArgs,
     NormalizeArgs,
     RandomCropArgs,
     RandomFlipArgs,
@@ -50,9 +47,14 @@ class SemanticSegmentationTransformArgs(TaskTransformArgs):
     color_jitter: ColorJitterArgs | None
     scale_jitter: ScaleJitterArgs | None
     smallest_max_size: SmallestMaxSizeArgs | None
-    longest_max_size: LongestMaxSizeArgs | None
-    center_crop: CenterCropArgs | None
     random_crop: RandomCropArgs | None
+
+    def resolve_auto(self) -> None:
+        height, width = self.image_size
+        for field_name in self.__class__.model_fields:
+            field = getattr(self, field_name)
+            if hasattr(field, "resolve_auto"):
+                field.resolve_auto(height=height, width=width)
 
 
 class SemanticSegmentationTransform(TaskTransform):
@@ -92,7 +94,7 @@ class SemanticSegmentationTransform(TaskTransform):
             # The aspect ratio is preserved.
             transform += [
                 SmallestMaxSize(
-                    max_size=transform_args.smallest_max_size.max_size,
+                    max_size=no_auto(transform_args.smallest_max_size.max_size),
                     p=transform_args.smallest_max_size.prob,
                 )
             ]
@@ -100,45 +102,13 @@ class SemanticSegmentationTransform(TaskTransform):
         if transform_args.random_crop is not None:
             transform += [
                 RandomCrop(
-                    height=transform_args.random_crop.height,
-                    width=transform_args.random_crop.width,
+                    height=no_auto(transform_args.random_crop.height),
+                    width=no_auto(transform_args.random_crop.width),
                     pad_if_needed=transform_args.random_crop.pad_if_needed,
                     pad_position=transform_args.random_crop.pad_position,
                     fill=transform_args.random_crop.fill,
                     fill_mask=transform_args.ignore_index,
                     p=transform_args.random_crop.prob,
-                )
-            ]
-
-        # During evaluation we force the image to be of a fixed size
-        # using padding if needed. The aspect ratio is preserved and no
-        # information is lost if crop size is the same as max_size.
-        if transform_args.longest_max_size is not None:
-            # Resize the image such that the longest side is of a fixed size.
-            transform += [
-                LongestMaxSize(
-                    max_size=transform_args.longest_max_size.max_size,
-                    p=transform_args.longest_max_size.prob,
-                )
-            ]
-
-            # Center crop the image to a fixed size.
-            # No information is lost if crop size is the same as max_size.
-            if transform_args.center_crop is None:
-                raise ValueError(
-                    "center_crop must be provided if longest_max_size is set."
-                )
-
-        if transform_args.center_crop is not None:
-            transform += [
-                CenterCrop(
-                    height=transform_args.center_crop.height,
-                    width=transform_args.center_crop.width,
-                    pad_if_needed=transform_args.center_crop.pad_if_needed,
-                    pad_position=transform_args.center_crop.pad_position,
-                    fill=transform_args.center_crop.fill,
-                    fill_mask=transform_args.ignore_index,
-                    p=transform_args.center_crop.prob,
                 )
             ]
 

--- a/src/lightly_train/_transforms/task_transform.py
+++ b/src/lightly_train/_transforms/task_transform.py
@@ -20,13 +20,19 @@ TaskTransformOutput = Dict[str, Tensor]
 
 
 class TaskTransformArgs(PydanticConfig):
-    pass
+    def resolve_auto(self) -> None:
+        pass
 
 
 class TaskTransform:
     transform_args_cls: type[TaskTransformArgs]
 
     def __init__(self, transform_args: TaskTransformArgs):
+        if not isinstance(transform_args, self.transform_args_cls):
+            raise TypeError(
+                f"transform_args must be of type {self.transform_args_cls.__name__}, "
+                f"got {type(transform_args).__name__} instead."
+            )
         self.transform_args = transform_args
 
     def __call__(self, input: TaskTransformInput) -> TaskTransformOutput:

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import (
+    Literal,
     Type,
     TypeVar,
 )
@@ -130,31 +131,28 @@ class ScaleJitterArgs(PydanticConfig):
 
 
 class SmallestMaxSizeArgs(PydanticConfig):
-    max_size: int | list[int]  # Maximum size of the smallest side of the image.
+    # Maximum size of the smallest side of the image.
+    max_size: int | list[int] | Literal["auto"]
     prob: float
 
-
-class LongestMaxSizeArgs(PydanticConfig):
-    max_size: int | list[int]  # Maximum size of the longest side of the image.
-    prob: float
+    def resolve_auto(self, height: int, width: int) -> None:
+        if self.max_size == "auto":
+            self.max_size = min(height, width)
 
 
 class RandomCropArgs(PydanticConfig):
-    height: int
-    width: int
+    height: int | Literal["auto"]
+    width: int | Literal["auto"]
     pad_position: str
-    pad_if_needed: bool = False  # Pad if crop size exceeds image size.
+    pad_if_needed: bool  # Pad if crop size exceeds image size.
     fill: tuple[float, ...] | float  # Padding value for images.
-    prob: float = 1.0  # Probability to apply RandomCrop.
+    prob: float  # Probability to apply RandomCrop.
 
-
-class CenterCropArgs(PydanticConfig):
-    height: int
-    width: int
-    pad_position: str
-    pad_if_needed: bool = False  # Pad if crop size exceeds image size.
-    fill: tuple[float, ...] | float  # Padding value for images.
-    prob: float = 1.0  # Probability to apply RandomCrop.
+    def resolve_auto(self, height: int, width: int) -> None:
+        if self.height == "auto":
+            self.height = height
+        if self.width == "auto":
+            self.width = width
 
 
 class MethodTransformArgs(PydanticConfig):


### PR DESCRIPTION
## What has changed and why?

* Add fine-tune transform arg customization
* Cleanup transform code
* Remove unused transforms
* Add documentation

## How has it been tested?

Train log from a run:
```
[2025-08-22 13:38:38,965][DEBUG] Resolved train transform args {
    "color_jitter": {
        "brightness": 0.12549019607843137,
        "contrast": 0.5,
        "hue": 0.05,
        "prob": 0.5,
        "saturation": 0.5,
        "strength": 1.0
    },
    "ignore_index": -100,
    "image_size": [
        512,
        512
    ],
    "normalize": {
        "mean": [
            0.0,
            0.0,
            0.0
        ],
        "std": [
            1.0,
            1.0,
            1.0
        ]
    },
    "random_crop": {
        "fill": 0,
        "height": 512,
        "pad_if_needed": true,
        "pad_position": "center",
        "prob": 1.0,
        "width": 512
    },
    "random_flip": {
        "horizontal_prob": 0.5,
        "vertical_prob": 0.0
    },
    "scale_jitter": {
        "max_scale": 2.0,
        "min_scale": 0.5,
        "num_scales": 20,
        "prob": 1.0
    },
    "smallest_max_size": null
}
[2025-08-22 13:38:38,965][DEBUG] Resolved val transform args {
    "color_jitter": null,
    "ignore_index": -100,
    "image_size": [
        512,
        512
    ],
    "normalize": {
        "mean": [
            0.0,
            0.0,
            0.0
        ],
        "std": [
            1.0,
            1.0,
            1.0
        ]
    },
    "random_crop": null,
    "random_flip": null,
    "scale_jitter": null,
    "smallest_max_size": {
        "max_size": 512,
        "prob": 1.0
    }
}
```

Docs:

[Semantic Segmentation - LightlyTrain documentation transform args.pdf](https://github.com/user-attachments/files/21938627/Semantic.Segmentation.-.LightlyTrain.documentation.transform.args.pdf)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
