### PR TITLE
Improve loss running window handling

### DIFF
--- a/src/lightly_train/_metrics/classification/task_metric.py
+++ b/src/lightly_train/_metrics/classification/task_metric.py
@@ -101,7 +101,7 @@ class ClassificationTaskMetric(TaskMetric):
         split: str,
         class_names: Sequence[str],
         loss_names: Sequence[str],
-        train_loss_running_mean_window: int,
+        train_loss_running_mean_window: int | None = None,
         init_metrics: bool | None = None,
     ) -> None:
         """Initialize classification metrics container.
@@ -113,6 +113,7 @@ class ClassificationTaskMetric(TaskMetric):
             loss_names: Names of losses to track
             train_loss_running_mean_window:
                 Window size for the running mean of training losses.
+                Required when split == "train", ignored for other splits.
             init_metrics:
                 Whether to initialize metrics. If None, uses task_metric_args.train
                 for the train split and True for other splits.

--- a/src/lightly_train/_metrics/detection/task_metric.py
+++ b/src/lightly_train/_metrics/detection/task_metric.py
@@ -45,7 +45,7 @@ class ObjectDetectionTaskMetric(TaskMetric):
         class_names: Sequence[str],
         box_format: Literal["xyxy", "xywh", "cxcywh"],
         loss_names: Sequence[str],
-        train_loss_running_mean_window: int,
+        train_loss_running_mean_window: int | None = None,
         init_metrics: bool | None = None,
     ) -> None:
         """Initialize object detection metrics container.
@@ -58,6 +58,7 @@ class ObjectDetectionTaskMetric(TaskMetric):
             loss_names: Names of losses to track
             train_loss_running_mean_window:
                 Window size for the running mean of training losses.
+                Required when split == "train", ignored for other splits.
             init_metrics:
                 Whether to initialize metrics. If None, uses task_metric_args.train
                 for the train split and True for other splits.

--- a/src/lightly_train/_metrics/instance_segmentation/task_metric.py
+++ b/src/lightly_train/_metrics/instance_segmentation/task_metric.py
@@ -46,7 +46,7 @@ class InstanceSegmentationTaskMetric(TaskMetric):
         split: str,
         class_names: Sequence[str],
         loss_names: Sequence[str],
-        train_loss_running_mean_window: int,
+        train_loss_running_mean_window: int | None = None,
         init_metrics: bool | None = None,
     ) -> None:
         """Initialize instance segmentation metrics container.
@@ -58,6 +58,7 @@ class InstanceSegmentationTaskMetric(TaskMetric):
             loss_names: Names of losses to track
             train_loss_running_mean_window:
                 Window size for the running mean of training losses.
+                Required when split == "train", ignored for other splits.
             init_metrics:
                 Whether to initialize metrics. If None, uses task_metric_args.train
                 for the train split and True for other splits.

--- a/src/lightly_train/_metrics/loss_metric_collection.py
+++ b/src/lightly_train/_metrics/loss_metric_collection.py
@@ -17,7 +17,10 @@ class LossMetricCollection(Module):
     """Tracks a collection of loss metrics, one for each loss name."""
 
     def __init__(
-        self, split: str, loss_names: Sequence[str], train_loss_running_mean_window: int
+        self,
+        split: str,
+        loss_names: Sequence[str],
+        train_loss_running_mean_window: int | None = None,
     ) -> None:
         """Create a LossMetricCollection.
 
@@ -33,6 +36,7 @@ class LossMetricCollection(Module):
                 This is used to smooth the training loss metric. You want to set this to
                 the same value as the gradient_accumulation_steps to get a stable training
                 loss metric that reflects the actual optimization steps.
+                Required when split == "train", ignored for other splits.
         """
         from torchmetrics import MeanMetric as TorchmetricsMeanMetric
         from torchmetrics import Metric as TorchmetricsMetric
@@ -42,6 +46,10 @@ class LossMetricCollection(Module):
 
         metric_cls: Callable[[], TorchmetricsMetric]
         if split == "train":
+            if train_loss_running_mean_window is None:
+                raise ValueError(
+                    "train_loss_running_mean_window must be specified for train split"
+                )
             try:
                 from torchmetrics.wrappers import (
                     Running as TorchmetricsRunning,  # type: ignore[attr-defined]

--- a/src/lightly_train/_metrics/panoptic_segmentation/task_metric.py
+++ b/src/lightly_train/_metrics/panoptic_segmentation/task_metric.py
@@ -46,7 +46,7 @@ class PanopticSegmentationTaskMetric(TaskMetric):
         thing_class_names: Sequence[str],
         stuff_class_names: Sequence[str],
         loss_names: Sequence[str],
-        train_loss_running_mean_window: int,
+        train_loss_running_mean_window: int | None = None,
         init_metrics: bool | None = None,
     ) -> None:
         """Initialize panoptic segmentation metrics container.
