### PR TITLE
Use floor operation in determining DINOv2 epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix warning that occurs with default epoch settings in DINOv2.
+
 ## [0.11.3] - 2025-09-25
 
 ### Added

--- a/src/lightly_train/_methods/dinov2/dinov2.py
+++ b/src/lightly_train/_methods/dinov2/dinov2.py
@@ -673,7 +673,7 @@ class DINOv2(Method):
         # Compute dataset-specific epoch recommendation.
         dataset_size = len(self.trainer.train_dataloader.dataset)
         steps_per_epoch = dataset_size // self.global_batch_size
-        recommended_epochs = math.ceil(self.RECOMMENDED_MIN_STEPS / steps_per_epoch)
+        recommended_epochs = math.floor(self.RECOMMENDED_MIN_STEPS / steps_per_epoch)
         total_num_steps = self.trainer.estimated_stepping_batches
 
         # Display recommendation.


### PR DESCRIPTION
## What has changed and why?
- the ceiling operation leads to a warning when using the "auto" epoch setting
- changing to `floor` from `ceil` should fix it
<img width="1703" height="52" alt="Screenshot 2025-10-01 at 17 00 13" src="https://github.com/user-attachments/assets/49f29af0-6046-41c2-a224-36871189f359" />


## How has it been tested?
- not

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
