### PR TITLE
Temporarily disable flaky test

### DIFF
--- a/tests/_commands/test_export_task.py
+++ b/tests/_commands/test_export_task.py
@@ -88,11 +88,10 @@ onnx_export_testset = [
     (2, 4, None, None, OnnxPrecision.F32_TRUE),
     (3, 3, 140, None, OnnxPrecision.F16_TRUE),
     (4, 3, None, 28, OnnxPrecision.F16_TRUE),
-    # (4, 4, None, 28, OnnxPrecision.F16_TRUE),  # TODO this test currently fails due to rounding deviations before argmax
+    (4, 4, None, 28, OnnxPrecision.F16_TRUE),
 ]
 
 
-@pytest.mark.skip(reason='Temporarily disabled due to flakiness; see TRN-1610')
 @pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason=("Fails on Windows because of potential memory issues"),
@@ -119,6 +118,9 @@ def test_onnx_export(
     dinov2_vits14_eomt_4_channels_checkpoint: Path,
     tmp_path: Path,
 ) -> None:
+    if num_channels == 4:
+        pytest.skip("Tests with 4 channels are currently flaky")
+
     import onnx
     import onnxruntime as ort
 


### PR DESCRIPTION
This PR disables a test that sometimes fails.

There are two causes:
- One is related to rounding errors and already has an existing issue: https://linear.app/lightly/issue/TRN-1610/verification-logic-for-onnx-export-runs-into-issues-due-to-rounding
- The other is somehow related to Pillow - the cause is not yet clear to me - I will invest a bit of time to investigate and either create a PR or an issue if it is more complicated.