### PR TITLE
Resume scheduler properly

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -342,6 +342,7 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
         state = TrainTaskState(
             train_model=train_model,
             optimizer=optimizer,
+            scheduler=scheduler,
             train_dataloader=train_dataloader,
             step=-1,
             model_class_path=train_model.get_task_model().class_path,

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -610,6 +610,7 @@ def load_checkpoint(fabric: Fabric, out_dir: PathLike, state: TrainTaskState) ->
     train_model_grads = {n: p.requires_grad for n, p in train_model.named_parameters()}
     train_model_trainings = {n: m.training for n, m in train_model.named_modules()}
     optimizer = state["optimizer"]
+    scheduler = state["scheduler"]
     train_dataloader = state["train_dataloader"]
 
     logger.info(f"Loading checkpoint from '{ckpt_path}'")
@@ -625,4 +626,5 @@ def load_checkpoint(fabric: Fabric, out_dir: PathLike, state: TrainTaskState) ->
         n: m.training for n, m in state["train_model"].named_modules()
     } == train_model_trainings
     assert state["optimizer"] is optimizer
+    assert state["scheduler"] is scheduler
     assert state["train_dataloader"] is train_dataloader

--- a/src/lightly_train/_train_task_state.py
+++ b/src/lightly_train/_train_task_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, TypedDict
 
 from torch.nn import Module
+from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
 
@@ -19,6 +20,7 @@ from lightly_train.types import TaskBatch
 class TrainTaskState(TypedDict):
     train_model: Module
     optimizer: Optimizer
+    scheduler: LRScheduler
     train_dataloader: DataLoader[TaskBatch]
     step: int
     # Model class path and initialization arguments for serialization.


### PR DESCRIPTION
## What has changed and why?

When training DINOv3_EoMT (or anything else with `TwoStageWarmupPolySchedule`), the learning rate will reset to the initial stage when `resume_interrupted=True`. This is because the scheduler status is not saved and resumed properly, so `last_epoch` is always equal to -1 when resumed from checkpoints.

<img width="1309" height="707" alt="lr_1" src="https://github.com/user-attachments/assets/2398b4ff-ee9a-49cd-8c5c-cb653685cde5" />
<img width="1216" height="741" alt="lr_2" src="https://github.com/user-attachments/assets/a0946fbb-4b1b-4e1d-9b06-ab008d93ff9d" />


What changed:
- Added scheduler: LRScheduler to TrainTaskState so the LR scheduler state is saved and restored with checkpoints.
- Included the scheduler instance in the saved state in train_task.py.
- Ensured the same scheduler object is preserved on load by asserting identity in load_checkpoint.

## How has it been tested?

Rerun the same train and resume from checkpoints to make sure the learning rate is consistent.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
