### PR TITLE
Fix grid size in linear segmentation

### DIFF
--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
@@ -240,8 +240,8 @@ class DINOv2LinearSemanticSegmentation(TaskModel):
         logits: Tensor = self.head(patch_tokens)
 
         # Reshape back to (B, K|K+1, H_patch, W_patch).
-        H_patch = H // self.patch_size
-        W_patch = W // self.patch_size
+        H_patch = math.ceil(H / self.patch_size)
+        W_patch = math.ceil(W / self.patch_size)
         logits = logits.permute(0, 2, 1).reshape(B, -1, H_patch, W_patch)
 
         # Up-sample to match original image/mask resolution.


### PR DESCRIPTION
## What has changed and why?

Fix the grid size in linear segmentation for resolutions that are not multiple of 14.

## How has it been tested?

Manual test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
