### PR TITLE
Use image size everywhere in predict

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -246,14 +246,11 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
         image_h, image_w = x.shape[-2:]
 
         x = transforms_functional.to_dtype(x, dtype=torch.float32, scale=True)
-        # TODO(Guarin, 07/25): Save mean and std in the model.
         x = transforms_functional.normalize(
             x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
         )
-        # Resize shorter edge to 518
-        # TODO(Guarin, 07/25): Make this configurable. Save default image size in the
-        # model.
-        x = transforms_functional.resize(x, size=[518])  # (C, H, W) -> (C, H', W')
+        # (C, H, W) -> (C, H', W')
+        x = transforms_functional.resize(x, size=[min(self.image_size)])
         x = x.unsqueeze(0)  # (1, C, H', W')
 
         logits = self._forward_logits(x)  # (1, K+1, H', W'), K = len(self.classes)

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
@@ -209,9 +209,8 @@ class DINOv2LinearSemanticSegmentation(TaskModel):
             x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
         )
         # Resize to configured image size
-        x = transforms_functional.resize(
-            x, size=list(self.image_size)
-        )  # (C, H, W) -> (C, H', W')
+        # (C, H, W) -> (C, H', W')
+        x = transforms_functional.resize(x, size=[min(self.image_size)])
         x = x.unsqueeze(0)  # (1, C, H', W')
 
         logits = self._forward_logits(x)  # (1, K|K+1, H', W'), K=num_classes

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -256,15 +256,11 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         image_h, image_w = x.shape[-2:]
 
         x = transforms_functional.to_dtype(x, dtype=torch.float32, scale=True)
-        # TODO(Guarin, 07/25): Save mean and std in the model.
         x = transforms_functional.normalize(
             x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
         )
-        # Resize shorter edge to 518
-        # TODO(Guarin, 07/25): Make this configurable. Save default image size in the
-        # model.
-        # TODO(Guarin, 07/25): Check if we should change default to 512.
-        x = transforms_functional.resize(x, size=[518])  # (C, H, W) -> (C, H', W')
+        # (C, H, W) -> (C, H', W')
+        x = transforms_functional.resize(x, size=[min(self.image_size)])
         x = x.unsqueeze(0)  # (1, C, H', W')
 
         logits = self._forward_logits(x)  # (1, K+1, H', W'), K = len(self.classes)


### PR DESCRIPTION
## What has changed and why?

* Use image size everywhere in predict

Noticed that this wasn't passed everywhere.

## How has it been tested?



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