@@ -61,6 +61,7 @@ class PanopticSegmentationTaskMetric(TaskMetric):
             loss_names: Names of losses to track
             train_loss_running_mean_window:
                 Window size for the running mean of training losses.
+                Required when split == "train", ignored for other splits.
             init_metrics:
                 Whether to initialize metrics. If None, uses task_metric_args.train
                 for the train split and True for other splits.

--- a/src/lightly_train/_metrics/semantic_segmentation/task_metric.py
+++ b/src/lightly_train/_metrics/semantic_segmentation/task_metric.py
@@ -47,7 +47,7 @@ class SemanticSegmentationTaskMetric(TaskMetric):
         class_names: Sequence[str],
         ignore_index: int | None,
         loss_names: Sequence[str],
-        train_loss_running_mean_window: int,
+        train_loss_running_mean_window: int | None = None,
         init_metrics: bool | None = None,
     ) -> None:
         """Initialize semantic segmentation metrics container.
@@ -60,6 +60,7 @@ class SemanticSegmentationTaskMetric(TaskMetric):
             loss_names: Names of losses to track
             train_loss_running_mean_window:
                 Window size for the running mean of training losses.
+                Required when split == "train", ignored for other splits.
             init_metrics:
                 Whether to initialize metrics. If None, uses task_metric_args.train
                 for the train split and True for other splits.

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
@@ -219,7 +219,6 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
             split="val",
             class_names=list(data_args.included_classes.values()),
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
         self.train_metrics = InstanceSegmentationTaskMetric(

--- a/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/train_model.py
@@ -262,7 +262,6 @@ class DINOv2EoMTPanopticSegmentationTrain(TrainModel):
             thing_class_names=list(data_args.thing_classes.values()),
             stuff_class_names=list(data_args.stuff_classes.values()) + ["ignore"],
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
         _torch_helpers.register_load_state_dict_pre_hook(

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -239,7 +239,6 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
             class_names=list(data_args.included_classes.values()),
             ignore_index=data_args.ignore_index,
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
         _torch_helpers.register_load_state_dict_pre_hook(

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/train_model.py
@@ -140,7 +140,6 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
             class_names=class_names,
             ignore_index=data_args.ignore_index,
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
     def get_task_model(self) -> DINOv2LinearSemanticSegmentation:

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -208,7 +208,6 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             class_names=class_names,
             box_format="xyxy",
             loss_names=self.loss_names,
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
     def load_train_state_dict(

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -232,7 +232,6 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
             split="val",
             class_names=list(data_args.included_classes.values()),
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
         _torch_helpers.register_load_state_dict_pre_hook(

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/train_model.py
@@ -273,7 +273,6 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
             thing_class_names=list(data_args.thing_classes.values()),
             stuff_class_names=list(data_args.stuff_classes.values()) + ["ignore"],
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
         _torch_helpers.register_load_state_dict_pre_hook(

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
@@ -265,7 +265,6 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
             class_names=list(data_args.included_classes.values()),
             ignore_index=data_args.ignore_index,
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
         _torch_helpers.register_load_state_dict_pre_hook(

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -207,7 +207,6 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             class_names=class_names,
             box_format="xyxy",
             loss_names=self.loss_names,
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
     def load_train_state_dict(

--- a/src/lightly_train/_task_models/image_classification/train_model.py
+++ b/src/lightly_train/_task_models/image_classification/train_model.py
@@ -158,7 +158,6 @@ class ImageClassificationTrain(TrainModel):
             split="val",
             class_names=list(data_args.included_classes.values()),
             loss_names=["loss"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
         self.train_metrics = ClassificationTaskMetric(
             task_metric_args=metric_args,

--- a/src/lightly_train/_task_models/image_classification_multihead/train_model.py
+++ b/src/lightly_train/_task_models/image_classification_multihead/train_model.py
@@ -170,7 +170,6 @@ class ImageClassificationMultiheadTrain(TrainModel):
                 split="val",
                 class_names=class_names,
                 loss_names=["loss"],
-                train_loss_running_mean_window=gradient_accumulation_steps,
             )
         self.val_metrics: MultiheadTaskMetric = MultiheadTaskMetric(
             head_metrics=val_head_metrics,

--- a/src/lightly_train/_task_models/picodet_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/train_model.py
@@ -213,7 +213,6 @@ class PicoDetObjectDetectionTrain(TrainModel):
             class_names=class_names,
             box_format="xyxy",
             loss_names=["loss", "loss_vfl", "loss_giou", "loss_dfl"],
-            train_loss_running_mean_window=gradient_accumulation_steps,
         )
 
     def set_train_mode(self) -> None:

--- a/src/lightly_train/_task_models/semantic_segmentation_multihead/train_model.py
+++ b/src/lightly_train/_task_models/semantic_segmentation_multihead/train_model.py
@@ -156,7 +156,6 @@ class SemanticSegmentationMultiheadTrain(TrainModel):
                 class_names=class_names,
                 ignore_index=ignore_index,
                 loss_names=["loss"],
-                train_loss_running_mean_window=gradient_accumulation_steps,
             )
         self.train_metrics: MultiheadTaskMetric = MultiheadTaskMetric(
             head_metrics=train_head_metrics,

--- a/tests/_metrics/classification/test_task_metric.py
+++ b/tests/_metrics/classification/test_task_metric.py
@@ -32,7 +32,6 @@ class TestClassificationTaskMetric:
             split="val",
             class_names=["cat", "dog", "bird"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.tensor([[0.8, 0.1, 0.1], [0.1, 0.7, 0.2]])
         target = torch.tensor([0, 1])
@@ -54,7 +53,6 @@ class TestClassificationTaskMetric:
             split="val",
             class_names=["cat", "dog", "bird"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.tensor([[0.8, 0.5, 0.1], [0.1, 0.7, 0.2]])
         target = torch.tensor([[1, 1, 0], [0, 1, 1]])
@@ -77,7 +75,6 @@ class TestClassificationTaskMetric:
             split="val",
             class_names=["cat", "dog", "bird"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.tensor([[0.8, 0.1, 0.1], [0.1, 0.7, 0.2]])
         target = torch.tensor([0, 1])

--- a/tests/_metrics/detection/test_task_metric.py
+++ b/tests/_metrics/detection/test_task_metric.py
@@ -32,7 +32,6 @@ class TestObjectDetectionTaskMetric:
             class_names=["cat", "dog"],
             box_format="xyxy",
             loss_names=["loss", "loss_vfl", "loss_bbox", "loss_giou"],
-            train_loss_running_mean_window=1,
         )
         metric.update_with_predictions(
             preds=[
@@ -86,7 +85,6 @@ class TestObjectDetectionTaskMetric:
             class_names=["cat", "dog"],
             box_format="xyxy",
             loss_names=["loss", "loss_vfl", "loss_bbox", "loss_giou"],
-            train_loss_running_mean_window=1,
         )
         metric.update_with_predictions(
             preds=[

--- a/tests/_metrics/instance_segmentation/test_task_metric.py
+++ b/tests/_metrics/instance_segmentation/test_task_metric.py
@@ -31,7 +31,6 @@ class TestInstanceSegmentationTaskMetric:
             split="val",
             class_names=["cat", "dog"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         metric.update_with_predictions(
             preds=[
@@ -73,7 +72,6 @@ class TestInstanceSegmentationTaskMetric:
             split="val",
             class_names=["cat", "dog"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         metric.update_with_predictions(
             preds=[

--- a/tests/_metrics/panoptic_segmentation/test_task_metric.py
+++ b/tests/_metrics/panoptic_segmentation/test_task_metric.py
@@ -33,7 +33,6 @@ class TestPanopticSegmentationTaskMetric:
             thing_class_names=["cat", "dog"],
             stuff_class_names=["road"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.randint(0, 3, (1, 10, 10, 2), dtype=torch.int32)
         target = torch.randint(0, 3, (1, 10, 10, 2), dtype=torch.int32)
@@ -55,7 +54,6 @@ class TestPanopticSegmentationTaskMetric:
             thing_class_names=["cat", "dog"],
             stuff_class_names=["road", "ignore"],
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.randint(0, 3, (1, 10, 10, 2), dtype=torch.int32)
         target = torch.randint(0, 3, (1, 10, 10, 2), dtype=torch.int32)

--- a/tests/_metrics/semantic_segmentation/test_task_metric.py
+++ b/tests/_metrics/semantic_segmentation/test_task_metric.py
@@ -32,7 +32,6 @@ class TestSemanticSegmentationTaskMetric:
             class_names=["cat", "dog"],
             ignore_index=None,
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.zeros(2, 10, 10, dtype=torch.long)
         target = torch.zeros(2, 10, 10, dtype=torch.long)
@@ -52,7 +51,6 @@ class TestSemanticSegmentationTaskMetric:
             class_names=["cat", "dog"],
             ignore_index=255,
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.zeros(2, 4, 4, dtype=torch.long)
         target = torch.zeros(2, 4, 4, dtype=torch.long)
@@ -70,7 +68,6 @@ class TestSemanticSegmentationTaskMetric:
             class_names=["cat", "dog"],
             ignore_index=None,
             loss_names=["loss"],
-            train_loss_running_mean_window=1,
         )
         preds = torch.zeros(2, 10, 10, dtype=torch.long)
         target = torch.zeros(2, 10, 10, dtype=torch.long)

--- a/tests/_metrics/test_loss_metric_collection.py
+++ b/tests/_metrics/test_loss_metric_collection.py
@@ -35,9 +35,7 @@ class TestLossMetricCollection:
 
     def test_compute__val_split(self) -> None:
         # MeanMetric accumulates a weighted mean across batches.
-        metric = LossMetricCollection(
-            split="val", loss_names=["loss"], train_loss_running_mean_window=1
-        )
+        metric = LossMetricCollection(split="val", loss_names=["loss"])
         metric.update({"loss": torch.tensor(1.0)}, weight=1)
         metric.update({"loss": torch.tensor(3.0)}, weight=1)
         result = metric.compute()
@@ -48,7 +46,6 @@ class TestLossMetricCollection:
         metric = LossMetricCollection(
             split="val",
             loss_names=["loss", "loss_vfl"],
-            train_loss_running_mean_window=1,
         )
         metric.update(
             {"loss": torch.tensor(1.0), "loss_vfl": torch.tensor(2.0)}, weight=1
@@ -59,9 +56,7 @@ class TestLossMetricCollection:
         }
 
     def test_update__mismatched_keys(self) -> None:
-        metric = LossMetricCollection(
-            split="val", loss_names=["loss"], train_loss_running_mean_window=1
-        )
+        metric = LossMetricCollection(split="val", loss_names=["loss"])
         with pytest.raises(ValueError):
             metric.update({"wrong_key": torch.tensor(1.0)}, weight=1)
 
@@ -69,7 +64,16 @@ class TestLossMetricCollection:
         metric = LossMetricCollection(
             split="val",
             loss_names=["loss", "loss_vfl"],
-            train_loss_running_mean_window=1,
         )
         with pytest.raises(ValueError):
             metric.update({"loss": torch.tensor(1.0)}, weight=1)
+
+    def test_init__train_split_without_window(self) -> None:
+        # Should raise ValueError when train split without train_loss_running_mean_window
+        with pytest.raises(
+            ValueError, match="train_loss_running_mean_window must be specified"
+        ):
+            LossMetricCollection(
+                split="train",
+                loss_names=["loss"],
+            )

--- a/tests/_metrics/test_multihead_task_metric.py
+++ b/tests/_metrics/test_multihead_task_metric.py
@@ -35,7 +35,7 @@ def _make_head_metric(split: str = "val") -> SemanticSegmentationTaskMetric:
         class_names=["cat", "dog", "bird"],
         ignore_index=None,
         loss_names=["loss"],
-        train_loss_running_mean_window=1,
+        train_loss_running_mean_window=1 if split == "train" else None,
     )
 
 


### PR DESCRIPTION
## What has changed and why?

* Make `train_loss_running_mean_window ` for non-train splits

## How has it been tested?

* Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
