### PR TITLE
Fix failing export tests

### DIFF
--- a/tests/_commands/test_export.py
+++ b/tests/_commands/test_export.py
@@ -83,7 +83,7 @@ def test_export__torch_model(tmp_path: Path) -> None:
             part=part,
             format="torch_model",
         )
-        loaded_model = torch.load(out_path)
+        loaded_model = torch.load(out_path, weights_only=False)
         assert isinstance(loaded_model, type(expected))
         _assert_state_dict_equal(loaded_model.state_dict(), expected.state_dict())
 


### PR DESCRIPTION
## What has changed and why?

Change `weights_only` flag to False in a test to fix a test.

## How has it been tested?

Manual test.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
