### PR TITLE
Fix dynamic batch sizes for onnx export

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -22,7 +22,7 @@ from torchvision.transforms.v2 import functional as transforms_functional
 
 from lightly_train import _logging, _torch_helpers, _torch_testing
 from lightly_train._data import file_helpers
-from lightly_train._export import tensorrt_helpers
+from lightly_train._export import onnx_helpers, tensorrt_helpers
 from lightly_train._models import package_helpers
 from lightly_train._models.dinov2_vit.dinov2_vit_package import DINOV2_VIT_PACKAGE
 from lightly_train._models.dinov2_vit.dinov2_vit_src.layers.attention import Attention
@@ -668,6 +668,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
         batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         height: int | None = None,
         width: int | None = None,
         opset_version: int | None = None,
@@ -677,10 +678,11 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (batch_size, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph uses dynamic batch size for both inputs and produces
-        three outputs: labels, masks, and scores.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph produces three
+        outputs: labels, masks, and scores.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -694,6 +696,9 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
                 uses the model's current precision.
             batch_size:
                 Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             height:
                 Height of the ONNX input. If None, will be taken from `self.image_size`.
             width:
@@ -739,6 +744,10 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
         width = self.image_size[1] if width is None else width
         num_channels = len(self.image_normalize["mean"])
 
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         dummy_input = torch.randn(
             batch_size,
             num_channels,
@@ -748,6 +757,10 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
             device=model_device,
             dtype=dtype,
         )
+
+        # Precalculate interpolated positional encoding for ONNX export.
+        with onnx_helpers.precalculate_for_onnx_export():
+            self(dummy_input)
 
         input_names = ["images"]
         output_names = ["labels", "masks", "scores"]
@@ -760,7 +773,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
             output_names=output_names,
             opset_version=opset_version,
             dynamo=False,
-            dynamic_axes={"images": {0: "N"}},
+            dynamic_axes=dynamic_axes,
             **(format_args or {}),
         )
 

--- a/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
@@ -23,7 +23,7 @@ from torchvision.transforms.v2 import functional as transforms_functional
 
 from lightly_train import _logging, _torch_helpers, _torch_testing
 from lightly_train._data import file_helpers
-from lightly_train._export import tensorrt_helpers
+from lightly_train._export import onnx_helpers, tensorrt_helpers
 from lightly_train._models import package_helpers
 from lightly_train._models.dinov2_vit.dinov2_vit_package import DINOV2_VIT_PACKAGE
 from lightly_train._models.dinov2_vit.dinov2_vit_src.layers.attention import Attention
@@ -1032,6 +1032,10 @@ class DINOv2EoMTPanopticSegmentation(TaskModel):
             device=model_device,
             dtype=dtype,
         )
+
+        # Precalculate interpolated positional encoding for ONNX export.
+        with onnx_helpers.precalculate_for_onnx_export():
+            self(dummy_input)
 
         input_names = ["images"]
         output_names = ["masks", "segment_ids", "scores"]

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -697,6 +697,7 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
         batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         height: int | None = None,
         width: int | None = None,
         opset_version: int | None = None,
@@ -706,10 +707,11 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (batch_size, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph uses dynamic batch size for both inputs and produces
-        two outputs: masks and logits.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph produces two
+        outputs: masks and logits.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -723,6 +725,9 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
                 uses the model's current precision.
             batch_size:
                 Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             height:
                 Height of the ONNX input. If None, will be taken from `self.image_size`.
             width:
@@ -768,6 +773,10 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
         width = self.image_size[1] if width is None else width
         num_channels = len(self.image_normalize["mean"])
 
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         dummy_input = torch.randn(
             batch_size,
             num_channels,
@@ -793,7 +802,7 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
             output_names=output_names,
             opset_version=opset_version,
             dynamo=False,
-            dynamic_axes={"images": {0: "N"}},
+            dynamic_axes=dynamic_axes,
             **(format_args or {}),
         )
 

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
@@ -242,6 +242,7 @@ class DINOv2LinearSemanticSegmentation(TaskModel):
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         # Function used for ONNX export
+        # TODO (Simon, 05/26) This class does not seem to have an export_onnx function
         logits = self._forward_logits(x)  # (B, K|K+1, H, W), K=num_classes
         if self.class_ignore_index is not None:
             # Restrict logits to known classes only.

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
@@ -817,6 +817,7 @@ class DINOv2LTDETRObjectDetection(TaskModel):
         self, x: Tensor, orig_target_size: Tensor | None = None
     ) -> tuple[Tensor, Tensor, Tensor]:
         # Function used for ONNX export
