### PR TITLE
Fix NormalizeArgs from dict

### DIFF
--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -153,10 +153,7 @@ class NormalizeArgs(PydanticConfig):
 
     @classmethod
     def from_dict(cls, config: dict[str, list[float]]) -> NormalizeArgs:
-        return cls(
-            mean=(config["mean"][0], config["mean"][1], config["mean"][2]),
-            std=(config["std"][0], config["std"][1], config["std"][2]),
-        )
+        return cls(mean=tuple(config["mean"]), std=tuple(config["std"]))
 
 
 class ScaleJitterArgs(PydanticConfig):


### PR DESCRIPTION
## What has changed and why?

* Fix NormalizeArgs.from_dict for multi-channel images
