### PR TITLE
Fix pytest out of disk space

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def lightly_train_cache_dir(
     try:
         yield cache_dir
     finally:
-        # Delete the cache dir after the test. By default, pytest only deletes 
+        # Delete the cache dir after the test. By default, pytest only deletes
         # directories created via tmp_path_factory at the end of the whole test
         # session.
         shutil.rmtree(cache_dir, ignore_errors=True)


### PR DESCRIPTION
## What has changed and why?

* Cleanup per-test ligthly train cache dir after every test instead of after the full test session

## How has it been tested?

* CI

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
