### PR TITLE
Support custom mask names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Supported using custom mask names for the inputs in semantic segmentation.
+
 ### Deprecated
 
 ### Removed

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -360,7 +360,7 @@ def _decrement_and_cleanup_if_zero(mmap_file: Path, ref_file: Path) -> None:
 
 def get_dataset_mmap_filenames(
     fabric: Fabric,
-    filenames: Iterable[str],
+    filenames: Iterable[tuple[Path, Path]],
     mmap_filepath: Path,
 ) -> MemoryMappedSequence[str]:
     """Returns memory-mapped filenames shared across all ranks.
@@ -391,7 +391,7 @@ def get_dataset_mmap_filenames(
             not is_shared_filesystem and fabric.local_rank == 0
         ):
             memory_mapped_sequence.write_filenames_to_file(
-                filenames=filenames,
+                filenames=filenames,  # type: ignore[arg-type]
                 mmap_filepath=mmap_filepath,
             )
 
@@ -407,13 +407,13 @@ def get_dataset(
     transform: TaskTransform,
     mmap_filepath: Path,
 ) -> MaskSemanticSegmentationDataset:
-    filenames = list(dataset_args.list_image_filenames())
+    image_and_mask_filepaths = list(dataset_args.list_image_and_mask_filepaths())
     dataset_cls = dataset_args.get_dataset_cls()
     return dataset_cls(
         dataset_args=dataset_args,
-        image_filenames=get_dataset_mmap_filenames(
+        image_and_mask_filepaths=get_dataset_mmap_filenames(  # type: ignore[arg-type]
             fabric=fabric,
-            filenames=filenames,
+            filenames=image_and_mask_filepaths,
             mmap_filepath=mmap_filepath,
         ),
         transform=transform,

--- a/src/lightly_train/_data/_serialize/memory_mapped_sequence_task.py
+++ b/src/lightly_train/_data/_serialize/memory_mapped_sequence_task.py
@@ -161,10 +161,11 @@ def _stream_write_table_to_file(
         for item in items:
             for chunk, value in zip(chunks, item):
                 chunk.append(value)
-            if len(chunk) == chunk_size:
+            if len(chunks[0]) == chunk_size:
                 writer.write_table(pa.table(data=chunks, names=column_names))
-                chunk.clear()
-        if len(chunk) > 0:
+                for chunk in chunks:
+                    chunk.clear()
+        if len(chunks[0]) > 0:
             writer.write_table(pa.table(data=chunks, names=column_names))
 
 

--- a/src/lightly_train/_data/_serialize/memory_mapped_sequence_task.py
+++ b/src/lightly_train/_data/_serialize/memory_mapped_sequence_task.py
@@ -1,0 +1,173 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Generic, Iterable, Sequence, TypeVar, overload
+
+import pyarrow as pa  # type: ignore
+from pyarrow import Table, ipc
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def write_filenames_to_file(
+    filenames: Iterable[tuple[str, ...]],
+    mmap_filepath: Path,
+    column_names: list[str],
+    chunk_size: int = 10_000,
+) -> None:
+    """Writes the filenamess to a file for memory mapping."""
+    if chunk_size <= 0:
+        raise ValueError(f"Invalid `chunk_size` {chunk_size} must be positive!")
+    logger.debug(f"Writing filenames to '{mmap_filepath}' (chunk_size={chunk_size})")
+    _stream_write_table_to_file(
+        items=filenames,
+        mmap_filepath=mmap_filepath,
+        chunk_size=chunk_size,
+        column_names=column_names,
+    )
+
+
+def memory_mapped_sequence_from_file(
+    mmap_filepath: Path, column_names: list[str]
+) -> MemoryMappedSequenceTask[str]:
+    table = _mmap_table_from_file(mmap_filepath=mmap_filepath)
+    logger.debug(
+        f"Creating memory mapped sequence with {table.num_rows} '{column_names}'."
+    )
+    return MemoryMappedSequenceTask(path=mmap_filepath, columns=column_names)
+
+
+class MemoryMappedSequenceTask(Sequence[tuple[T, ...]], Generic[T]):
+    """A memory mapped sequence built around PyArrow's memory mapped tables.
+
+    A memory mapped sequence does not store its items in RAM but loads the data from disk.
+
+    Pickling: A memory mapped sequence can be pickled and loaded without copying the data in
+    memory. Instead, the path to the PyArrow file and the relevant column name is pickled. When
+    loading a pickled memory mapped sequence, the memory map is restored from the path.
+
+    Note: This implementation is inspired by https://github.com/huggingface/datasets. In the future
+    we can add it as a hard dependency or implement table-based datasets for a richer interface.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        columns: list[str],
+    ):
+        """Instantiates a new memory mapped sequence from a table and path.
+
+        Args:
+            path:
+                The path to the PyArrow file.
+            columns:
+                The relevant columns in the table.
+        """
+        self._path = path
+        self._columns = columns
+        # The table is lazily initialized on every process independently. This avoids
+        # accidentally sharing table references between processes.
+        # The following scenarios are covered:
+        # - Dataloader processes are created with "spawn" method:
+        #   __setstate__ is called which initializes the instance again, setting the
+        #   table to None.
+        # - Dataloader processes are created with "fork" method:
+        #   __setstate__ is not called as the dataset is not pickled. Instead the memory
+        #   space for the dataset from the main process is copied. In this case, no
+        #   table reference is shared as the table is re-initialized in the new process
+        #   when the first item is accessed.
+        self._table: Table | None = None
+        # Process ID of the process that last accessed the table.
+        self._pid: int | None = None
+
+    def table(self) -> Table:
+        pid = os.getpid()
+        if pid != self._pid or self._table is None:
+            # Re-initialize the table if the process ID has changed or if the table is
+            # not initialized yet.
+            self._pid = pid
+            self._table = _mmap_table_from_file(mmap_filepath=self._path)
+        return self._table
+
+    def __len__(self) -> int:
+        num_rows: int = self.table().num_rows
+        return num_rows
+
+    @overload
+    def __getitem__(self, index: int) -> tuple[T, ...]: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[tuple[T, ...]]: ...
+
+    def __getitem__(
+        self, index: int | slice
+    ) -> tuple[T, ...] | Sequence[tuple[T, ...]]:
+        if isinstance(index, int):
+            row_dict: list[dict[str, T]] = (
+                self.table().select(self._columns).slice(index, 1).to_pylist()
+            )
+            # Each row is a tuple of values corresponding to the requested columns.
+            return tuple(row_dict[0][col] for col in self._columns)
+        else:
+            start, stop, step = index.indices(len(self))
+
+            if step == 1:
+                # Contiguous slice - use slice() method (much faster)
+                rows_dict: list[dict[str, T]] = (
+                    self.table()
+                    .select(self._columns)
+                    .slice(start, stop - start)
+                    .to_pylist()
+                )
+            else:
+                # Non-contiguous slice - still need take()
+                indices = list(range(start, stop, step))
+                rows_dict = self.table().select(self._columns).take(indices).to_pylist()
+
+            items: Sequence[tuple[T, ...]] = [
+                tuple(row_dict[col] for col in self._columns) for row_dict in rows_dict
+            ]
+            return items
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {"path": self._path, "columns": self._columns}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        columns = state["columns"]
+        path = state["path"]
+        MemoryMappedSequenceTask.__init__(self, path=path, columns=columns)
+
+
+def _stream_write_table_to_file(
+    items: Iterable[tuple[str, ...]],
+    mmap_filepath: Path,
+    column_names: list[str],
+    chunk_size: int = 10_000,
+) -> None:
+    schema = pa.schema([(name, pa.string()) for name in column_names])
+    with ipc.new_file(sink=str(mmap_filepath.resolve()), schema=schema) as writer:
+        chunks: list[list[str]] = list([] for _ in column_names)
+        for item in items:
+            for chunk, value in zip(chunks, item):
+                chunk.append(value)
+            if len(chunk) == chunk_size:
+                writer.write_table(pa.table(data=chunks, names=column_names))
+                chunk.clear()
+        if len(chunk) > 0:
+            writer.write_table(pa.table(data=chunks, names=column_names))
+
+
+def _mmap_table_from_file(mmap_filepath: Path) -> Table:
+    with pa.memory_map(str(mmap_filepath.resolve())) as source:
+        return ipc.open_file(source).read_all()

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import ClassVar, Dict, Union
 
