### PR TITLE
Add semantic segmentation class mapping support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `data` argument in the `train_semantic_segmentation` command now supports mapping multiple classes into one class in the `classes` entry.
 - Add support for DINOv2 linear semantic segmentation models. You can train them with
   `model="dinov2/vits14-linear"` in the `train_semantic_segmentation` command. Those
   models are trained with a linear head on top of a frozen backbone and are useful

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -177,7 +177,7 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, set):
             return sorted(obj)
         try:
-            return self.default(obj)
+            return super().default(obj)
         except TypeError:
             # Return class name for objects that cannot be serialized
             return obj.__class__.__name__

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -175,7 +175,7 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
         if isinstance(obj, set):
-            return sorted([super().default(o) for o in obj])
+            return sorted([self.default(o) for o in obj])
         try:
             return super().default(obj)
         except TypeError:

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -175,7 +175,15 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
         if isinstance(obj, set):
-            return sorted([self.default(o) for o in obj])
+            result = []
+            for o in obj:
+                # Check if the object is already JSON-serializable
+                try:
+                    json.dumps(o)  # Test if it's directly serializable
+                    result.append(o)  # Use the object directly
+                except (TypeError, ValueError):
+                    result.append(self.default(o))  # Apply custom formatting
+            return sorted(result)
         try:
             return super().default(obj)
         except TypeError:

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -179,7 +179,9 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
             for o in obj:
                 # Check if the object is already JSON-serializable
                 try:
-                    json.dumps(o, cls=self.__class__)  # Test with the same encoder class
+                    json.dumps(
+                        o, cls=self.__class__
+                    )  # Test with the same encoder class
                     result.append(o)  # Use the object directly
                 except (TypeError, ValueError):
                     result.append(self.default(o))  # Apply custom formatting

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -179,7 +179,7 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
             for o in obj:
                 # Check if the object is already JSON-serializable
                 try:
-                    json.dumps(o)  # Test if it's directly serializable
+                    json.dumps(o, cls=self.__class__)  # Test with the same encoder class
                     result.append(o)  # Use the object directly
                 except (TypeError, ValueError):
                     result.append(self.default(o))  # Apply custom formatting

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -175,17 +175,7 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
         if isinstance(obj, set):
-            result = []
-            for o in obj:
-                # Check if the object is already JSON-serializable
-                try:
-                    json.dumps(
-                        o, cls=self.__class__
-                    )  # Test with the same encoder class
-                    result.append(o)  # Use the object directly
-                except (TypeError, ValueError):
-                    result.append(self.default(o))  # Apply custom formatting
-            return sorted(result)
+            return sorted(list(obj))
         try:
             return super().default(obj)
         except TypeError:

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -175,7 +175,7 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
         if isinstance(obj, set):
-            return sorted(obj)
+            return sorted(list(obj))
         try:
             return super().default(obj)
         except TypeError:

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -174,6 +174,8 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
     def default(self, obj: Any) -> Any:
         if isinstance(obj, Path):
             return str(obj)
+        if isinstance(obj, set):
+            return sorted(list(obj))
         try:
             return super().default(obj)
         except TypeError:

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -175,9 +175,9 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
         if isinstance(obj, set):
-            return sorted(list(obj))
+            return sorted(obj)
         try:
-            return super().default(obj)
+            return self.default(obj)
         except TypeError:
             # Return class name for objects that cannot be serialized
             return obj.__class__.__name__

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -175,7 +175,7 @@ class PrettyFormatArgsJSONEncoder(JSONEncoder):
         if isinstance(obj, Path):
             return str(obj)
         if isinstance(obj, set):
-            return sorted(list(obj))
+            return sorted([super().default(o) for o in obj])
         try:
             return super().default(obj)
         except TypeError:

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -14,7 +14,7 @@ from typing import ClassVar, Dict, Literal, Union
 import numpy as np
 import torch
 from numpy.typing import NDArray
-from pydantic import Field, TypeAdapter, field_serializer, field_validator
+from pydantic import Field, TypeAdapter, field_validator
 from torch import Tensor
 from torch.utils.data import Dataset
 
