### PR TITLE
Raise ValueError during ONNX export if image size not divisible by patch size

### DIFF
--- a/tests/_commands/test_export_task.py
+++ b/tests/_commands/test_export_task.py
@@ -127,7 +127,6 @@ def test_onnx_export(
         torch.testing.assert_close(ort_y, expected_y, rtol=rtol, atol=atol)
 
 
-@pytest.mark.parametrize("batch_size,height,width", onnx_export_testset)
 @pytest.mark.skipif(
     sys.version_info < (3, 9),
     reason="Requires Python 3.9 or higher for image preprocessing.",
@@ -138,7 +137,7 @@ def test_onnx_export(
 )
 def test_onnx_export__height_not_patch_size_multiple_fails(
     dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
-):
+) -> None:
     # arrange
     model = lightly_train.load_model_from_checkpoint(
         dinov2_vits14_eomt_checkpoint, device="cpu"
@@ -165,7 +164,6 @@ def test_onnx_export__height_not_patch_size_multiple_fails(
         )
 
 
-@pytest.mark.parametrize("batch_size,height,width", onnx_export_testset)
 @pytest.mark.skipif(
     sys.version_info < (3, 9),
     reason="Requires Python 3.9 or higher for image preprocessing.",
@@ -176,7 +174,7 @@ def test_onnx_export__height_not_patch_size_multiple_fails(
 )
 def test_onnx_export__width_not_patch_size_multiple_fails(
     dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
-):
+) -> None:
     # arrange
     model = lightly_train.load_model_from_checkpoint(
         dinov2_vits14_eomt_checkpoint, device="cpu"

--- a/tests/_commands/test_export_task.py
+++ b/tests/_commands/test_export_task.py
@@ -127,7 +127,7 @@ def test_onnx_export(
         torch.testing.assert_close(ort_y, expected_y, rtol=rtol, atol=atol)
 
 
-def test_onnx_export_height_not_patch_size_multiple_fails(
+def test_onnx_export__height_not_patch_size_multiple_fails(
     dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
 ):
     # arrange
@@ -156,7 +156,7 @@ def test_onnx_export_height_not_patch_size_multiple_fails(
         )
 
 
-def test_onnx_export_width_not_patch_size_multiple_fails(
+def test_onnx_export__width_not_patch_size_multiple_fails(
     dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
 ):
     # arrange

--- a/tests/_commands/test_export_task.py
+++ b/tests/_commands/test_export_task.py
@@ -125,3 +125,61 @@ def test_onnx_export(
     assert len(ort_outputs) == len(expected_outputs)
     for ort_y, expected_y in zip(ort_outputs, expected_outputs):
         torch.testing.assert_close(ort_y, expected_y, rtol=rtol, atol=atol)
+
+
+def test_onnx_export_height_not_patch_size_multiple_fails(
+    dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
+):
+    # arrange
+    model = lightly_train.load_model_from_checkpoint(
+        dinov2_vits14_eomt_checkpoint, device="cpu"
+    )
+    onnx_path = tmp_path / "model.onnx"
+    patch_size = model.backbone.patch_size
+    height = patch_size - 1
+    width = patch_size
+
+    # act
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Height {height} and width {width} must be a multiple of patch size {patch_size}."
+        ),
+    ):
+        lightly_train.export_onnx(
+            out=onnx_path,
+            checkpoint=dinov2_vits14_eomt_checkpoint,
+            height=height,
+            width=width,
+            batch_size=1,
+            overwrite=True,
+        )
+
+
+def test_onnx_export_width_not_patch_size_multiple_fails(
+    dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
+):
+    # arrange
+    model = lightly_train.load_model_from_checkpoint(
+        dinov2_vits14_eomt_checkpoint, device="cpu"
+    )
+    onnx_path = tmp_path / "model.onnx"
+    patch_size = model.backbone.patch_size
+    height = patch_size
+    width = patch_size - 1
+
+    # act
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Height {height} and width {width} must be a multiple of patch size {patch_size}."
+        ),
+    ):
+        lightly_train.export_onnx(
+            out=onnx_path,
+            checkpoint=dinov2_vits14_eomt_checkpoint,
+            height=height,
+            width=width,
+            batch_size=1,
+            overwrite=True,
+        )

--- a/tests/_commands/test_export_task.py
+++ b/tests/_commands/test_export_task.py
@@ -127,6 +127,15 @@ def test_onnx_export(
         torch.testing.assert_close(ort_y, expected_y, rtol=rtol, atol=atol)
 
 
+@pytest.mark.parametrize("batch_size,height,width", onnx_export_testset)
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Requires Python 3.9 or higher for image preprocessing.",
+)
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
 def test_onnx_export__height_not_patch_size_multiple_fails(
     dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
 ):
@@ -156,6 +165,15 @@ def test_onnx_export__height_not_patch_size_multiple_fails(
         )
 
 
+@pytest.mark.parametrize("batch_size,height,width", onnx_export_testset)
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Requires Python 3.9 or higher for image preprocessing.",
+)
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
 def test_onnx_export__width_not_patch_size_multiple_fails(
     dinov2_vits14_eomt_checkpoint: Path, tmp_path: Path
 ):


### PR DESCRIPTION
## What has changed and why?

This PR makes it so that when we export an ONNX model and the iamge size is not divisible by the patch size, we raise a ValueError that explains what is going on. Previously the user would get a confusing RuntimeError.

## How has it been tested?

Case is covered by two new tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

We get an exception anyways if the image size is not correct, this just gives a gentler error message.

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)

No documentation yet
