### PR TITLE
add log of best result

### DIFF
--- a/mlruns/0/meta.yaml
+++ b/mlruns/0/meta.yaml
@@ -1,6 +1,0 @@
-artifact_location: file:///Users/masakljun/Documents/git/lightly-train/mlruns/0
-creation_time: 1764235413456
-experiment_id: '0'
-last_update_time: 1764235413456
-lifecycle_stage: active
-name: Default


### PR DESCRIPTION
This PR adds logging of the final best metric at the end of training. The value is written right before the `Training completed `message so the user can see which score was achieved.

I verified the change by running `pytest tests/_commands/test_train_task.py::test_train_semantic_segmentation__checkpoint --log-cli-level=INFO -s`. The logs show that the best result is recorded correctly.
<img width="1428" height="102" alt="Screenshot 2025-11-27 at 14 32 36" src="https://github.com/user-attachments/assets/83047dda-554f-46bd-baaa-e04b769926d4" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
