### PR TITLE
Add verify option to validate exported onnx model

### DIFF
--- a/src/lightly_train/_commands/export_task.py
+++ b/src/lightly_train/_commands/export_task.py
@@ -167,7 +167,7 @@ def _export_task_from_config(config: ExportTaskConfig) -> None:
 
             x = torch.rand_like(dummy_input)
             session = ort.InferenceSession(out_path)
-            input_feed = {input_name: x.numpy()}
+            input_feed = {input_name: x.cpu().numpy()}
             outputs_onnx = session.run(output_names=output_names, input_feed=input_feed)
             outputs_onnx = tuple(torch.from_numpy(y) for y in outputs_onnx)
 


### PR DESCRIPTION
## What has changed and why?

Added a verify option to the onnx export task to validate the exported model. This option does two things:
- Use onnx.checker.check_model to verify the exported models.
- Run a random tensor trough both the exported model and the torch model. 

The second part could probably be made arbitrary complicated - but for not I just test with random data and use `torch.testing.assert_close` as that function seems to be able to also handle `NaN`, `+Inf` and `-Inf`.

## How has it been tested?

As the verify option is enabled by default it is covered by the tests anyway.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [] Is this change big enough that we want in CHANGELOG.md?



