### PR TITLE
Add pretrain to API docs

### DIFF
--- a/docs/source/python_api/lightly_train.md
+++ b/docs/source/python_api/lightly_train.md
@@ -9,7 +9,7 @@ Documentation of the public API of the `lightly_train` package.
 ```{eval-rst}
 
 .. automodule:: lightly_train
-    :members: embed, export, export_onnx, list_methods, list_models, load_model, train, train_instance_segmentation, train_object_detection, train_panoptic_segmentation, train_semantic_segmentation
+    :members: embed, export, export_onnx, list_methods, list_models, load_model, pretrain, train, train_instance_segmentation, train_object_detection, train_panoptic_segmentation, train_semantic_segmentation
 
 ```
 


### PR DESCRIPTION
## What has changed and why?

Noticed that the pretrain command was missing from the docs since it was renamed from `train`

## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your test
configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)