@@ -193,21 +193,6 @@ class MaskSemanticSegmentationDatasetArgs(PydanticConfig):
             return f"{v}/{{image_path.stem}}.png"
         else:  # mask_dir_or_file is a format string
             return v
-
-    # NOTE(Guarin, 07/25): The interface with below methods is experimental. Not yet
-    # sure if it makes sense to have this in dataset args.
-    def list_image_and_mask_filepaths(self) -> Iterable[tuple[str, str]]:
-        for image_filepath in file_helpers.list_image_files(
-            imgs_and_dirs=[self.image_dir]
-        ):
-            mask_filepath = Path(
-                self.mask_dir_or_file.format(
-                    image_path=image_filepath,
-                )
-            )
-
-            if mask_filepath.exists():
-                yield image_filepath.as_posix(), mask_filepath.as_posix()
 
     @staticmethod
     def get_dataset_cls() -> type[MaskSemanticSegmentationDataset]:

--- a/tests/_data/_serialize/test_memory_mapped_sequence_task.py
+++ b/tests/_data/_serialize/test_memory_mapped_sequence_task.py
@@ -84,7 +84,7 @@ class TestMemoryMappedSequenceTask:
         assert sequence[:] == copy[:]
 
 
-@pytest.mark.parametrize("chunk_size", [1, 2, 10_000])
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 10_000])
 def test_write_filenames_to_file(chunk_size: int, tmp_path: Path) -> None:
     column_names = ["image_filenames", "mask_filenames"]
     memory_mapped_sequence_task.write_filenames_to_file(

--- a/tests/_data/_serialize/test_memory_mapped_sequence_task.py
+++ b/tests/_data/_serialize/test_memory_mapped_sequence_task.py
@@ -1,0 +1,131 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+import pickle
+from pathlib import Path
+
+import pytest
+
+from lightly_train._data._serialize import memory_mapped_sequence_task
+
+
+class TestMemoryMappedSequenceTask:
+    def test_index(self, tmp_path: Path) -> None:
+        memory_mapped_sequence_task.write_filenames_to_file(
+            filenames=[
+                ("image1.jpg", "mask1.png"),
+                ("image2.jpg", "mask2.png"),
+                ("image3.jpg", "mask3.png"),
+            ],
+            mmap_filepath=tmp_path / "test.arrow",
+            column_names=["image_filenames", "mask_filenames"],
+        )
+        sequence = memory_mapped_sequence_task.memory_mapped_sequence_from_file(
+            mmap_filepath=tmp_path / "test.arrow",
+            column_names=["image_filenames", "mask_filenames"],
+        )
+        assert len(sequence) == 3
+        assert sequence[0] == ("image1.jpg", "mask1.png")
+        assert sequence[1] == ("image2.jpg", "mask2.png")
+        assert sequence[2] == ("image3.jpg", "mask3.png")
+        with pytest.raises(IndexError, match="list index out of range"):
+            sequence[3]
+
+    def test_slice(self, tmp_path: Path) -> None:
+        memory_mapped_sequence_task.write_filenames_to_file(
+            filenames=[
+                ("image1.jpg", "mask1.png"),
+                ("image2.jpg", "mask2.png"),
+                ("image3.jpg", "mask3.png"),
+            ],
+            mmap_filepath=tmp_path / "test.arrow",
+            column_names=["image_filenames", "mask_filenames"],
+        )
+        sequence = memory_mapped_sequence_task.memory_mapped_sequence_from_file(
+            mmap_filepath=tmp_path / "test.arrow",
+            column_names=["image_filenames", "mask_filenames"],
+        )
+        assert len(sequence) == 3
+        assert sequence[0:2] == [
+            ("image1.jpg", "mask1.png"),
+            ("image2.jpg", "mask2.png"),
+        ]
+        assert sequence[1:3] == [
+            ("image2.jpg", "mask2.png"),
+            ("image3.jpg", "mask3.png"),
+        ]
+        assert sequence[0:100] == [
+            ("image1.jpg", "mask1.png"),
+            ("image2.jpg", "mask2.png"),
+            ("image3.jpg", "mask3.png"),
+        ]
+
+    def test_pickle(self, tmp_path: Path) -> None:
+        memory_mapped_sequence_task.write_filenames_to_file(
+            filenames=[
+                ("image1.jpg", "mask1.png"),
+                ("image2.jpg", "mask2.png"),
+                ("image3.jpg", "mask3.png"),
+            ],
+            mmap_filepath=tmp_path / "test.arrow",
+            column_names=["image_filenames", "mask_filenames"],
+        )
+        sequence = memory_mapped_sequence_task.memory_mapped_sequence_from_file(
+            mmap_filepath=tmp_path / "test.arrow",
+            column_names=["image_filenames", "mask_filenames"],
+        )
+        assert len(sequence) == 3
+        copy = pickle.loads(pickle.dumps(sequence))
+        assert len(copy) == 3
+        assert sequence[:] == copy[:]
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 10_000])
+def test_write_filenames_to_file(chunk_size: int, tmp_path: Path) -> None:
+    column_names = ["image_filenames", "mask_filenames"]
+    memory_mapped_sequence_task.write_filenames_to_file(
+        filenames=[
+            ("image1.jpg", "mask1.png"),
+            ("image2.jpg", "mask2.png"),
+            ("image3.jpg", "mask3.png"),
+        ],
+        mmap_filepath=tmp_path / "test.arrow",
+        chunk_size=chunk_size,
+        column_names=column_names,
+    )
+    sequence = memory_mapped_sequence_task.memory_mapped_sequence_from_file(
+        mmap_filepath=tmp_path / "test.arrow",
+        column_names=column_names,
+    )
+    assert len(sequence) == 3
+    assert sequence[:] == [
+        ("image1.jpg", "mask1.png"),
+        ("image2.jpg", "mask2.png"),
+        ("image3.jpg", "mask3.png"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "chunk_size",
+    [0, -1],
+)
+def test_write_filenames_to_file__invalid_chunks(
+    chunk_size: int, tmp_path: Path
+) -> None:
+    with pytest.raises(
+        ValueError, match=f"Invalid `chunk_size` {chunk_size} must be positive!"
+    ):
+        memory_mapped_sequence_task.write_filenames_to_file(
+            filenames=[
+                ("image1.jpg", "mask1.png"),
+                ("image2.jpg", "mask2.png"),
+                ("image3.jpg", "mask3.png"),
+            ],
+            mmap_filepath=tmp_path / "test.arrow",
+            chunk_size=chunk_size,
+            column_names=["image_filenames", "mask_filenames"],
+        )

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 from torch import Tensor
 
+from lightly_train._commands.train_task_helpers import list_image_and_mask_filepaths
 from lightly_train._data.mask_semantic_segmentation_dataset import (
     ClassInfo,
     MaskSemanticSegmentationDataArgs,
@@ -250,7 +251,11 @@ class TestMaskSemanticSegmentationDataset:
         transform = DummyTransform(transform_args=TaskTransformArgs())
         dataset = MaskSemanticSegmentationDataset(
             dataset_args=dataset_args,
-            image_and_mask_filepaths=list(dataset_args.list_image_and_mask_filepaths()),
+            image_and_mask_filepaths=list(
+                list_image_and_mask_filepaths(
+                    dataset_args.image_dir, dataset_args.mask_dir_or_file
+                )
+            ),
             transform=transform,
         )
 
@@ -305,7 +310,11 @@ class TestMaskSemanticSegmentationDataset:
         transform = DummyTransform(transform_args=TaskTransformArgs())
         dataset = MaskSemanticSegmentationDataset(
             dataset_args=dataset_args,
-            image_and_mask_filepaths=list(dataset_args.list_image_and_mask_filepaths()),
+            image_and_mask_filepaths=list(
+                list_image_and_mask_filepaths(
+                    dataset_args.image_dir, dataset_args.mask_dir_or_file
+                )
+            ),
             transform=transform,
         )
 
@@ -340,7 +349,11 @@ class TestMaskSemanticSegmentationDataset:
         transform = DummyTransform(transform_args=TaskTransformArgs())
         dataset = MaskSemanticSegmentationDataset(
             dataset_args=dataset_args,
-            image_and_mask_filepaths=list(dataset_args.list_image_and_mask_filepaths()),
+            image_and_mask_filepaths=list(
+                list_image_and_mask_filepaths(
+                    dataset_args.image_dir, dataset_args.mask_dir_or_file
+                )
+            ),
             transform=transform,
         )
 
@@ -367,7 +380,11 @@ class TestMaskSemanticSegmentationDatasetArgs:
             ignore_index=-100,
         )
 
-        filepaths = list(dataset_args.list_image_and_mask_filepaths())
+        filepaths = list(
+            list_image_and_mask_filepaths(
+                dataset_args.image_dir, dataset_args.mask_dir_or_file
+            )
+        )
 
         assert len(filepaths) == 2
         expected_pairs = [
@@ -395,7 +412,11 @@ class TestMaskSemanticSegmentationDatasetArgs:
             ignore_index=-100,
         )
 
-        filepaths = list(dataset_args.list_image_and_mask_filepaths())
+        filepaths = list(
+            list_image_and_mask_filepaths(
+                dataset_args.image_dir, dataset_args.mask_dir_or_file
+            )
+        )
 
         assert len(filepaths) == 2
         expected_pairs = [
@@ -423,7 +444,11 @@ class TestMaskSemanticSegmentationDatasetArgs:
             ignore_index=-100,
         )
 
-        filepaths = list(dataset_args.list_image_and_mask_filepaths())
+        filepaths = list(
+            list_image_and_mask_filepaths(
+                dataset_args.image_dir, dataset_args.mask_dir_or_file
+            )
+        )
 
         assert len(filepaths) == 1
         assert filepaths[0] == (

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -233,12 +233,15 @@ class TestMaskSemanticSegmentationDataset:
         mask_dir = tmp_path / "masks"
         image_filenames = ["image0.jpg", "image1.jpg"]
         mask_filenames = ["image0.png", "image1.png"]
+
+        mask_file = "{image_path.parent.parent}/masks/{image_path.stem}.png"
+
         helpers.create_images(image_dir, files=image_filenames)
         helpers.create_masks(mask_dir, files=mask_filenames, num_classes=num_classes)
 
         dataset_args = MaskSemanticSegmentationDatasetArgs(
             image_dir=image_dir,
-            mask_dir=mask_dir,
+            mask_file=mask_file,
             classes={
                 i: ClassInfo(name=f"class_{i}", values={i}) for i in range(num_classes)
             },
@@ -247,7 +250,7 @@ class TestMaskSemanticSegmentationDataset:
         transform = DummyTransform(transform_args=TaskTransformArgs())
         dataset = MaskSemanticSegmentationDataset(
             dataset_args=dataset_args,
-            image_filenames=list(dataset_args.list_image_filenames()),
+            image_and_mask_filepaths=list(dataset_args.list_image_and_mask_filepaths()),
             transform=transform,
         )
 
@@ -281,6 +284,9 @@ class TestMaskSemanticSegmentationDataset:
         mask_dir = tmp_path / "masks"
         image_filenames = ["image0.jpg"]
         mask_filenames = ["image0.png"]
+
+        mask_file = "{image_path.parent.parent}/masks/{image_path.stem}.png"
+
         helpers.create_images(image_dir, files=image_filenames)
         helpers.create_masks(mask_dir, files=mask_filenames, num_classes=5)
 
@@ -292,14 +298,14 @@ class TestMaskSemanticSegmentationDataset:
 
         dataset_args = MaskSemanticSegmentationDatasetArgs(
             image_dir=image_dir,
-            mask_dir=mask_dir,
+            mask_file=mask_file,
             classes=classes,
             ignore_index=-100,
         )
         transform = DummyTransform(transform_args=TaskTransformArgs())
         dataset = MaskSemanticSegmentationDataset(
             dataset_args=dataset_args,
-            image_filenames=list(dataset_args.list_image_filenames()),
+            image_and_mask_filepaths=list(dataset_args.list_image_and_mask_filepaths()),
             transform=transform,
         )
 
@@ -310,6 +316,9 @@ class TestMaskSemanticSegmentationDataset:
         mask_dir = tmp_path / "masks"
         image_filenames = ["image0.jpg"]
         mask_filenames = ["image0.png"]
+
+        mask_file = "{image_path.parent.parent}/masks/{image_path.stem}.png"
+
         helpers.create_images(image_dir, files=image_filenames)
         helpers.create_masks(mask_dir, files=mask_filenames, num_classes=5)
 
@@ -323,7 +332,7 @@ class TestMaskSemanticSegmentationDataset:
 
         dataset_args = MaskSemanticSegmentationDatasetArgs(
             image_dir=image_dir,
-            mask_dir=mask_dir,
+            mask_file=mask_file,
             classes=classes,
             ignore_classes=ignore_classes,
             ignore_index=-100,
@@ -331,7 +340,7 @@ class TestMaskSemanticSegmentationDataset:
         transform = DummyTransform(transform_args=TaskTransformArgs())
         dataset = MaskSemanticSegmentationDataset(
             dataset_args=dataset_args,
-            image_filenames=list(dataset_args.list_image_filenames()),
+            image_and_mask_filepaths=list(dataset_args.list_image_and_mask_filepaths()),
             transform=transform,
         )
 

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -371,8 +371,8 @@ class TestMaskSemanticSegmentationDatasetArgs:
 
         assert len(filepaths) == 2
         expected_pairs = [
-            (image_dir / "image0.jpg", mask_dir / "image0.png"),
-            (image_dir / "image1.jpg", mask_dir / "image1.png"),
+            (str(image_dir / "image0.jpg"), str(mask_dir / "image0.png")),
+            (str(image_dir / "image1.jpg"), str(mask_dir / "image1.png")),
         ]
         assert set(filepaths) == set(expected_pairs)
 
@@ -399,8 +399,8 @@ class TestMaskSemanticSegmentationDatasetArgs:
 
         assert len(filepaths) == 2
         expected_pairs = [
-            (image_dir / "image0.jpg", mask_dir / "image0.png"),
-            (image_dir / "image1.jpg", mask_dir / "image1.png"),
+            (str(image_dir / "image0.jpg"), str(mask_dir / "image0.png")),
+            (str(image_dir / "image1.jpg"), str(mask_dir / "image1.png")),
         ]
         assert set(filepaths) == set(expected_pairs)
 
@@ -426,4 +426,7 @@ class TestMaskSemanticSegmentationDatasetArgs:
         filepaths = list(dataset_args.list_image_and_mask_filepaths())
 
         assert len(filepaths) == 1
-        assert filepaths[0] == (image_dir / "image0.jpg", mask_dir / "image0.png")
+        assert filepaths[0] == (
+            str(image_dir / "image0.jpg"),
+            str(mask_dir / "image0.png"),
+        )


### PR DESCRIPTION
## Summary
• Add memory-mapped sequence task class for efficient large dataset handling
• Improve mask semantic segmentation dataset to support custom mask naming patterns
• Move helper functions to common_helpers module for better code organization

## Test plan
- [x] Add comprehensive test coverage for memory-mapped sequence task class
- [x] Add tests for custom mask name pattern support in semantic segmentation dataset
- [x] Add tests for file helper functions
- [x] Update existing tests to cover new functionality
- [x] All tests pass with `make test-ci`