### PR TITLE
Support URLs in predict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "albumentations>=1.3.1,!=1.4.5,!=1.4.9,!=1.4.16,!=1.4.17,!=1.4.18,!=1.4.19,!=1.4.20,!=1.4.21,!=1.4.22,!=1.4.23", # 1.4.18-1.4.22 will cause mypy issues and 1.4.16, 1.4.17 have bugs with albucore, 1.4.9 was yanked, 1.4.5 has a bug with opencv, 1.4.23 has a lot of deprecation warnings
     "eval-type-backport>=0.2",  # Required for Pydantic. Allows 3.10 types in old Python versions.
     "filelock>=3.0.0",     # Cross-platform file locking
+    "fsspec>=2023.1.0",
     "lightly>=1.5.20",
     "omegaconf>=2.3",
     "psutil>=5.0",
@@ -126,6 +127,7 @@ warn_unused_ignores = false
 [[tool.mypy.overrides]]
 module = [
     "albumentations.*",
+    "fsspec.*",
     "lightly.*",
     "lightning_fabric.*",
     "lightning_fabric.loggers.logger",

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -239,8 +239,8 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
 
         Args:
             image:
-                The input image as a path, PIL image, or tensor. Tensors must have shape
-                (C, H, W).
+                The input image as a path, URL, PIL image, or tensor. Tensors must have
+                shape (C, H, W).
 
         Returns:
             The predicted mask as a tensor of shape (H, W). The values represent the

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
@@ -186,8 +186,8 @@ class DINOv2LinearSemanticSegmentation(TaskModel):
 
         Args:
             image:
-                The input image as a path, PIL image, or tensor. Tensors must have shape
-                (C, H, W).
+                The input image as a path, URL, PIL image, or tensor. Tensors must have
+                shape (C, H, W).
 
         Returns:
             The predicted mask as a tensor of shape (H, W). The values represent the

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -233,8 +233,8 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
 
         Args:
             image:
-                The input image as a path, PIL image, or tensor. Tensors must have shape
-                (C, H, W).
+                The input image as a path, URL, PIL image, or tensor. Tensors must have
+                shape (C, H, W).
 
         Returns:
             A {"labels": Tensor, "masks": Tensor, "scores": Tensor} dict. Labels is a

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -248,8 +248,8 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
 
         Args:
             image:
-                The input image as a path, PIL image, or tensor. Tensors must have shape
-                (C, H, W).
+                The input image as a path, URL, PIL image, or tensor. Tensors must have
+                shape (C, H, W).
 
         Returns:
             The predicted mask as a tensor of shape (H, W). The values represent the

--- a/src/lightly_train/_task_models/task_model.py
+++ b/src/lightly_train/_task_models/task_model.py
@@ -77,8 +77,8 @@ class TaskModel(Module):
 
         Args:
             image:
-                The input image as a path, PIL image, or tensor. Tensors must have shape
-                (C, H, W).
+                The input image as a path, URL, PIL image, or tensor. Tensors must have
+                shape (C, H, W).
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
## What has changed and why?

* Support URLs in predict

This improves UX and makes the solution easier to test. I used fsspec because it handles all types of paths/URLs including s3/gcs/azure buckets.

## How has it been tested?

```python
import lightly_train
model = lightly_train.load_model("dinov3/vits16-eomt-coco")
out = model.predict("https://farm6.staticflickr.com/5466/9514492689_8c327cffb3_z.jpg")
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