+        # TODO (Simon, 05/26) This class does not seem to have an export_onnx function
         if orig_target_size is None:
             h, w = x.shape[-2:]
             orig_target_size_ = torch.tensor([[w, h]]).to(x.device)

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -630,6 +630,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
         batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         height: int | None = None,
         width: int | None = None,
         opset_version: int | None = None,
@@ -639,10 +640,11 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (batch_size, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph uses dynamic batch size for both inputs and produces
-        three outputs: labels, masks, and scores.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph produces three
+        outputs: labels, masks, and scores.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -656,6 +658,9 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
                 uses the model's current precision.
             batch_size:
                 Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             height:
                 Height of the ONNX input. If None, will be taken from `self.image_size`.
             width:
@@ -701,6 +706,12 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
         width = self.image_size[1] if width is None else width
         num_channels = len(self.image_normalize["mean"])
 
+        # if the batch size is dynamic the dummy input must have multiple batches
+        # as torch might still think the batch size is one
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         dummy_input = torch.randn(
             batch_size,
             num_channels,
@@ -722,7 +733,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
             output_names=output_names,
             opset_version=opset_version,
             dynamo=False,
-            dynamic_axes={"images": {0: "N"}},
+            dynamic_axes=dynamic_axes,
             **(format_args or {}),
         )
 

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -675,6 +675,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
         batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         height: int | None = None,
         width: int | None = None,
         opset_version: int | None = None,
@@ -684,10 +685,11 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (batch_size, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph uses dynamic batch size for both inputs and produces
-        two outputs: masks and logits.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph produces two
+        outputs: masks and logits.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -701,6 +703,9 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
                 uses the model's current precision.
             batch_size:
                 Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             height:
                 Height of the ONNX input. If None, will be taken from `self.image_size`.
             width:
@@ -746,6 +751,10 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         width = self.image_size[1] if width is None else width
         num_channels = len(self.image_normalize["mean"])
 
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         dummy_input = torch.randn(
             batch_size,
             num_channels,
@@ -767,7 +776,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
             output_names=output_names,
             opset_version=opset_version,
             dynamo=False,
-            dynamic_axes={"images": {0: "N"}},
+            dynamic_axes=dynamic_axes,
             **(format_args or {}),
         )
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -971,6 +971,8 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         out: PathLike,
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
+        batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         opset_version: int | None = None,
         simplify: bool = True,
         verify: bool = True,
@@ -979,10 +981,11 @@ class DINOv3LTDETRObjectDetection(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (1, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph uses dynamic batch size for both inputs and produces
-        three outputs: labels, boxes, and scores.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph produces three
+        outputs: labels, boxes, and scores.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -994,6 +997,11 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             precision:
                 Precision for the ONNX model. Either "auto", "fp32", or "fp16". "auto"
                 uses the model's current precision.
+            batch_size:
+                Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             opset_version:
                 ONNX opset version to target. If None, PyTorch's default opset is used.
             simplify:
@@ -1062,9 +1070,13 @@ class DINOv3LTDETRObjectDetection(TaskModel):
                         "num_channels must be provided for ONNX export if it cannot be inferred."
                     )
 
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         # Create dummy input using same device and dtype as the model.
         dummy_input = torch.randn(
-            1,
+            batch_size,
             num_channels,
             self.image_size[
                 0
@@ -1089,9 +1101,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             output_names=output_names,
             opset_version=opset_version,
             dynamo=False,
-            dynamic_axes={
-                "images": {0: "N"}
-            },  # TODO(Thomas, 12/25): Add dynamic axes for H and W.
+            dynamic_axes=dynamic_axes,
             **(format_args or {}),
         )
 

--- a/src/lightly_train/_task_models/image_classification/task_model.py
+++ b/src/lightly_train/_task_models/image_classification/task_model.py
@@ -366,6 +366,7 @@ class ImageClassification(TaskModel):
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
         batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         height: int | None = None,
         width: int | None = None,
         opset_version: int | None = None,
@@ -375,10 +376,11 @@ class ImageClassification(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (batch_size, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph uses dynamic batch size for both inputs and produces
-        two outputs: labels and scores.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph produces two
+        outputs: labels and scores.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -392,6 +394,9 @@ class ImageClassification(TaskModel):
                 uses the model's current precision.
             batch_size:
                 Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             height:
                 Height of the ONNX input. If None, will be taken from `self.image_size`.
             width:
@@ -439,6 +444,10 @@ class ImageClassification(TaskModel):
             3 if self.image_normalize is None else len(self.image_normalize["mean"])
         )
 
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         dummy_input = torch.randn(
             batch_size,
             num_channels,
@@ -464,7 +473,7 @@ class ImageClassification(TaskModel):
             output_names=output_names,
             opset_version=opset_version,
             dynamo=False,
-            dynamic_axes={"images": {0: "N"}},
+            dynamic_axes=dynamic_axes,
             **(format_args or {}),
         )
 

--- a/src/lightly_train/_task_models/picodet_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/task_model.py
@@ -528,6 +528,8 @@ class PicoDetObjectDetection(TaskModel):
         out: PathLike,
         *,
         precision: Literal["auto", "fp32", "fp16"] = "auto",
+        batch_size: int = 1,
+        dynamic_batch_size: bool = True,
         opset_version: int | None = None,
         simplify: bool = True,
         verify: bool = True,
@@ -536,9 +538,11 @@ class PicoDetObjectDetection(TaskModel):
     ) -> None:
         """Exports the model to ONNX for inference.
 
-        The export uses a dummy input of shape (1, C, H, W) where C is inferred
-        from the first model parameter and (H, W) come from `self.image_size`.
-        The ONNX graph outputs labels, boxes, and scores.
+        The export uses a dummy input of shape (batch_size, C, H, W) where C is
+        inferred from the first model parameter and (H, W) come from
+        `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
+        have a dynamic batch dimension for the input. The graph outputs labels,
+        boxes, and scores.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -550,6 +554,11 @@ class PicoDetObjectDetection(TaskModel):
             precision:
                 Precision for the ONNX model. Either "auto", "fp32", or "fp16". "auto"
                 uses the model's current precision.
+            batch_size:
+                Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                input. If False, the batch dimension is fixed to `batch_size`.
             opset_version:
                 ONNX opset version to target. If None, PyTorch's default opset is used.
             simplify:
@@ -606,8 +615,12 @@ class PicoDetObjectDetection(TaskModel):
                         "num_channels must be provided for ONNX export if it cannot be inferred."
                     )
 
+        if dynamic_batch_size:
+            batch_size = 2
+        dynamic_axes = {"images": {0: "N"}} if dynamic_batch_size else None
+
         dummy_input = torch.randn(
-            1,
+            batch_size,
             num_channels,
             self.image_size[0],
             self.image_size[1],
@@ -638,7 +651,7 @@ class PicoDetObjectDetection(TaskModel):
             "input_names": input_names,
             "output_names": output_names,
             "opset_version": opset_version,
-            "dynamic_axes": {"images": {0: "N"}},
+            "dynamic_axes": dynamic_axes,
             **(format_args or {}),
         }
         torch_version = version.parse(torch.__version__.split("+", 1)[0])

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/__init__.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.dinov2_eomt_instance_segmentation.task_model import (
+    DINOv2EoMTInstanceSegmentation,
+)
+
+
+@pytest.fixture()
+def model() -> DINOv2EoMTInstanceSegmentation:
+    return DINOv2EoMTInstanceSegmentation(
+        model_name="dinov2/_vittest14-eomt",
+        classes={0: "background", 1: "car"},
+        image_size=(14, 14),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        num_queries=2,
+        num_joint_blocks=1,
+        load_weights=False,
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx(model: DINOv2EoMTInstanceSegmentation, tmp_path: Path) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 14, 14).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(
+    model: DINOv2EoMTInstanceSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
@@ -34,7 +34,9 @@ def model() -> DINOv2EoMTInstanceSegmentation:
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
 )
-def test_export_onnx(model: DINOv2EoMTInstanceSegmentation, tmp_path: Path) -> None:
+def test_export_onnx__dynamic_batch_size(
+    model: DINOv2EoMTInstanceSegmentation, tmp_path: Path
+) -> None:
     import numpy as np
     import onnx
     import onnxruntime as ort

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
@@ -46,9 +46,23 @@ def test_export_onnx(model: DINOv2EoMTInstanceSegmentation, tmp_path: Path) -> N
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    import torch
+
     inputs = np.random.randn(3, 3, 14, 14).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+
+    with torch.no_grad():
+        torch_outputs = model(torch.from_numpy(inputs))
+
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        if torch_out.is_floating_point():
+            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
+            assert close.float().mean() > 0.95
+        else:
+            assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/dinov2_eomt_panoptic_segmentation/__init__.py
+++ b/tests/_task_models/dinov2_eomt_panoptic_segmentation/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+

--- a/tests/_task_models/dinov2_eomt_panoptic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_panoptic_segmentation/test_task_model.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.dinov2_eomt_panoptic_segmentation.task_model import (
+    DINOv2EoMTPanopticSegmentation,
+)
+
+
+@pytest.fixture()
+def model() -> DINOv2EoMTPanopticSegmentation:
+    return DINOv2EoMTPanopticSegmentation(
+        model_name="dinov2/_vittest14-eomt",
+        thing_classes={0: "car", 1: "person"},
+        stuff_classes={2: "sky", 3: "road"},
+        image_size=(14, 14),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        num_queries=2,
+        num_joint_blocks=1,
+        load_weights=False,
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx(model: DINOv2EoMTPanopticSegmentation, tmp_path: Path) -> None:
+    import onnx
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    output_names = [o.name for o in onnx_model.graph.output]
+    assert "masks" in output_names
+    assert "segment_ids" in output_names
+    assert "scores" in output_names

--- a/tests/_task_models/dinov2_eomt_semantic_segmentation/__init__.py
+++ b/tests/_task_models/dinov2_eomt_semantic_segmentation/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
@@ -49,9 +49,23 @@ def test_export_onnx__dynamic_batch_size(
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    import torch
+
     inputs = np.random.randn(3, 3, 14, 14).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+
+    with torch.no_grad():
+        torch_outputs = model(torch.from_numpy(inputs))
+
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        if torch_out.is_floating_point():
+            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
+            assert close.float().mean() > 0.95
+        else:
+            assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
@@ -1,0 +1,78 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.dinov2_eomt_semantic_segmentation.task_model import (
+    DINOv2EoMTSemanticSegmentation,
+)
+
+
+@pytest.fixture()
+def model() -> DINOv2EoMTSemanticSegmentation:
+    return DINOv2EoMTSemanticSegmentation(
+        model_name="dinov2/_vittest14-eomt",
+        classes={0: "background", 1: "car"},
+        class_ignore_index=None,
+        image_size=(14, 14),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        num_queries=2,
+        num_joint_blocks=1,
+        load_weights=False,
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(
+    model: DINOv2EoMTSemanticSegmentation, tmp_path: Path
+) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, dynamic_batch_size=True, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 14, 14).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(
+    model: DINOv2EoMTSemanticSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__custom_height_width(
+    model: DINOv2EoMTSemanticSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, height=28, width=42, simplify=False, verify=True)

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/__init__.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.dinov3_eomt_instance_segmentation.task_model import (
+    DINOv3EoMTInstanceSegmentation,
+)
+
+
+@pytest.fixture()
+def model() -> DINOv3EoMTInstanceSegmentation:
+    return DINOv3EoMTInstanceSegmentation(
+        model_name="dinov3/_vittest16-eomt",
+        classes={0: "background", 1: "car"},
+        image_size=(16, 16),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        num_queries=2,
+        num_joint_blocks=1,
+        load_weights=False,
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(
+    model: DINOv3EoMTInstanceSegmentation, tmp_path: Path
+) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, dynamic_batch_size=True, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 16, 16).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.xfail(
+    strict=True, reason="dinov3 ONNX export shape mismatch with static batch size"
+)
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(
+    model: DINOv3EoMTInstanceSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__custom_height_width(
+    model: DINOv3EoMTInstanceSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, height=32, width=48, simplify=False, verify=True)

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -48,9 +48,23 @@ def test_export_onnx__dynamic_batch_size(
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    import torch
+
     inputs = np.random.randn(3, 3, 16, 16).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+
+    with torch.no_grad():
+        torch_outputs = model(torch.from_numpy(inputs))
+
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        if torch_out.is_floating_point():
+            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
+            assert close.float().mean() > 0.95
+        else:
+            assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
 @pytest.mark.xfail(

--- a/tests/_task_models/dinov3_eomt_panoptic_segmentation/__init__.py
+++ b/tests/_task_models/dinov3_eomt_panoptic_segmentation/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+

--- a/tests/_task_models/dinov3_eomt_panoptic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_panoptic_segmentation/test_task_model.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.dinov3_eomt_panoptic_segmentation.task_model import (
+    DINOv3EoMTPanopticSegmentation,
+)
+
+
+@pytest.fixture()
+def model() -> DINOv3EoMTPanopticSegmentation:
+    return DINOv3EoMTPanopticSegmentation(
+        model_name="dinov3/_vittest16-eomt",
+        thing_classes={0: "car", 1: "person"},
+        stuff_classes={2: "sky", 3: "road"},
+        image_size=(16, 16),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        num_queries=2,
+        num_joint_blocks=1,
+        load_weights=False,
+    )
+
+
+@pytest.mark.xfail(strict=True, reason="dinov3 ONNX export shape mismatch")
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx(model: DINOv3EoMTPanopticSegmentation, tmp_path: Path) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+
+@pytest.mark.xfail(strict=True, reason="dinov3 ONNX export shape mismatch")
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__custom_height_width(
+    model: DINOv3EoMTPanopticSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, height=32, width=48, simplify=False, verify=True)

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/__init__.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -49,9 +49,23 @@ def test_export_onnx__dynamic_batch_size(
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    import torch
+
     inputs = np.random.randn(3, 3, 16, 16).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+
+    with torch.no_grad():
+        torch_outputs = model(torch.from_numpy(inputs))
+
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        if torch_out.is_floating_point():
+            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
+            assert close.float().mean() > 0.95
+        else:
+            assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
 @pytest.mark.xfail(

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model import (
+    DINOv3EoMTSemanticSegmentation,
+)
+
+
+@pytest.fixture()
+def model() -> DINOv3EoMTSemanticSegmentation:
+    return DINOv3EoMTSemanticSegmentation(
+        model_name="dinov3/_vittest16-eomt",
+        classes={0: "background", 1: "car"},
+        class_ignore_index=None,
+        image_size=(16, 16),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        num_queries=2,
+        num_joint_blocks=1,
+        load_weights=False,
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(
+    model: DINOv3EoMTSemanticSegmentation, tmp_path: Path
+) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, dynamic_batch_size=True, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 16, 16).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.xfail(
+    strict=True, reason="dinov3 ONNX export shape mismatch with static batch size"
+)
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(
+    model: DINOv3EoMTSemanticSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )
+
+
+@pytest.mark.xfail(strict=True, reason="dinov3 ONNX export shape mismatch")
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__custom_height_width(
+    model: DINOv3EoMTSemanticSegmentation, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, height=32, width=48, simplify=False, verify=True)

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -199,9 +199,23 @@ def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    import torch
+
     inputs = np.random.randn(3, 3, 256, 256).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+
+    with torch.no_grad():
+        torch_outputs = model(torch.from_numpy(inputs))
+
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        if torch_out.is_floating_point():
+            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
+            assert close.float().mean() > 0.95
+        else:
+            assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Literal
 
 import pytest
+from lightning_utilities.core.imports import RequirementCache
 from torch import nn
 from torch.optim.lr_scheduler import LinearLR
 
@@ -19,6 +20,9 @@ from lightly_train._data.yolo_object_detection_dataset import (
     YOLOObjectDetectionDataArgs,
 )
 from lightly_train._metrics.detection.task_metric import ObjectDetectionTaskMetricArgs
+from lightly_train._task_models.dinov3_ltdetr_object_detection.task_model import (
+    DINOv3LTDETRObjectDetection,
+)
 from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model import (
     DINOv3LTDETRObjectDetectionTrain,
     DINOv3LTDETRObjectDetectionTrainArgs,
@@ -170,3 +174,49 @@ def test_get_optimizer__linear_warns_when_warmup_exceeds_training(
         train_model.get_optimizer(total_steps=1000, global_batch_size=16)
 
     assert "the schedule will not complete as intended" in caplog.text
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    model = DINOv3LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "car", 1: "person"},
+        image_size=(256, 256),
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 256, 256).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(tmp_path: Path) -> None:
+    model = DINOv3LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "car", 1: "person"},
+        image_size=(256, 256),
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )

--- a/tests/_task_models/image_classification/__init__.py
+++ b/tests/_task_models/image_classification/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+

--- a/tests/_task_models/image_classification/test_task_model.py
+++ b/tests/_task_models/image_classification/test_task_model.py
@@ -1,0 +1,77 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._task_models.image_classification.task_model import (
+    ImageClassification,
+)
+
+
+@pytest.fixture()
+def model() -> ImageClassification:
+    return ImageClassification(
+        model="dinov2/_vittest14",
+        classes={0: "cat", 1: "dog"},
+        classification_task="multiclass",
+        image_size=(14, 14),
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        backbone_freeze=False,
+        load_weights=False,
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(
+    model: ImageClassification, tmp_path: Path
+) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 14, 14).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(
+    model: ImageClassification, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__custom_height_width(
+    model: ImageClassification, tmp_path: Path
+) -> None:
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, height=28, width=42, simplify=False, verify=True)

--- a/tests/_task_models/image_classification/test_task_model.py
+++ b/tests/_task_models/image_classification/test_task_model.py
@@ -48,9 +48,23 @@ def test_export_onnx__dynamic_batch_size(
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    import torch
+
     inputs = np.random.randn(3, 3, 14, 14).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+
+    with torch.no_grad():
+        torch_outputs = model(torch.from_numpy(inputs))
+
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        if torch_out.is_floating_point():
+            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
+            assert close.float().mean() > 0.95
+        else:
+            assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/picodet_object_detection/test_task_model.py
+++ b/tests/_task_models/picodet_object_detection/test_task_model.py
@@ -72,6 +72,9 @@ def test_task_model_forward_shapes() -> None:
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
 def test_export_onnx_has_no_nms(tmp_path: Path) -> None:
     import onnx
 

--- a/tests/_task_models/picodet_object_detection/test_task_model.py
+++ b/tests/_task_models/picodet_object_detection/test_task_model.py
@@ -91,6 +91,52 @@ def test_export_onnx_has_no_nms(tmp_path: Path) -> None:
     assert "If" not in op_types
 
 
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
+    import numpy as np
+    import onnx
+    import onnxruntime as ort
+
+    model = PicoDetObjectDetection(
+        model_name="picodet/s-416",
+        image_size=(416, 416),
+        num_classes=80,
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    inputs = np.random.randn(3, 3, 416, 416).astype(np.float32)
+    session.run(None, {"images": inputs})
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(tmp_path: Path) -> None:
+    model = PicoDetObjectDetection(
+        model_name="picodet/s-416",
+        image_size=(416, 416),
+        num_classes=80,
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )
+
+
 def _is_module_frozen(m: nn.Module) -> bool:
     return all(not param.requires_grad for param in m.parameters())
 

--- a/tests/_task_models/picodet_object_detection/test_task_model.py
+++ b/tests/_task_models/picodet_object_detection/test_task_model.py
@@ -83,7 +83,7 @@ def test_export_onnx_has_no_nms(tmp_path: Path) -> None:
     )
 
     out = tmp_path / "picodet.onnx"
-    model.export_onnx(out=out, simplify=False, verify=False)
+    model.export_onnx(out=out, simplify=False, verify=True)
 
     onnx_model = onnx.load(out)
     op_types = {node.op_type for node in onnx_model.graph.node}
@@ -114,9 +114,21 @@ def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
-    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
     inputs = np.random.randn(3, 3, 416, 416).astype(np.float32)
-    session.run(None, {"images": inputs})
+
+    session = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_outputs = session.run(None, {"images": inputs})
+    onnx_labels, onnx_boxes, onnx_scores = (torch.from_numpy(o) for o in onnx_outputs)
+
+    with torch.no_grad():
+        boxes, obj_logits, cls_logits = model(torch.from_numpy(inputs))
+        scores = torch.sigmoid(obj_logits)
+
+    assert onnx_labels.shape == (3, boxes.shape[1])
+    close_boxes = torch.isclose(onnx_boxes, boxes, atol=2e-2, rtol=1e-1)
+    assert close_boxes.float().mean() > 0.95
+    close_scores = torch.isclose(onnx_scores, scores, atol=2e-2, rtol=1e-1)
+    assert close_scores.float().mean() > 0.95
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")


### PR DESCRIPTION
## What has changed and why?

The previous code did not handle dynamic batch sizes correctly, this PR intends to change that. In particular:

- If the batch size is dyamic, we should always run it with a dummy tensor of size > 1 as otherwise PyTorch might incorrectly think the batch size is not dynamic, even if we told the model so.
- We should ensure that one can always avoid dynamic batch sizes, as non-dynamic models tend to be faster.

Furthermore:
- Added the `onnx_helpers.precalculate_for_onnx_export` function in some places as this helps to avoid a bug where positional encodings differ when exporting to ONNX.
- I discovered some issues with the ONNX export in `DINOv3EoMTSemanticSegmentation` - I've added some failing tests that we should resolve in a future issue.

## How has it been tested?

Added a lot of tests as coverage was lacking before.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
