### PR TITLE
Parse labels in YoloObjectDetectionDatasetArgs.list_image_info

### DIFF
--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -424,10 +424,10 @@ def open_yolo_oriented_object_detection_label_numpy(
     return oriented_bboxes_np, classes_np
 
 
-def open_yolo_object_detection_label_numpy(
+def open_yolo_object_detection_label(
     label_path: Path,
-) -> tuple[NDArrayBBoxes, NDArrayClasses]:
-    """Open a YOLO label file and return the bounding boxes and classes as numpy arrays.
+) -> tuple[list[list[float]], list[int]]:
+    """Open a YOLO label file and return the bounding boxes and classes.
 
     Returns:
         (bboxes, classes) tuple. All values are in normalized coordinates
@@ -444,9 +444,7 @@ def open_yolo_object_detection_label_numpy(
         height = parts[4]
         bboxes.append([x_center, y_center, width, height])
         classes.append(int(class_id))
-    bboxes_np = np.array(bboxes) if bboxes else np.zeros((0, 4), dtype=np.float64)
-    classes_np = np.array(classes, dtype=np.int64)
-    return bboxes_np, classes_np
+    return bboxes, classes
 
 
 def open_yolo_instance_segmentation_label_numpy(

--- a/src/lightly_train/_data/yolo_object_detection_dataset.py
+++ b/src/lightly_train/_data/yolo_object_detection_dataset.py
@@ -7,7 +7,9 @@
 #
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+import itertools
+import json
+from collections.abc import Iterable
 from pathlib import Path
 from typing import ClassVar
 
@@ -21,7 +23,7 @@ from lightly_train._data.task_dataset import TaskDataset, TaskDatasetArgs
 from lightly_train._transforms.object_detection_transform import (
     ObjectDetectionCollateFunction,
 )
-from lightly_train._transforms.task_transform import TaskCollateFunction, TaskTransform
+from lightly_train._transforms.task_transform import TaskCollateFunction
 from lightly_train.types import ObjectDetectionDatasetItem, PathLike
 
 
@@ -33,29 +35,10 @@ class YOLOObjectDetectionDataset(TaskDataset):
         ObjectDetectionCollateFunction
     )
 
-    def __init__(
-        self,
-        dataset_args: YOLOObjectDetectionDatasetArgs,
-        image_info: Sequence[dict[str, str]],
-        transform: TaskTransform,
-    ) -> None:
-        super().__init__(
-            transform=transform, dataset_args=dataset_args, image_info=image_info
-        )
-
-        # Get the class mapping.
-        self.class_id_to_internal_class_id = (
-            label_helpers.get_class_id_to_internal_class_id_mapping(
-                class_ids=self.dataset_args.classes.keys(),
-                ignore_classes=self.dataset_args.ignore_classes,
-            )
-        )
-
     def __getitem__(self, index: int) -> ObjectDetectionDatasetItem:
         # Load the image.
         image_info = self.image_info[index]
         image_path = Path(image_info["image_path"])
-        label_path = Path(image_info["label_path"]).with_suffix(".txt")
 
         if not image_path.exists():
             raise FileNotFoundError(f"Image file {image_path} does not exist.")
@@ -63,39 +46,19 @@ class YOLOObjectDetectionDataset(TaskDataset):
         image_np = file_helpers.open_image_numpy(image_path)
         h, w, _ = image_np.shape
 
-        if label_path.exists():
-            bboxes_np, class_labels_np = (
-                file_helpers.open_yolo_object_detection_label_numpy(label_path)
-            )
-        else:
-            bboxes_np = np.zeros((0, 4), dtype=np.float64)
-            class_labels_np = np.zeros((0,), dtype=np.int64)
+        bboxes = json.loads(image_info["bboxes"])
+        class_labels = json.loads(image_info["class_labels"])
+        # TODO (simon, 03/26) do we need this assert?
+        assert len(bboxes) == len(class_labels)
 
-        # Remove instances with class IDs that are not in the included classes.
-        keep = np.array(
-            [
-                int(class_id) in self.class_id_to_internal_class_id
-                for class_id in class_labels_np
-            ],
-            dtype=np.bool_,
-        )
-        bboxes_np = bboxes_np[keep]
-        class_labels_np = class_labels_np[keep]
-
-        # Map class IDs to internal class IDs.
-        internal_class_labels_np = np.array(
-            [
-                self.class_id_to_internal_class_id[int(class_id)]
-                for class_id in class_labels_np
-            ],
-            dtype=np.int_,
-        )
+        bboxes_np = np.array(bboxes, dtype=np.float64).reshape(len(bboxes), 4)
+        class_labels_np = np.array(class_labels, dtype=np.int64)
 
         transformed = self.transform(
             {
                 "image": image_np,
                 "bboxes": bboxes_np,  # Shape (n_boxes, 4)
-                "class_labels": internal_class_labels_np,  # Shape (n_boxes,)
+                "class_labels": class_labels_np,  # Shape (n_boxes,)
             }
         )
 
@@ -189,20 +152,46 @@ class YOLOObjectDetectionDatasetArgs(TaskDatasetArgs):
     skip_if_label_file_missing: bool
 
     def list_image_info(self) -> Iterable[dict[str, str]]:
+
+        class_id_to_internal_class_id = (
+            label_helpers.get_class_id_to_internal_class_id_mapping(
+                class_ids=self.classes.keys(),
+                ignore_classes=self.ignore_classes,
+            )
+        )
+
         for image_filename in file_helpers.list_image_filenames_from_dir(
             image_dir=self.image_dir
         ):
-            image_filepath = self.image_dir / Path(image_filename)
-            label_filepath = self.label_dir / Path(image_filename).with_suffix(".txt")
+            image_filepath = self.image_dir / image_filename
+            label_filepath = (self.label_dir / image_filename).with_suffix(".txt")
 
-            # TODO (Thomas, 10/25): Log warning if label file does not exist.
-            # And keep track of how many files are missing labels.
-            if self.skip_if_label_file_missing and not label_filepath.exists():
-                continue
+            if label_filepath.exists():
+                bboxes, class_labels = file_helpers.open_yolo_object_detection_label(
+                    label_filepath
+                )
+            else:
+                # TODO (Thomas, 10/25): Log warning if label file does not exist.
+                #   And keep track of how many files are missing labels.
+                if self.skip_if_label_file_missing:
+                    continue
+                bboxes = []
+                class_labels = []
+
+            # Remove instances with class IDs that are not in the included classes
+            keep = [label in class_id_to_internal_class_id for label in class_labels]
+            bboxes = list(itertools.compress(bboxes, keep))
+            class_labels = list(itertools.compress(class_labels, keep))
+
+            # Map class IDs to internal class IDs.
+            class_labels = [
+                class_id_to_internal_class_id[label] for label in class_labels
+            ]
 
             yield {
                 "image_path": str(image_filepath),
-                "label_path": str(label_filepath),
+                "bboxes": json.dumps(bboxes),
+                "class_labels": json.dumps(class_labels),
             }
 
     @staticmethod

--- a/tests/_data/test_file_helpers.py
+++ b/tests/_data/test_file_helpers.py
@@ -460,28 +460,26 @@ def test_open_yolo_oriented_object_detection_label_numpy__empty(
     assert class_labels.shape == (0,)
 
 
-def test_open_yolo_object_detection_label_numpy(tmp_path: Path) -> None:
+def test_open_yolo_object_detection_label(tmp_path: Path) -> None:
     with open(tmp_path / "label.txt", "w") as f:
         f.write("2 0.1 0.1 0.2 0.2\n1 0.3 0.3 0.4 0.4\n")
-    bboxes, class_labels = file_helpers.open_yolo_object_detection_label_numpy(
+    bboxes, class_labels = file_helpers.open_yolo_object_detection_label(
         label_path=tmp_path / "label.txt"
     )
-    np.testing.assert_array_almost_equal(
-        bboxes, np.array([[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4]])
-    )
-    np.testing.assert_array_equal(class_labels, np.array([2, 1]))
+    assert bboxes == [[0.1, 0.1, 0.2, 0.2], [0.3, 0.3, 0.4, 0.4]]
+    assert class_labels == [2, 1]
 
 
-def test_open_yolo_object_detection_label_numpy__empty(
+def test_open_yolo_object_detection_label__empty(
     tmp_path: Path,
 ) -> None:
     with open(tmp_path / "label.txt", "w") as f:
         f.write("")
-    bboxes, class_labels = file_helpers.open_yolo_object_detection_label_numpy(
+    bboxes, class_labels = file_helpers.open_yolo_object_detection_label(
         label_path=tmp_path / "label.txt"
     )
-    assert bboxes.shape == (0, 4)
-    assert class_labels.shape == (0,)
+    assert bboxes == []
+    assert class_labels == []
 
 
 def test_open_yolo_instance_segmentation_label_numpy(tmp_path: Path) -> None:

--- a/tests/_data/test_yolo_object_detection_dataset.py
+++ b/tests/_data/test_yolo_object_detection_dataset.py
@@ -76,31 +76,13 @@ class TestYoloObjectDetectionDataset:
         train_dataset = YOLOObjectDetectionDataset(
             dataset_args=train_args,
             transform=ObjectDetectionTransform(DummyTransformArgs()),
-            image_info=[
-                {
-                    "image_path": str(tmp_path / "train/images/0.png"),
-                    "label_path": str(tmp_path / "train/labels/0.txt"),
-                },
-                {
-                    "image_path": str(tmp_path / "train/images/1.png"),
-                    "label_path": str(tmp_path / "train/labels/1.txt"),
-                },
-            ],
+            image_info=list(train_args.list_image_info()),
         )
 
         val_dataset = YOLOObjectDetectionDataset(
             dataset_args=val_args,
             transform=ObjectDetectionTransform(DummyTransformArgs()),
-            image_info=[
-                {
-                    "image_path": str(tmp_path / "val/images/0.png"),
-                    "label_path": str(tmp_path / "val/labels/0.txt"),
-                },
-                {
-                    "image_path": str(tmp_path / "val/images/1.png"),
-                    "label_path": str(tmp_path / "val/labels/1.txt"),
-                },
-            ],
+            image_info=list(val_args.list_image_info()),
         )
 
         sample = train_dataset[0]
@@ -129,31 +111,13 @@ class TestYoloObjectDetectionDataset:
         train_dataset = YOLOObjectDetectionDataset(
             dataset_args=train_args,
             transform=ObjectDetectionTransform(DummyTransformArgs()),
-            image_info=[
-                {
-                    "image_path": str(tmp_path / "images/train/0.png"),
-                    "label_path": str(tmp_path / "labels/train/0.txt"),
-                },
-                {
-                    "image_path": str(tmp_path / "images/train/1.png"),
-                    "label_path": str(tmp_path / "labels/train/1.txt"),
-                },
-            ],
+            image_info=list(train_args.list_image_info()),
         )
 
         val_dataset = YOLOObjectDetectionDataset(
             dataset_args=val_args,
             transform=ObjectDetectionTransform(DummyTransformArgs()),
-            image_info=[
-                {
-                    "image_path": str(tmp_path / "images/val/0.png"),
-                    "label_path": str(tmp_path / "labels/val/0.txt"),
-                },
-                {
-                    "image_path": str(tmp_path / "images/val/1.png"),
-                    "label_path": str(tmp_path / "labels/val/1.txt"),
-                },
-            ],
+            image_info=list(val_args.list_image_info()),
         )
 
         sample = train_dataset[0]
@@ -164,32 +128,3 @@ class TestYoloObjectDetectionDataset:
         sample = val_dataset[0]
         assert sample["image"].dtype == np.float32
         assert sample["bboxes"].shape == (1, 4)
-
-    def test__get_item__internal_class_ids(self, tmp_path: Path) -> None:
-        create_yolo_object_detection_dataset(tmp_path=tmp_path, split_first=True)
-
-        args = YOLOObjectDetectionDataArgs(
-            path=tmp_path,
-            train="train/images",
-            val="val/images",
-            names={0: "class_0", 2: "class_2"},
-        )
-        expected_mapping = {0: 0, 2: 1}
-
-        train_args = args.get_train_args()
-        train_dataset = YOLOObjectDetectionDataset(
-            dataset_args=train_args,
-            transform=ObjectDetectionTransform(DummyTransformArgs()),
-            image_info=[
-                {
-                    "image_path": str(tmp_path / "train/images/0.png"),
-                    "label_path": str(tmp_path / "train/labels/0.txt"),
-                },
-                {
-                    "image_path": str(tmp_path / "train/images/1.png"),
-                    "label_path": str(tmp_path / "train/labels/1.txt"),
-                },
-            ],
-        )
-
-        assert train_dataset.class_id_to_internal_class_id == expected_mapping


### PR DESCRIPTION
## What has changed and why?

This PR makes it so that `YOLOObjectDetectionDatasetArgs.list_image_info` parses the label files and returns the parsed results instead of returning the paths to the label files.

## How has it been tested?

I relayed on the existing tests which had to be slightly changed.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
