### PR TITLE
Fix Torch Version in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ install-latest-3.8:
 # Install package with the latest dependencies for Python 3.12.
 .PHONY: install-latest-3.12
 install-latest-3.12:
-	uv pip install --upgrade --reinstall ${EDITABLE} ".${EXTRAS_PY312}"
+	uv pip install --upgrade --reinstall ${EDITABLE} ".${EXTRAS_PY312}" "torch<2.9.0"
 
 # Install package with same dependencies as for Python 3.12
 .PHONY: install-latest-3.13


### PR DESCRIPTION
## What has changed and why?

This is a follow-up PR for #350 and #362. The failing CI is because we recently removed the upper limit of PyTorch version. It lead the latest dep check to use `torch==2.9.0` released several days ago which caused CI issues. While the weight loading issues was fixed by #362, another issue -- "the `onnxscript` dep used by `torch` is not installed" -- also pops up.

Since `onnxscript` has been a dep of `torch` for some while, I believe there might be something wrong with the latest PyTorch dep configuration, so I limited to `torch==2.8.0` for our latest dep check, which works fine. We can remove the limit once this is fixed.

## How has it been tested?

Passed CI.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
