### PR TITLE
Add SAT493m models to distillation docs

### DIFF
--- a/docs/source/methods/distillation.md
+++ b/docs/source/methods/distillation.md
@@ -108,9 +108,11 @@ The following models for `teacher` are supported:
   - `dinov3/vits16plus`
   - `dinov3/vitb16`
   - `dinov3/vitl16`
+  - `dinov3/vitl16-sat493m`
   - `dinov3/vitl16plus`
   - `dinov3/vith16plus`
   - `dinov3/vit7b16`
+  - `dinov3/vit7b16-sat493m`
 - DINOv2
   - `dinov2/vits14`
   - `dinov2/vitb14`


### PR DESCRIPTION
## What has changed and why?
- SAT493m DINOv3 checkpoints were not in the docs, see #420 
- This PR adds them.

## How has it been tested?
- not tested, only docs

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
