### PR TITLE
Add `init_weights` to DINOv3 ViT to fix the flaky tests

### DIFF
--- a/tests/_models/dinov3/test_dinov3_vit.py
+++ b/tests/_models/dinov3/test_dinov3_vit.py
@@ -33,7 +33,7 @@ class TestDINOv3ViTModelWrapper:
 
     def test_forward_features(self) -> None:
         model = vit_small()
-        model.init_weights()
+        model.init_weights()  # type: ignore[no-untyped-call]
         feature_extractor = DINOv3ViTModelWrapper(model=model)
 
         x = torch.rand(1, 3, 224, 224)


### PR DESCRIPTION
## What has changed and why?

There is some flakiness in the recent DINOv3 ViT tests which examines whether `cls_token` changes after `.forward_features()`. Sometimes it fails and the `cls_tokens` are identical. The reason is possibly that, unlike DINOv2, DINOv3 `vit_small()` doesn’t call `init_weights()`. The model builder returns a raw `DinoVisionTransformer` with `cls_token` created via `torch.empty` (uninitialized) until `init_weights` is called to make sure the `cls_token` is properly initialized. In the DINOv3 repo, the `init_weights()` is called separately if training from scratch: https://github.com/facebookresearch/dinov3/blob/5aa7e93ab42ae3526291f6b4e3fcd22637e03326/dinov3/train/train.py#L402, but not the case for `vit_small()` etc used for tests in LightlyTrain.

This PR adds `init_weights` to these functions as an attempt to fix the flaky tests.

## How has it been tested?

Running private tests several times.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
