### PR TITLE
Update README conference banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://calendly.com/guarin-lightly/miccai">
-  <img width="1373" height="322" alt="Book meeting with Lightly at MICCAI 2025" src="https://github.com/user-attachments/assets/a47ff932-4612-4c66-b104-93dcbffff6fd"/>
+  <a href="https://calendar.app.google/5mqoEnnyacKGzZfw6">
+  <img width="1373" height="322" alt="Book meeting with Lightly at BioTechX 2025 in Basel" src="https://github.com/user-attachments/assets/a47ff932-4612-4c66-b104-93dcbffff6fd"/>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://calendar.app.google/5mqoEnnyacKGzZfw6">
-  <img width="1373" height="322" alt="Book meeting with Lightly at BioTechX 2025 in Basel" src="https://github.com/user-attachments/assets/a47ff932-4612-4c66-b104-93dcbffff6fd"/>
+  <img width="1373" height="322" alt="Book meeting with Lightly at BioTechX 2025 in Basel" src="https://github.com/user-attachments/assets/a798a575-762d-4713-b550-2861b09425ee"/>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://calendar.app.google/5mqoEnnyacKGzZfw6">
-  <img width="1373" height="322" alt="Book meeting with Lightly at BioTechX 2025 in Basel" src="https://github.com/user-attachments/assets/a798a575-762d-4713-b550-2861b09425ee"/>
+  <img width="1373" height="322" alt="Book meeting with Lightly at BioTechX 2025 in Basel" src="https://github.com/user-attachments/assets/00431826-5d4f-4428-b341-104e4fb59e7b"/>
   </a>
 </p>
 


### PR DESCRIPTION
## What has changed and why?
- banner is outdated
- new banner: 
<img width="2037" height="468" alt="output-onlinepngtools" src="https://github.com/user-attachments/assets/00431826-5d4f-4428-b341-104e4fb59e7b" />


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