@@ -34,10 +34,6 @@ from lightly_train.types import (
 class ClassInfo(PydanticConfig):
     name: str
     values: set[int] = Field(strict=False)
-
-    @field_serializer("values")
-    def serialize_values(self, values: set[int]) -> list[int]:
-        return sorted(values)
 
 
 class MaskSemanticSegmentationDataset(Dataset[MaskSemanticSegmentationDatasetItem]):
@@ -210,10 +206,6 @@ class MaskSemanticSegmentationDatasetArgs(PydanticConfig):
     check_empty_targets: bool = True
     ignore_index: int
 
-    @field_serializer("ignore_classes")
-    def serialize_ignore_classes(self, values: set[int] | None) -> list[int] | None:
-        return sorted(values) if values is not None else None
-
     # NOTE(Guarin, 07/25): The interface with below methods is experimental. Not yet
     # sure if it makes sense to have this in dataset args.
     def list_image_filenames(self) -> Iterable[ImageFilename]:
@@ -240,10 +232,6 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     classes: dict[int, ClassInfo]
     ignore_classes: set[int] | None = Field(default=None, strict=False)
     check_empty_targets: bool = True
-
-    @field_serializer("ignore_classes")
-    def serialize_ignore_classes(self, values: set[int] | None) -> list[int] | None:
-        return sorted(values) if values is not None else None
 
     @field_validator("classes", mode="before")
     @classmethod

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -239,9 +239,9 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         cls, classes: dict[int, str | dict[str, str | Sequence[int]]]
     ) -> dict[int, ClassInfo]:
         # Let Pydantic validate the structure and types
-        classes_validated = TypeAdapter(dict[int, Union[str, ClassInfo]]).validate_python(
-            classes
-        )
+        classes_validated = TypeAdapter(
+            Dict[int, Union[str, ClassInfo]]
+        ).validate_python(classes)
 
         # Convert to ClassInfo objects
         class_infos: dict[int, ClassInfo] = {}

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import ClassVar, Dict, Literal, Union
 
 import numpy as np
 import torch
@@ -239,7 +239,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         cls, classes: dict[int, str | dict[str, str | Sequence[int]]]
     ) -> dict[int, ClassInfo]:
         # Let Pydantic validate the structure and types
-        classes_validated = TypeAdapter(dict[int, str | ClassInfo]).validate_python(
+        classes_validated = TypeAdapter(dict[int, Union[str, ClassInfo]]).validate_python(
             classes
         )
 

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -253,19 +253,9 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
 
         # Check the class mappings for validity.
         new_classes = set(class_infos.keys())
-        class_names: set[str] = set()
         class_values: set[int] = set()
 
         for class_id, class_info in class_infos.items():
-            # Check for duplicate class names
-            class_name = class_info.name
-            if class_name in class_names:
-                raise ValueError(
-                    f"Invalid class mapping: Class name '{class_name}' appears in multiple class definitions. "
-                    f"Each class name must be unique."
-                )
-            class_names.add(class_name)
-
             for value in class_info.values:
                 # Check for multiple values across different class mappings
                 if value in class_values:

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -158,7 +158,7 @@ class TestMaskSemanticSegmentationDataArgs:
         mask_dir = tmp_path / "masks"
 
         # Test that overlapping values in ClassInfo instances raise error
-        classes_with_multiple_mapping = {
+        classes_with_all_mappings = {
             0: {"name": "background", "values": [0, 1, 2]},
             5: {
                 "name": "vehicle",
@@ -173,28 +173,23 @@ class TestMaskSemanticSegmentationDataArgs:
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes=classes_with_multiple_mapping,  # type: ignore[arg-type]
+                classes=classes_with_all_mappings,  # type: ignore[arg-type]
             )
 
-    def test_validate_classes__mapping_to_existing_keys(self, tmp_path: Path) -> None:
-        """Test that new classes cannot appear as values to be mapped to a different class."""
-        image_dir = tmp_path / "images"
-        mask_dir = tmp_path / "masks"
-
-        # Test that class keys appearing in ClassInfo values raise error
-        classes_with_existing_keys = {
-            0: {"name": "background", "values": [1, 2, 3]},
-            10: {"name": "person", "values": [7, 8, 0]},  # Value 0 conflicts with key 0
+        # Test that overlapping values in ClassInfo instances raise error
+        classes_with_partial_mappings = {
+            0: {"name": "background", "values": [0, 1, 2]},
+            1: "vehicle",  # Implicitly maps to {1}, Value 1 is mapped to both background and vehicle
         }
 
         with pytest.raises(
             ValueError,
-            match="Class 0 exists as a new class label and also appears in the values to be mapped to a different class 10. ",
+            match="Invalid class mapping: Class 1 appears in multiple class definitions. ",
         ):
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes=classes_with_existing_keys,  # type: ignore[arg-type]
+                classes=classes_with_partial_mappings,  # type: ignore[arg-type]
             )
 
     def test_included_classes(self, tmp_path: Path) -> None:

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -197,55 +197,6 @@ class TestMaskSemanticSegmentationDataArgs:
                 classes=classes_with_existing_keys,  # type: ignore[arg-type]
             )
 
-    @pytest.mark.parametrize(
-        "classes_with_duplicate_names, duplicate_name",
-        [
-            # Test with dict input having duplicate names
-            (
-                {
-                    0: {"name": "background", "values": [0, 1]},
-                    5: {"name": "background", "values": [5, 6]},
-                },
-                "background",
-            ),
-            # Test with string input having duplicate names
-            (
-                {
-                    0: "vehicle",
-                    1: "vehicle",
-                },
-                "vehicle",
-            ),
-            # Test with mixed input having duplicate names
-            (
-                {
-                    0: "person",
-                    1: {"name": "person", "values": [1, 2]},
-                },
-                "person",
-            ),
-        ],
-    )
-    def test_validate_classes__duplicate_class_names(
-        self,
-        classes_with_duplicate_names: dict[int, str | dict[str, str | list[int]]],
-        duplicate_name: str,
-        tmp_path: Path,
-    ) -> None:
-        """Test that duplicate class names raise validation error."""
-        image_dir = tmp_path / "images"
-        mask_dir = tmp_path / "masks"
-
-        with pytest.raises(
-            ValueError,
-            match=f"Invalid class mapping: Class name '{duplicate_name}' appears in multiple class definitions",
-        ):
-            MaskSemanticSegmentationDataArgs(
-                train=SplitArgs(images=image_dir, masks=mask_dir),
-                val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes=classes_with_duplicate_names,  # type: ignore[arg-type]
-            )
-
     def test_included_classes(self, tmp_path: Path) -> None:
         image_dir = tmp_path / "images"
         mask_dir = tmp_path / "masks"

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -319,9 +319,10 @@ class TestMaskSemanticSegmentationDataset:
                 {
                     1: ClassInfo(name="vehicle", values={1, 2, 3}),
                     4: ClassInfo(name="ignore_me", values={4}),
+                    5: ClassInfo(name="person", values={5}),
                 },
                 {4},
-                {1: 0, 2: 0, 3: 0},
+                {1: 0, 2: 0, 3: 0, 5: 1},
             ),
             # Test ignoring a class that's in values list
             (
@@ -331,6 +332,16 @@ class TestMaskSemanticSegmentationDataset:
                 },
                 {4},
                 {1: 0, 2: 0, 3: 0, 5: 1},
+            ),
+            # Test ignoring multiple classes that are both in keys and values
+            (
+                {
+                    0: ClassInfo(name="background", values={0, 5}),
+                    1: ClassInfo(name="vehicle", values={1, 2, 3, 4}),
+                    7: ClassInfo(name="person", values={7}),
+                },
+                {0, 4, 6},  # ignore non-existing class should also work
+                {1: 0, 2: 0, 3: 0, 7: 1},
             ),
         ],
     )


