### PR TITLE
Use np.loadtxt for YOLO label loading

### DIFF
--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -392,60 +392,50 @@ def _open_mask_numpy__with_pil(
 def open_yolo_oriented_object_detection_label_numpy(
     label_path: Path,
 ) -> tuple[NDArray4Corners, NDArrayClasses]:
-    """Open a YOLO label file and return the oriented bounding boxes and classes as numpy arrays.
+    """Open a YOLO label file and return oriented bounding boxes and classes.
 
     Returns:
-        (bboxes, classes) tuple. All values are in normalized coordinates
-        between [0, 1]. Bboxes are formatted as (x1, y1, x2, y2, x3, y3, x4, y4).
+        (bboxes, classes):
+        - bboxes: shape (n, 8), normalized (x1, y1, x2, y2, x3, y3, x4, y4)
+        - classes: shape (n,)
     """
-    oriented_bboxes = []
-    classes = []
-    for line in _iter_yolo_label_lines(label_path=label_path):
-        parts = [float(x) for x in line.split()]
-        class_id = parts[0]
-        x1 = parts[1]
-        y1 = parts[2]
-        x2 = parts[3]
-        y2 = parts[4]
-        x3 = parts[5]
-        y3 = parts[6]
-        x4 = parts[7]
-        y4 = parts[8]
-        bbox_4_corners = np.array([x1, y1, x2, y2, x3, y3, x4, y4], dtype=np.float64)
-        oriented_bboxes.append(bbox_4_corners)
-        classes.append(int(class_id))
+    data = np.loadtxt(label_path, dtype=np.float64, ndmin=2)
 
-    oriented_bboxes_np = (
-        np.array(oriented_bboxes)
-        if oriented_bboxes
-        else np.zeros((0, 8), dtype=np.float64)
-    )
-    classes_np = np.array(classes, dtype=np.int64)
-    return oriented_bboxes_np, classes_np
+    if data.size == 0:
+        return np.zeros((0, 8), dtype=np.float64), np.zeros((0,), dtype=np.int64)
+
+    # Remove duplicate lines (preserve order by keeping first occurrence)
+    _, unique_idx = np.unique(data, axis=0, return_index=True)
+    unique_idx = np.sort(unique_idx)  # Sort to preserve original order
+    data = data[unique_idx]
+
+    classes_np = data[:, 0].astype(np.int64)
+    bboxes_np = data[:, 1:9]
+    return bboxes_np, classes_np
 
 
 def open_yolo_object_detection_label_numpy(
     label_path: Path,
 ) -> tuple[NDArrayBBoxes, NDArrayClasses]:
-    """Open a YOLO label file and return the bounding boxes and classes as numpy arrays.
+    """Open a YOLO label file and return bounding boxes and classes.
 
     Returns:
-        (bboxes, classes) tuple. All values are in normalized coordinates
-        between [0, 1]. Bboxes are formatted as (x_center, y_center, width, height).
+        (bboxes, classes):
+        - bboxes: shape (n, 4), normalized (x_center, y_center, width, height)
+        - classes: shape (n,)
     """
-    bboxes = []
-    classes = []
-    for line in _iter_yolo_label_lines(label_path=label_path):
-        parts = [float(x) for x in line.split()]
-        class_id = parts[0]
-        x_center = parts[1]
-        y_center = parts[2]
-        width = parts[3]
-        height = parts[4]
-        bboxes.append([x_center, y_center, width, height])
-        classes.append(int(class_id))
-    bboxes_np = np.array(bboxes) if bboxes else np.zeros((0, 4), dtype=np.float64)
-    classes_np = np.array(classes, dtype=np.int64)
+    data = np.loadtxt(label_path, dtype=np.float64, ndmin=2)
+
+    if data.size == 0:
+        return np.zeros((0, 4), dtype=np.float64), np.zeros((0,), dtype=np.int64)
+
+    # Remove duplicate lines (preserve order by keeping first occurrence)
+    _, unique_idx = np.unique(data, axis=0, return_index=True)
+    unique_idx = np.sort(unique_idx)  # Sort to preserve original order
+    data = data[unique_idx]
+
+    classes_np = data[:, 0].astype(np.int64)
+    bboxes_np = data[:, 1:5]
     return bboxes_np, classes_np
 
 

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -392,7 +392,7 @@ def _open_mask_numpy__with_pil(
 def open_yolo_oriented_object_detection_label_numpy(
     label_path: Path,
 ) -> tuple[NDArray4Corners, NDArrayClasses]:
-    """Open a YOLO label file and return oriented bounding boxes and classes.
+    """Open a YOLO label file and return the oriented bounding boxes and classes as numpy arrays.
 
     Returns:
         (bboxes, classes):
@@ -417,7 +417,7 @@ def open_yolo_oriented_object_detection_label_numpy(
 def open_yolo_object_detection_label_numpy(
     label_path: Path,
 ) -> tuple[NDArrayBBoxes, NDArrayClasses]:
-    """Open a YOLO label file and return bounding boxes and classes.
+    """Open a YOLO label file and return the bounding boxes and classes as numpy arrays.
 
     Returns:
         (bboxes, classes):


### PR DESCRIPTION
## What has changed and why?

Replace Python loop-based YOLO label parsing with `np.loadtxt` for improved performance on fixed-column formats, while preserving existing duplicate line handling. Improved also the documentation to include shapes for the arrays.

- `open_yolo_object_detection_label_numpy`: Now uses `np.loadtxt` + `np.unique` for parsing
- `open_yolo_oriented_object_detection_label_numpy`: Same pattern for 9-column oriented bboxes

## How has it been tested?

- 130 tests passed, 2 skipped
- Format checks pass (ruff, mdformat, pre-commit)
- Order preservation verified (duplicates are removed while keeping first occurrence)

## Did you update CHANGELOG.md?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)