### PR TITLE
Add argument for number of channels and better inference.

### DIFF
--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -700,7 +700,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
 
             # Simplify.
             onnxslim.slim(
-                out_path,
+                str(out_path),
                 output_model=out_path,
             )
 


### PR DESCRIPTION
## What has changed and why?

Fixed wrongly inferred number of channels when exporting object detection models.

## How has it been tested?

Tested by manually exporting convnext-based and vit-based models.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
