### PR TITLE
Fix mmap cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue where segmentation fine-tuning could fail when encountering masks containing
+- Fix issue where segmentation fine-tuning could fail when encountering masks containing
   only unknown classes.
+- Fix issue with mmap cache when multiple runs use the same dataset on the same machine.
 
 ### Security
 

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -130,7 +130,9 @@ def embed_from_config(config: EmbedConfig) -> None:
     # file has to exist while the dataset is used.
     with common_helpers.verify_out_dir_equal_on_all_local_ranks(
         out=out_path
-    ), common_helpers.get_dataset_temp_mmap_path(data=config.data) as mmap_filepath:
+    ), common_helpers.get_dataset_temp_mmap_path(
+        data=config.data, out=out_path
+    ) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
             transform=transform,

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -287,7 +287,8 @@ def train_from_config(config: TrainConfig) -> None:
     with common_helpers.verify_out_dir_equal_on_all_local_ranks(
         out=out_dir
     ), common_helpers.get_dataset_temp_mmap_path(
-        data=config.data
+        data=config.data,
+        out=out_dir,
     ) as mmap_filepath, _float32_matmul_precision.float32_matmul_precision(
         float32_matmul_precision=config.float32_matmul_precision
     ):

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -45,7 +45,7 @@ def _dec_ref_worker(mmap_str: str, ref_str: str) -> None:
     common_helpers._decrement_and_cleanup_if_zero(Path(mmap_str), Path(ref_str))
 
 
-def _ctx_mmap_worker(data_str: str) -> str:
+def _ctx_mmap_worker(data_str: str, out_str: str) -> str:
     """Open the mmap path context and return the path as string.
 
     Kept top-level to be picklable for ProcessPoolExecutor on spawn/forkserver.
@@ -55,7 +55,9 @@ def _ctx_mmap_worker(data_str: str) -> str:
     from lightly_train._commands import common_helpers
 
     data_path = Path(data_str)
-    with common_helpers.get_dataset_temp_mmap_path(data=data_path) as mmap_path:
+    with common_helpers.get_dataset_temp_mmap_path(
+        data=data_path, out=out_str
+    ) as mmap_path:
         assert mmap_path.suffix == ".mmap"
         return str(mmap_path)
 
@@ -734,10 +736,14 @@ def test_get_dataset_temp_mmap_path__concurrent_context_managers(
     import concurrent.futures
 
     data_path = tmp_path / "data"
+    out_path = tmp_path / "out"
 
     # Run 5 concurrent context managers (processes)
     with concurrent.futures.ProcessPoolExecutor(max_workers=5) as executor:
-        futures = [executor.submit(_ctx_mmap_worker, str(data_path)) for _ in range(5)]
+        futures = [
+            executor.submit(_ctx_mmap_worker, str(data_path), str(out_path))
+            for _ in range(5)
+        ]
         # Collect results and re-raise any exceptions
         mmap_paths = [Path(future.result()) for future in futures]
 


### PR DESCRIPTION
## What has changed and why?

* Change mmap cache behavior

This fixes an issue when multiple runs with the same data are scheduled on the same node. Before this PR the mmap files were based on the `data` directory. A mmap file could already exist for a given `data` directory if a previous run created and didn't delete it (e.g. if the run crashed). The new behavior is to use the `data` directory only if `LIGHTLY_TRAIN_MMAP_REUSE_FILE` is true, otherwise the `out` directory determines the mmap location. This is safer as only one run at a time can use a given `out` directory and we can error quickly if multiple runs with the same `out` directory are detected. This is not possible with the `data` directory as it is valid to have multiple runs using the same `data` directory at once.




## How has it been tested?

* Manual

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
