### PR TITLE
no model name in predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ image_with_boxes = utils.draw_bounding_boxes(
 
 fig, ax = plt.subplots(figsize=(30, 30))
 ax.imshow(image_with_boxes.permute(1, 2, 0))
-fig.savefig(f"predictions_{model.model_name}.png")
+fig.savefig(f"predictions.png")
 ```
 
 </details>


### PR DESCRIPTION
## What has changed and why?
- using the full model name gives an error since `model_name=dinov2/...` will try to create a folder

## How has it been tested?
- manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
