### PR TITLE
Skip slow multihead test on windows

### DIFF
--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -117,6 +117,7 @@ def test_train_image_classification__multilabel(tmp_path: Path) -> None:
     assert results["scores"].shape == (3,)
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
 def test_train_image_classification_multihead(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What has changed and why?

Skip test that takes >1h on windows:
```
4001.27s call     tests/_commands/test_train_task.py::test_train_image_classification_multihead
```
See: https://github.com/lightly-ai/lightly-train/actions/runs/22724970356/job/65897413283


## How has it been tested?

(Delete this: Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your test
configuration.)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