### PR DESCRIPTION
## What has changed and why?

Allow mapping multiple classes to a single class for training when using `train_semantic_segmentation` command. More specifically, we now allow the following input format for `classes` in the `data` argument:

```python
classes={
  255: {"name": "background", "values": [0, 1, 2]},
  3: {"name": "class 3", "values": [3]},
}
```

Use the `"name"` to specify the name of the new label, and `"values"` to specify all the class labels to be mapped. 

Note that one can still pass a single string as the label name in the `classes` dict, i.e. the following works:

```python
classes: dict[int, ClassInfo] = {
  255: {"name": "background", "values": [0, 1, 2]},
  3: "class 3", 
}
```

Internally, all the inputs will be mapped as such:

```python
classes: dict[int, ClassInfo] = {
  255: {"name": "background", "values": [0, 1, 2]},
  3: {"name": "class 3", "values": [3]},
}
```

and then converted to a `class_mapping` with continuous natural numbers as the new labels, without the ignored labels.

Final note for ignore behavior:

- if you ignore a label that appear in keys, then all labels mapped to this label are ignored; 
- if you ignore a label that is to be mapped (which shouldn't appear in the keys, see case 2 below), only the label itself will be ignored.

Several cases:

1. Self-mapping is allowed. Note that we see the label `255` as a new label anyway.

```python
classes: dict[int, ClassInfo] = {
  255: {"name": "background", "values": [0, 1, 255]}, # this is allowed
  3: "class 3", 
}
```

2. The classes to be mapped are not allowed to appear in the class keys:

```python
classes: dict[int, ClassInfo] = {
  255: {"name": "background", "values": [0, 1, 2]},
  0: "class 0", # this is not allowed
}

classes: dict[int, ClassInfo] = {
  255: {"name": "background-255", "values": [0, 1, 2]},
  0: {"name": "background-0", "values": [3, 4 ,5]}, # this is not allowed
}
```

3. Multi-mapping is not allowed

```python
classes: dict[int, ClassInfo] = {
  255: {"name": "background-255", "values": [0, 1, 2]},
  254: {"name": "background-254", "values": [0, 1, 2]}, #this is not allowed
}
```

## How has it been tested?

Unit tests & Actual task runs on the compute machine.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (will be updated once everything for segmentation finishes)
