### PR TITLE
Improve existing mmap file handling

### DIFF
--- a/src/lightly_train/_commands/common_helpers.py
+++ b/src/lightly_train/_commands/common_helpers.py
@@ -391,6 +391,8 @@ def _get_package(model: Module) -> BasePackage:
 def get_dataset_temp_mmap_path(
     data: PathLike | Sequence[PathLike],
     out: PathLike,
+    resume_interrupted: bool,
+    overwrite: bool,
 ) -> Generator[Path, Any, Any]:
     """Generate file in the cache directory to be used for memory-mapping the dataset.
 
@@ -414,6 +416,8 @@ def get_dataset_temp_mmap_path(
         # Use data as identifier to share the mmap file across multiple runs.
         # NOTE(Guarin, 09/25): Hash of data might be slow if data is a long list of
         # filenames or directories.
+        if isinstance(data, (str, Path)):
+            data = Path(data).resolve()
         identifier = f"{data}-{distributed_helpers.get_node_rank() or 0}"
     else:
         # Use out as identifier to create a unique mmap file for each run. We assume
@@ -430,6 +434,10 @@ def get_dataset_temp_mmap_path(
 
     if (
         not Env.LIGHTLY_TRAIN_MMAP_REUSE_FILE.value
+        # With resume and overwrite we make the assumption that the data did not change
+        # since the last run.
+        and not resume_interrupted
+        and not overwrite
         and mmap_filepath.exists()
         and distributed_helpers.is_local_rank_zero()
     ):
@@ -453,8 +461,8 @@ def get_dataset_temp_mmap_path(
                 "If the files in `data` were modified since the last run, please "
                 "re-run with a new output directory or delete the following leftover "
                 "files:\n "
-                "   - {mmap_filepath}\n"
-                "   - {ref_count_filepath}\n"
+                f"  - {mmap_filepath}\n"
+                f"  - {ref_count_filepath}"
             )
         else:
             raise RuntimeError(
@@ -462,8 +470,8 @@ def get_dataset_temp_mmap_path(
                 "This error can also happen if a previous run crashed and did not shut "
                 "down properly. If no other run is using this output directory, please go "
                 "ahead and delete the following leftover files:\n "
-                f" - {mmap_filepath}\n"
-                f" - {ref_count_filepath}\n"
+                f"  - {mmap_filepath}\n"
+                f"  - {ref_count_filepath}"
             )
 
     try:
@@ -512,12 +520,16 @@ def get_dataset_mmap_file(
     out_dir: Path,
     filenames: Iterable[str],
     mmap_filepath: Path,
+    resume_interrupted: bool,
+    overwrite: bool,
 ) -> MemoryMappedSequence[str]:
     """Returns memory-mapped filenames shared across all ranks.
 
     Filenames are written to mmap_filepath by rank zero and read by all ranks.
     """
-    if Env.LIGHTLY_TRAIN_MMAP_REUSE_FILE.value and mmap_filepath.exists():
+    if (
+        Env.LIGHTLY_TRAIN_MMAP_REUSE_FILE.value or resume_interrupted or overwrite
+    ) and mmap_filepath.exists():
         # If the file already exists and we are allowed to reuse it, return it.
         logger.warning(f"Reusing existing memory-mapped file '{mmap_filepath}'.")
         return MemoryMappedSequence.from_file(mmap_filepath=mmap_filepath)
@@ -567,6 +579,8 @@ def get_dataset(
     num_channels: int,
     mmap_filepath: Path | None,
     out_dir: Path,
+    resume_interrupted: bool,
+    overwrite: bool,
 ) -> Dataset[DatasetItem]:
     if isinstance(data, Dataset):
         logger.debug("Using provided dataset.")
@@ -597,6 +611,8 @@ def get_dataset(
                 out_dir=out_dir,
                 filenames=filenames,
                 mmap_filepath=mmap_filepath,
+                resume_interrupted=resume_interrupted,
+                overwrite=overwrite,
             ),
             transform=transform,
             num_channels=num_channels,
@@ -616,6 +632,8 @@ def get_dataset(
                 out_dir=out_dir,
                 filenames=filenames,
                 mmap_filepath=mmap_filepath,
+                resume_interrupted=resume_interrupted,
+                overwrite=overwrite,
             ),
             transform=transform,
             num_channels=num_channels,

--- a/src/lightly_train/_commands/embed.py
+++ b/src/lightly_train/_commands/embed.py
@@ -133,7 +133,10 @@ def embed_from_config(config: EmbedConfig) -> None:
     with common_helpers.verify_out_dir_equal_on_all_local_ranks(
         out=out_path
     ), common_helpers.get_dataset_temp_mmap_path(
-        data=config.data, out=out_path
+        data=config.data,
+        out=out_path,
+        resume_interrupted=False,
+        overwrite=config.overwrite,
     ) as mmap_filepath:
         dataset = common_helpers.get_dataset(
             data=config.data,
@@ -141,6 +144,8 @@ def embed_from_config(config: EmbedConfig) -> None:
             num_channels=len(checkpoint_instance.lightly_train.normalize_args.mean),
             mmap_filepath=mmap_filepath,
             out_dir=out_path,
+            resume_interrupted=False,
+            overwrite=config.overwrite,
         )
         dataloader = _get_dataloader(
             dataset=dataset,

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -290,6 +290,8 @@ def train_from_config(config: TrainConfig) -> None:
     ), common_helpers.get_dataset_temp_mmap_path(
         data=config.data,
         out=out_dir,
+        resume_interrupted=config.resume_interrupted,
+        overwrite=config.overwrite,
     ) as mmap_filepath, _float32_matmul_precision.float32_matmul_precision(
         float32_matmul_precision=config.float32_matmul_precision
     ):
@@ -299,6 +301,8 @@ def train_from_config(config: TrainConfig) -> None:
             num_channels=no_auto(transform_instance.transform_args.num_channels),
             mmap_filepath=mmap_filepath,
             out_dir=out_dir,
+            resume_interrupted=config.resume_interrupted,
+            overwrite=config.overwrite,
         )
         dataset_size = train_helpers.get_dataset_size(dataset=dataset)
         config.epochs = train_helpers.get_epochs(

--- a/tests/_commands/test_common_helpers.py
+++ b/tests/_commands/test_common_helpers.py
@@ -56,7 +56,10 @@ def _ctx_mmap_worker(data_str: str, out_str: str) -> str:
 
     data_path = Path(data_str)
     with common_helpers.get_dataset_temp_mmap_path(
-        data=data_path, out=out_str
+        data=data_path,
+        out=out_str,
+        resume_interrupted=False,
+        overwrite=False,
     ) as mmap_path:
         assert mmap_path.suffix == ".mmap"
         return str(mmap_path)
@@ -724,14 +727,14 @@ def test_get_dataset_temp_mmap_path__rank(
     out = tmp_path / "out"
     mocker.patch.dict(os.environ, {"LOCAL_RANK": "0"})
     with common_helpers.get_dataset_temp_mmap_path(
-        data=data, out=out
+        data=data, out=out, resume_interrupted=False, overwrite=False
     ) as mmap_path_rank0:
         pass
 
     # Simulate calling the function from rank 1
     mocker.patch.dict(os.environ, {"LOCAL_RANK": "1"})
     with common_helpers.get_dataset_temp_mmap_path(
-        data=data, out=out
+        data=data, out=out, resume_interrupted=False, overwrite=False
     ) as mmap_path_rank1:
         pass
 
@@ -772,6 +775,8 @@ def test_get_dataset_mmap_file__rank0(tmp_path: Path) -> None:
         out_dir=tmp_path,
         filenames=filenames,
         mmap_filepath=mmap_filepath,
+        resume_interrupted=False,
+        overwrite=False,
     )
     assert list(mmap_filenames) == filename_items
 
@@ -787,6 +792,8 @@ def test_get_dataset_mmap_file__rank(tmp_path: Path, mocker: MockerFixture) -> N
         out_dir=tmp_path,
         filenames=filenames,
         mmap_filepath=mmap_filepath,
+        resume_interrupted=False,
+        overwrite=False,
     )
 
     # Simulate calling the function from rank 1
@@ -795,6 +802,8 @@ def test_get_dataset_mmap_file__rank(tmp_path: Path, mocker: MockerFixture) -> N
         out_dir=tmp_path,
         filenames=filenames,
         mmap_filepath=mmap_filepath,
+        resume_interrupted=False,
+        overwrite=False,
     )
     assert list(mmap_filenames_rank0) == filename_items
     assert list(mmap_filenames_rank1) == filename_items
@@ -815,6 +824,8 @@ def test_get_dataset_mmap_file__rank_error(
         out_dir=tmp_path,
         filenames=filenames,
         mmap_filepath=mmap_filepath_rank0,
+        resume_interrupted=False,
+        overwrite=False,
     )
 
     # Simulate calling the function from rank 1.
@@ -826,6 +837,8 @@ def test_get_dataset_mmap_file__rank_error(
             out_dir=tmp_path,
             filenames=filenames,
             mmap_filepath=mmap_filepath_rank1,
+            resume_interrupted=False,
+            overwrite=False,
         )
 
 
@@ -842,6 +855,8 @@ def test_get_dataset_mmap_file__reuse(
         out_dir=tmp_path,
         filenames=filenames,
         mmap_filepath=mmap_filepath,
+        resume_interrupted=False,
+        overwrite=False,
     )
 
     # make sure warning is raised if the file already exists
@@ -851,6 +866,8 @@ def test_get_dataset_mmap_file__reuse(
             out_dir=tmp_path,
             filenames=filenames,
             mmap_filepath=mmap_filepath,
+            resume_interrupted=False,
+            overwrite=False,
         )
     assert "Reusing existing memory-mapped file " in caplog.text
     assert list(mmap_filenames_first) == filename_items
@@ -866,6 +883,8 @@ def test_get_dataset__path(tmp_path: Path) -> None:
         num_channels=3,
         mmap_filepath=mmap_filepath,
         out_dir=tmp_path,
+        resume_interrupted=False,
+        overwrite=False,
     )
 
 
@@ -877,6 +896,8 @@ def test_get_dataset__path__nonexisting(tmp_path: Path) -> None:
             num_channels=3,
             mmap_filepath=None,
             out_dir=tmp_path,
+            resume_interrupted=False,
+            overwrite=False,
         )
 
 
@@ -890,6 +911,8 @@ def test_get_dataset__path__nondir(tmp_path: Path) -> None:
             num_channels=3,
             mmap_filepath=None,
             out_dir=tmp_path,
+            resume_interrupted=False,
+            overwrite=False,
         )
 
 
@@ -901,6 +924,8 @@ def test_get_dataset__path__empty(tmp_path: Path) -> None:
             num_channels=3,
             mmap_filepath=None,
             out_dir=tmp_path,
+            resume_interrupted=False,
+            overwrite=False,
         )
 
 
@@ -925,6 +950,8 @@ def test_get_dataset__dirs_and_files(tmp_path: Path) -> None:
         num_channels=3,
         mmap_filepath=mmap_filepath,
         out_dir=tmp_path,
+        resume_interrupted=False,
+        overwrite=False,
     )
 
 
@@ -936,6 +963,8 @@ def test_get_dataset__dataset() -> None:
         num_channels=3,
         mmap_filepath=None,
         out_dir=Path("/tmp"),
+        resume_interrupted=False,
+        overwrite=False,
     )
     assert dataset == dataset_1
 


### PR DESCRIPTION
## What has changed and why?

* Relax checks if run is resumed or overwritten

This should "fix" most occurrences where we raise an error because a mmap file already exists and we don't know whether it is the correct one. It makes the assumption that `resume_interrupted` and `overwrite` are used without changing the underlying data. For `resume_interrupted` this makes always sense because resume doesn't work properly if you change the data anyways. For `overwrite` this makes sense if we assume that overwrite is mostly used during debugging. Proper runs should always use a new directory.


## How has it been tested?

* Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
