### PR TITLE
Speed up logging of datasets with many files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for using custom mask names for the inputs in semantic segmentation.
 
 ### Changed
-- Speed up logging of datasets with many files.
 
 ### Deprecated
 
@@ -24,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where segmentation fine-tuning could fail when encountering masks containing
   only unknown classes.
 - Fix issue with mmap cache when multiple runs use the same dataset on the same machine.
+- Speed up logging of datasets with many files.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for using custom mask names for the inputs in semantic segmentation.
 - Add `precision` flag to ONNX export task to specify if we export with float16 or float32 precision.
+- Speed up logging of datasets with many files.
 
 ### Deprecated
 

--- a/docs/prebuild.py
+++ b/docs/prebuild.py
@@ -81,7 +81,9 @@ def dump_transform_args_for_methods(dest_dir: Path) -> None:
         transform_args = train_helpers.get_transform_args(
             method=method, transform_args=None
         )
-        args = common_helpers.pretty_format_args(transform_args.model_dump())
+        args = common_helpers.pretty_format_args(
+            transform_args.model_dump(), limit=False
+        )
         # write to file
         with open(dest_dir / f"{method}_transform_args.md", "w") as f:
             f.write("```json\n")
@@ -101,7 +103,7 @@ def dump_transform_args_for_tasks(dest_dir: Path) -> None:
             ignore_index=MaskSemanticSegmentationDataArgs.ignore_index
         )
         train_args = train_task_helpers.pretty_format_args(
-            train_transform_args.model_dump()
+            train_transform_args.model_dump(),
         )
         val_args = train_task_helpers.pretty_format_args(
             val_transform_args.model_dump()
@@ -125,7 +127,7 @@ def dump_method_args(dest_dir: Path) -> None:
         if method in {"distillationv1", "distillationv2"}:
             continue
         method_args = method_helpers.get_method_cls(method).method_args_cls()()
-        args = common_helpers.pretty_format_args(method_args.model_dump())
+        args = common_helpers.pretty_format_args(method_args.model_dump(), limit=False)
         # write to file
         with open(dest_dir / f"{method}_method_args.md", "w") as f:
             f.write("```json\n")

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -15,10 +15,10 @@ import os
 import sys
 import time
 import warnings
-from collections.abc import Iterable, Sequence, Set
+from collections.abc import Iterable, Sequence, Set, Sized
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generator, Literal, Sized, TypeVar
+from typing import Any, Generator, Literal, TypeVar
 
 import torch
 from filelock import FileLock

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -223,7 +223,7 @@ def pretty_format_args(
 
 
 def remove_excessive_args(
-    args: dict[str, Any], limit_keys: set[str] | None = None, num_elems: int = 10
+    args: dict[str, Any], limit_keys: Set[str] | None = None, num_elems: int = 10
 ) -> dict[str, Any]:
     """Limit the number of elements in sequences of a dict to a certain number. This is
     strictly for logging purposes. Does not work with nested structures.

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -15,9 +15,10 @@ import os
 import sys
 import time
 import warnings
+from collections.abc import Iterable, Sequence, Set
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generator, Iterable, Literal, Sequence, Set, Sized, TypeVar
+from typing import Any, Generator, Literal, Sized, TypeVar
 
 import torch
 from filelock import FileLock

--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -17,7 +17,7 @@ import time
 import warnings
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generator, Iterable, Literal, Sequence, Sized, TypeVar
+from typing import Any, Generator, Iterable, Literal, Sequence, Set, Sized, TypeVar
 
 import torch
 from filelock import FileLock
@@ -206,14 +206,23 @@ def verify_out_dir_equal_on_all_local_ranks(out: Path) -> Generator[None, None, 
         _unlink_and_ignore(out_tmp)
 
 
-def pretty_format_args(args: dict[str, Any], indent: int = 4) -> str:
+def pretty_format_args(
+    args: dict[str, Any],
+    indent: int = 4,
+    limit: bool = True,
+    limit_keys: Set[str] | None = None,
+    limit_num_elems: int = 10,
+) -> str:
+    if limit:
+        args = remove_excessive_args(
+            args, limit_keys=limit_keys, num_elems=limit_num_elems
+        )
     args = sanitize_config_dict(args)
-
     return json.dumps(args, indent=indent, sort_keys=True)
 
 
 def remove_excessive_args(
-    args: dict[str, Any], limit_keys: set[str] | None = None, num_elems: int = 5
+    args: dict[str, Any], limit_keys: set[str] | None = None, num_elems: int = 10
 ) -> dict[str, Any]:
     """Limit the number of elements in sequences of a dict to a certain number. This is
     strictly for logging purposes. Does not work with nested structures.
@@ -234,8 +243,14 @@ def remove_excessive_args(
             and not isinstance(args[key], str)
             and len(args[key]) > num_elems
         ):
-            args[key] = type(args[key])(
-                (*args[key][: num_elems - 2], "...", args[key][-1])
+            val = args[key]
+            num_extra_values = len(val) - (num_elems - 1)
+            args[key] = type(val)(
+                (
+                    *val[: num_elems - 2],
+                    f"... {num_extra_values} more values",
+                    val[-1],
+                )
             )
     return args
 

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -101,7 +101,9 @@ def embed_from_config(config: EmbedConfig) -> None:
     _warnings.filter_embed_warnings()
     _logging.set_up_console_logging()
     _logging.set_up_filters()
-    logger.info(common_helpers.pretty_format_args(args=config.model_dump()))
+    logger.info(
+        common_helpers.pretty_format_args(args=config.model_dump(), limit_keys={"data"})
+    )
 
     logger.info(
         f"Embedding images in '{common_helpers.remove_excessive_args({'data': config.data})}'."

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -260,7 +260,7 @@ def train_from_config(config: TrainConfig) -> None:
     _logging.set_up_file_logging(out_dir / "train.log")
     _logging.set_up_filters()
     logger.info(
-        f"Args: {common_helpers.pretty_format_args(args=common_helpers.remove_excessive_args(config.model_dump(), limit_keys={'data'}))}"
+        f"Args: {common_helpers.pretty_format_args(args=config.model_dump(), limit_keys={'data'})}"
     )
     logger.info(f"Using output directory '{out_dir}'.")
 
@@ -502,10 +502,12 @@ def log_resolved_config(config: TrainConfig, loggers: list[Logger]) -> None:
     """
     log_string = (
         "Resolved configuration:\n"
-        f"{common_helpers.pretty_format_args(args=common_helpers.remove_excessive_args(config.model_dump(), limit_keys={'data'}))}\n"
+        f"{common_helpers.pretty_format_args(args=config.model_dump(), limit_keys={'data'})}\n"
     )
     logger.info(log_string)
 
-    hyperparams = common_helpers.sanitize_config_dict(config.model_dump())
+    hyperparams = common_helpers.sanitize_config_dict(
+        common_helpers.remove_excessive_args(config.model_dump(), limit_keys={"data"})
+    )
     for logger_instance in loggers:
         logger_instance.log_hyperparams(params=hyperparams)

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -436,7 +436,7 @@ def test_pretty_format_args__custom_model() -> None:
                     "my_data_dir",
                     "my_data_dir_2",
                     "my_data_dir_3",
-                    "...",
+                    "... 2 more values",
                     "my_data_dir_6",
                 ],
                 "devices": [0, 1],
@@ -463,10 +463,10 @@ def test_pretty_format_args__custom_model() -> None:
                     "my_data_dir",
                     "my_data_dir_2",
                     "my_data_dir_3",
-                    "...",
+                    "... 2 more values",
                     "my_data_dir_6",
                 ],
-                "devices": [0, 1, 2, "...", 7],
+                "devices": [0, 1, 2, "... 4 more values", 7],
             },
         ),
     ],
@@ -474,7 +474,7 @@ def test_pretty_format_args__custom_model() -> None:
 def test_remove_excessive_args__all_keys(
     args: dict[str, Any], expected: dict[str, Any]
 ) -> None:
-    assert common_helpers.remove_excessive_args(args=args) == expected
+    assert common_helpers.remove_excessive_args(args=args, num_elems=5) == expected
 
 
 def test_remove_excessive_args__specific_key() -> None:
@@ -498,13 +498,16 @@ def test_remove_excessive_args__specific_key() -> None:
             "my_data_dir",
             "my_data_dir_2",
             "my_data_dir_3",
-            "...",
+            "... 2 more values",
             "my_data_dir_6",
         ],
         "devices": [0, 1, 2, 3, 4, 5, 6, 7],
     }
     assert (
-        common_helpers.remove_excessive_args(args=args, limit_keys={"data"}) == expected
+        common_helpers.remove_excessive_args(
+            args=args, limit_keys={"data"}, num_elems=5
+        )
+        == expected
     )
 
 


### PR DESCRIPTION
## What has changed and why?

* Speed up logging of datasets with many files
* Make sure we always prune excessively long lists before logging

Adresses #264 partially


## How has it been tested?

* Unit tests
* Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
