### PR TITLE
Fix CUDA OOM by reducing feature map size

### DIFF
--- a/tests/_commands/test_train.py
+++ b/tests/_commands/test_train.py
@@ -320,7 +320,7 @@ def test_train_from_dictconfig(tmp_path: Path) -> None:
         ),
         (
             "distillationv3",
-            lambda: DummyCustomModel(),
+            lambda: DummyCustomModel(stride=16),
         ),
     ],
 )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -137,11 +137,11 @@ class DummyMethod(Method):
 
 
 class DummyCustomModel(Module, ModelWrapper):
-    def __init__(self, feature_dim: int = 2):
+    def __init__(self, feature_dim: int = 2, stride: int = 1) -> None:
         super().__init__()
         self._feature_dim = feature_dim
         self.conv = Conv2d(
-            in_channels=3, out_channels=feature_dim, kernel_size=2, stride=16
+            in_channels=3, out_channels=feature_dim, kernel_size=2, stride=stride
         )
         self.global_pool = AdaptiveAvgPool2d(output_size=(1, 1))
 


### PR DESCRIPTION
## What has changed and why?
- `DummyCustomModel` uses only single conv layer, which makes the feature map huge
- This causes CUDA OOM error, since we're now actually using the feature map in distillationv3
- This PR adds aggressive stride to reduce feature map size to 14x14 which is relatively typical for conv nets and makes this test work

## How has it been tested?
- existing unit test

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
