### PR TITLE
Simon add coco instance segmentation dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ with DINOv3 teacher models. The new method also supports using
 - Add `MixUp` augmentation for LTDETR object detection training.
 - Add logging of completed `epoch`s to the console and the loggers.
 - Add support for COCO object detection dataset format.
+- Add support for COCO instance segmentation dataset format.
 - Semantic segmentation now allows one to specify classes from a JSON file.
 
 ### Changed

--- a/docs/source/instance_segmentation.md
+++ b/docs/source/instance_segmentation.md
@@ -56,10 +56,11 @@ if __name__ == "__main__":
         out="out/my_experiment",
         model="dinov3/vitl16-eomt-inst-coco", 
         data={
+            "format": "yolo",           # either "yolo" or "coco"
             "path": "my_data_dir",      # Path to dataset directory
             "train": "images/train",    # Path to training images
             "val": "images/val",        # Path to validation images
-            "names": {                  # Classes in the dataset                    
+            "names": {                  # Classes in the dataset
                 0: "background",
                 1: "car",
                 2: "bicycle",
@@ -173,29 +174,45 @@ fig.show()
 
 ## Data
 
-Lightly**Train** supports instance segmentation datasets in YOLO format. Every image
-must have a corresponding annotation file that contains for every object in the image a
-line with the class ID and (x1, y1, x2, y2, ...) polygon coordinates in normalized
-format.
+Lightly**Train** supports training instance segmentation models with images and polygon
+masks. We support inputs in either the [YOLO](#instance-segmentation-data-yolo) or
+[COCO](#instance-segmentation-data-coco) instance segmentation formats.
+
+We specify the training data with a `data` dictionary:
+
+```python
+import lightly_train
+
+lightly_train.train_instance_segmentation(
+    ...,
+    data={
+        "format": ...,           # either "yolo" or "coco"
+        "ignore_classes": [...], # optional list of class IDs that should be skipped during training
+         # format specific options
+    },
+)
+```
+
+If you would like to skip specific classes during training, add their IDs to the
+optional `ignore_classes` list. The trainer omits these classes from loss computation
+and the exported model does not predict them.
+
+(instance-segmentation-data-yolo)=
+
+### YOLO format
+
+For the [YOLO](https://labelformat.com/formats/instance-segmentation/yolov8/) format,
+every image has a corresponding label file with the `.txt` extension. Each line in the
+label file represents one object and contains the class ID followed by normalized
+polygon coordinates `(x1, y1, x2, y2, ...)`. An example annotation file for an image
+with two objects looks like this:
 
 ```text
 0 0.782016 0.986521 0.937078 0.874167 0.957297 0.782021 0.950562 0.739333
 1 0.557859 0.143813 0.487078 0.0314583 0.859547 0.00897917 0.985953 0.130333 0.984266 0.184271
 ```
 
-The following image formats are supported:
-
-- jpg
-- jpeg
-- png
-- ppm
-- bmp
-- pgm
-- tif
-- tiff
-- webp
-
-Your dataset directory must be organized like this:
+Your dataset directory should be organized like this:
 
 ```text
 my_data_dir/
@@ -219,7 +236,7 @@ my_data_dir/
         └── ...
 ```
 
-Alternatively, the train/val splits can also be at the top level:
+Alternatively, the splits can also be at the top level:
 
 ```text
 my_data_dir/
@@ -243,32 +260,12 @@ my_data_dir/
         └── ...
 ```
 
-The `data` argument in `train_instance_segmentation` must point to the dataset directory
-and specify the paths to the training and validation images relative to the dataset
-directory. For example:
+Each class in the dataset must be listed in the `names` dictionary. The keys are the
+class IDs used inside the YOLO annotations and the values are the human-readable class
+names. Any class IDs that appear in the label files but are not present in the
+dictionary are silently ignored.
 
-```python
-import lightly_train
-
-if __name__ == "__main__":
-    lightly_train.train_instance_segmentation(
-        out="out/my_experiment",
-        model="dinov3/vitl16-eomt-inst-coco", 
-        data={
-            "path": "my_data_dir",      # Path to dataset directory
-            "train": "images/train",    # Path to training images
-            "val": "images/val",        # Path to validation images
-            "names": {                  # Classes in the dataset                    
-                0: "background",        # Classes must match those in the annotation files
-                1: "car",
-                2: "bicycle",
-                # ...
-            },
-        },
-    )
-```
-
-### Missing Labels
+#### Missing Labels
 
 There are three cases in which an image may not have any corresponding labels:
 
@@ -284,21 +281,165 @@ If you would like to exclude images without label files from training, you can s
 images without a label file (case 1) but still includes cases 2 and 3 as negative
 samples.
 
+#### Example
+
 ```python
 import lightly_train
 
-if __name__ == "__main__":
-    lightly_train.train_instance_segmentation(
-        ...,
-        data={
-            "path": "my_data_dir",
-            "train": "images/train",
-            "val": "images/val",
-            "names": {...},
-            "skip_if_label_file_missing": True, # Skip images without label files.
-        }
-    )
+lightly_train.train_instance_segmentation(
+    ...,
+    data={
+        "format": "yolo",
+        "path": "my_data_dir",
+        "train": "images/train",
+        "val": "images/val",
+        "names": {...},
+        "skip_if_label_file_missing": True, # Skip images without label files.
+    }
+)
 ```
+
+(instance-segmentation-data-coco)=
+
+### COCO format
+
+For the [COCO](https://labelformat.com/formats/instance-segmentation/coco/) format,
+every split has a separate annotations JSON file. It specifies which images and classes
+belong to the split and contains the polygon masks. The structure of such a file is as
+follows:
+
+```json
+{
+    "images": [
+        {
+            "id": 1,
+            "file_name": "image1.jpg",
+            "width": 640,
+            "height": 480
+        },
+        {
+            "id": 2,
+            "file_name": "image2.jpg",
+            "width": 640,
+            "height": 480
+        }
+    ],
+    "categories": [
+        {
+            "id": 0,
+            "name": "cat"
+        },
+        {
+            "id": 1,
+            "name": "dog"
+        }
+    ],
+    "annotations": [
+        {
+            "id": 1,
+            "image_id": 1,
+            "category_id": 0,
+            "segmentation": [[10, 20, 30, 20, 30, 40, 10, 40]],
+            "bbox": [10, 20, 20, 20]
+        },
+        {
+            "id": 2,
+            "image_id": 1,
+            "category_id": 1,
+            "segmentation": [
+                [150, 30, 200, 30, 200, 80, 150, 80],
+                [210, 30, 260, 30, 260, 80, 210, 80]
+            ],
+            "bbox": [150, 30, 110, 50]
+        },
+        {
+            "id": 3,
+            "image_id": 2,
+            "category_id": 0,
+            "segmentation": [[5, 10, 90, 10, 90, 70, 5, 70]],
+            "bbox": [5, 10, 85, 60]
+        }
+    ]
+}
+```
+
+The `file_name` field can also be an absolute or relative path to an image. One can
+optionally specify the `images` directory so that the paths are resolved relatively to
+that directory. If it is omitted, the paths are resolved relatively to the annotations
+file. Furthermore, the `images` path itself is resolved relatively to the annotations
+file.
+
+It is good practice to have the same categories for all splits but in order to guarantee
+consistency, we always take them from the train split.
+
+The `segmentation` field contains a list of polygon coordinate lists, each being a flat
+sequence of absolute pixel coordinates `[x1, y1, x2, y2, ...]`. Multiple polygon lists
+represent disconnected parts of the same object. The optional `bbox` field specifies the
+bounding box as `[x, y, width, height]` in absolute pixel coordinates; if omitted it is
+derived from the polygon coordinates.
+
+#### Missing Labels
+
+There are two cases in which an image may not have any corresponding labels:
+
+1. There are no polygon masks specified for an image in the annotations file.
+1. The annotations file only contains annotations for classes that are in
+   `ignore_classes`.
+
+LightlyTrain treats both cases as "negative" samples and includes the images in training
+with an empty list of segmentation masks.
+
+If you would like to exclude images without polygon masks from training, you can set the
+`skip_if_annotations_missing` argument in the `data` configuration. This only excludes
+images without polygon masks (case 1) but still includes case 2 as negative samples.
+
+#### Example
+
+```python
+import lightly_train
+
+lightly_train.train_instance_segmentation(
+    ...,
+    data={
+        "format": "coco",
+        "train": {
+            "annotations": "train_labels.json",
+            "images": "train_images/",
+        },
+        "val": {
+            "annotations": "val_labels.json",
+            "images": "val_images/",
+        },
+        "skip_if_annotations_missing": True, # Skip images without polygon masks.
+    }
+)
+```
+
+If in this particular example we specified `file_name` like this in the train annotation
+file
+
+```json
+{
+    "id": 1,
+    "file_name": "train_images/image1.jpg"
+}
+```
+
+we could also omit `images`.
+
+### Image Formats
+
+The following image formats are supported:
+
+- jpg
+- jpeg
+- png
+- ppm
+- bmp
+- pgm
+- tif
+- tiff
+- webp
 
 (instance-segmentation-model)=
 

--- a/docs/source/instance_segmentation.md
+++ b/docs/source/instance_segmentation.md
@@ -201,11 +201,10 @@ and the exported model does not predict them.
 
 ### YOLO format
 
-For the [YOLO](https://labelformat.com/formats/instance-segmentation/yolov8/) format,
-every image has a corresponding label file with the `.txt` extension. Each line in the
-label file represents one object and contains the class ID followed by normalized
-polygon coordinates `(x1, y1, x2, y2, ...)`. An example annotation file for an image
-with two objects looks like this:
+For the YOLO format, every image has a corresponding label file with the `.txt`
+extension. Each line in the label file represents one object and contains the class ID
+followed by normalized polygon coordinates `(x1, y1, x2, y2, ...)`. An example
+annotation file for an image with two objects looks like this:
 
 ```text
 0 0.782016 0.986521 0.937078 0.874167 0.957297 0.782021 0.950562 0.739333
@@ -303,10 +302,9 @@ lightly_train.train_instance_segmentation(
 
 ### COCO format
 
-For the [COCO](https://labelformat.com/formats/instance-segmentation/coco/) format,
-every split has a separate annotations JSON file. It specifies which images and classes
-belong to the split and contains the polygon masks. The structure of such a file is as
-follows:
+For the COCO format, every split has a separate annotations JSON file. It specifies
+which images and classes belong to the split and contains the polygon masks. The
+structure of such a file is as follows:
 
 ```json
 {

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -44,6 +44,7 @@ from lightly_train._data.image_classification_dataset import (
 )
 from lightly_train._data.infinite_cycle_iterator import InfiniteCycleIterator
 from lightly_train._data.instance_segmentation_dataset import (
+    COCOInstanceSegmentationDataArgs,
     YOLOInstanceSegmentationDataArgs,
 )
 from lightly_train._data.mask_panoptic_segmentation_dataset import (
@@ -1879,8 +1880,18 @@ class ImageClassificationMultilabelTrainTaskConfig(TrainTaskConfig):
 
 
 class InstanceSegmentationTrainTaskConfig(TrainTaskConfig):
-    data: YOLOInstanceSegmentationDataArgs
+    data: Annotated[
+        Union[YOLOInstanceSegmentationDataArgs, COCOInstanceSegmentationDataArgs],
+        Field(discriminator="format"),
+    ]
     task: Literal["instance_segmentation"] = "instance_segmentation"
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def _set_default_format(cls, v: Any) -> Any:
+        if isinstance(v, dict) and "format" not in v:
+            v = {**v, "format": "yolo"}
+        return v
 
 
 class PanopticSegmentationTrainTaskConfig(TrainTaskConfig):

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -25,6 +25,7 @@ from torch import Tensor
 from torchvision.io import ImageReadMode
 from torchvision.transforms.v2 import functional as F
 
+from lightly_train._data import yolo_helpers
 from lightly_train.types import (
     ImageDtypes,
     ImageFilename,
@@ -447,13 +448,13 @@ def open_yolo_object_detection_label(
 
 def open_yolo_instance_segmentation_label(
     label_path: Path,
-) -> tuple[list[list[float]], list[list[float]], list[int]]:
+) -> tuple[list[list[list[float]]], list[list[float]], list[int]]:
     """Open a YOLO label file and return the polygons, bboxes, and classes.
 
     Returns:
         (polygons, bboxes, classes) tuple. All values are in normalized coordinates
-        between [0, 1]. Polygons are list of lists of floats, each being a sequence
-        of x0, y0, x1, y1, ... coordinates.
+        between [0, 1]. Polygons is a list of polygon groups, one per instance; each
+        group is a list of flat coordinate lists [x0, y0, x1, y1, ...].
         Bboxes are formatted as (x_center, y_center, width, height).
     """
     classes = []
@@ -462,10 +463,11 @@ def open_yolo_instance_segmentation_label(
     for line in _iter_yolo_label_lines(label_path=label_path):
         parts = [float(x) for x in line.split()]
         class_id = parts[0]
-        polygon = parts[1:]
+        flat_polygon = parts[1:]
+        polygon_group = yolo_helpers.split_yolo_polygon(flat_polygon)
         classes.append(int(class_id))
-        polygons.append(polygon)
-        bboxes.append(_bbox_from_polygon(polygon))
+        polygons.append(polygon_group)
+        bboxes.append(_bbox_from_polygon(flat_polygon))
     return polygons, bboxes, classes
 
 

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -418,6 +418,17 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     segmentation = annotation.get("segmentation", [])
                     if not segmentation or not isinstance(segmentation, list):
                         continue
+                    # Filter to valid polygon segments (list with >= 6
+                    # even-length coordinates, i.e. at least 3 points).
+                    valid_segments = [
+                        segment
+                        for segment in segmentation
+                        if isinstance(segment, list)
+                        and len(segment) >= 6
+                        and len(segment) % 2 == 0
+                    ]
+                    if not valid_segments:
+                        continue
                     # Normalize each polygon segment to [0, 1].
                     polygon_group_norm = [
                         [
@@ -426,11 +437,8 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             else coord / image_height_pixel
                             for i, coord in enumerate(segment)
                         ]
-                        for segment in segmentation
-                        if isinstance(segment, list)
+                        for segment in valid_segments
                     ]
-                    if not polygon_group_norm:
-                        continue
                     # Convert bbox from [x, y, w, h] pixels to normalized
                     # [x_center, y_center, w, h]. If bbox is missing, derive it
                     # from the axis-aligned bounding box of all segments.
@@ -440,10 +448,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                         ]
                     else:
                         all_px = [
-                            coord
-                            for segment in segmentation
-                            if isinstance(segment, list)
-                            for coord in segment
+                            coord for segment in valid_segments for coord in segment
                         ]
                         xs = all_px[0::2]
                         ys = all_px[1::2]

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -106,6 +106,10 @@ class InstanceSegmentationDataset(TaskDataset):
             image_path=image_path, mode=self.image_mode
         )
         polygons_np = [np.array(polygon, dtype=np.float64) for polygon in polygons]
+        polygons_np = [
+            [np.array(segment, dtype=np.float64) for segment in polygon_group]
+            for polygon_group in polygons
+        ]
         bboxes_np = np.array(bboxes, dtype=np.float64).reshape(len(bboxes), 4)
         class_labels_np = np.array(class_labels, dtype=np.int64)
 
@@ -374,10 +378,10 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
         """Yields image info dicts for each image in the COCO annotation file.
 
         Polygons are converted from COCO format (pixel coordinates) to normalized
-        [0, 1] coordinates. Bounding boxes are converted from COCO format
+        [0, 1] coordinates. Each annotation's polygon segments are stored as a list
+        of polygons. Bounding boxes are converted from COCO format
         (x, y, width, height in pixels) to normalized (x_center, y_center, width,
-        height) format. For annotations with multiple polygon segments, the largest
-        segment is used. Images with no annotations are included unless
+        height) format. Images with no annotations are included unless
         ``skip_if_annotations_missing`` is True.
         """
         class_id_to_internal_class_id = (
@@ -414,25 +418,35 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     segmentation = annotation.get("segmentation", [])
                     if not segmentation or not isinstance(segmentation, list):
                         continue
-                    # Take the largest polygon segment.
-                    polygon_px = max(segmentation, key=len)
-                    # Normalize polygon coordinates to [0, 1].
-                    polygon_norm = [
-                        coord / image_width_pixel
-                        if i % 2 == 0
-                        else coord / image_height_pixel
-                        for i, coord in enumerate(polygon_px)
+                    # Normalize each polygon segment to [0, 1].
+                    polygon_group_norm = [
+                        [
+                            coord / image_width_pixel
+                            if i % 2 == 0
+                            else coord / image_height_pixel
+                            for i, coord in enumerate(segment)
+                        ]
+                        for segment in segmentation
+                        if isinstance(segment, list)
                     ]
+                    if not polygon_group_norm:
+                        continue
                     # Convert bbox from [x, y, w, h] pixels to normalized
                     # [x_center, y_center, w, h]. If bbox is missing, derive it
-                    # from the polygon's axis-aligned bounding box.
+                    # from the axis-aligned bounding box of all segments.
                     if "bbox" in annotation:
                         left_pixel, top_pixel, width_pixel, height_pixel = annotation[
                             "bbox"
                         ]
                     else:
-                        xs = polygon_px[0::2]
-                        ys = polygon_px[1::2]
+                        all_px = [
+                            coord
+                            for segment in segmentation
+                            if isinstance(segment, list)
+                            for coord in segment
+                        ]
+                        xs = all_px[0::2]
+                        ys = all_px[1::2]
                         left_pixel = min(xs)
                         top_pixel = min(ys)
                         width_pixel = max(xs) - left_pixel
@@ -442,7 +456,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     width = width_pixel / image_width_pixel
                     height = height_pixel / image_height_pixel
 
-                    polygons.append(polygon_norm)
+                    polygons.append(polygon_group_norm)
                     bboxes.append([x_center, y_center, width, height])
                     class_labels.append(annotation["category_id"])
             else:

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -43,7 +43,7 @@ from lightly_train.types import (
 
 class InstanceSegmentationDataset(TaskDataset):
     # Narrow the type of dataset_args.
-    dataset_args: (
+    dataset_args: (  # type: ignore[assignment]
         COCOInstanceSegmentationDatasetArgs | YOLOInstanceSegmentationDatasetArgs
     )
 
@@ -53,7 +53,8 @@ class InstanceSegmentationDataset(TaskDataset):
 
     def __init__(
         self,
-        dataset_args: YOLOInstanceSegmentationDatasetArgs,
+        dataset_args: COCOInstanceSegmentationDatasetArgs
+        | YOLOInstanceSegmentationDatasetArgs,
         image_info: Sequence[dict[str, str]],
         transform: InstanceSegmentationTransform | None = None,
     ) -> None:
@@ -105,7 +106,6 @@ class InstanceSegmentationDataset(TaskDataset):
         image_np = file_helpers.open_image_numpy(
             image_path=image_path, mode=self.image_mode
         )
-        polygons_np = [np.array(polygon, dtype=np.float64) for polygon in polygons]
         polygons_np = [
             [np.array(segment, dtype=np.float64) for segment in polygon_group]
             for polygon_group in polygons

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -7,17 +7,20 @@
 #
 from __future__ import annotations
 
+import functools
 import itertools
 import json
+from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import ClassVar, Sequence
+from typing import Any, ClassVar, Literal, Sequence
 
 import numpy as np
 import pydantic
 import torch
 from pydantic import Field
 
+from lightly_train._configs.config import PydanticConfig
 from lightly_train._data import file_helpers, label_helpers, yolo_helpers
 from lightly_train._data.file_helpers import ImageMode
 from lightly_train._data.task_data_args import TaskDataArgs
@@ -40,7 +43,9 @@ from lightly_train.types import (
 
 class InstanceSegmentationDataset(TaskDataset):
     # Narrow the type of dataset_args.
-    dataset_args: YOLOInstanceSegmentationDatasetArgs
+    dataset_args: (
+        COCOInstanceSegmentationDatasetArgs | YOLOInstanceSegmentationDatasetArgs
+    )
 
     batch_collate_fn_cls: ClassVar[type[TaskCollateFunction]] = (
         InstanceSegmentationCollateFunction
@@ -145,6 +150,7 @@ class InstanceSegmentationDataset(TaskDataset):
 
 
 class YOLOInstanceSegmentationDataArgs(TaskDataArgs):
+    format: Literal["yolo"] = "yolo"
     ignore_index: ClassVar[int | None] = None
     path: PathLike
     train: PathLike
@@ -260,6 +266,192 @@ class YOLOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                 class_labels = []
 
             # Remove instances with class IDs that are not in the included classes
+            keep = [label in class_id_to_internal_class_id for label in class_labels]
+            polygons = list(itertools.compress(polygons, keep))
+            bboxes = list(itertools.compress(bboxes, keep))
+            class_labels = list(itertools.compress(class_labels, keep))
+
+            # Map class IDs to internal class IDs.
+            class_labels = [
+                class_id_to_internal_class_id[label] for label in class_labels
+            ]
+
+            yield {
+                "image_path": str(image_filepath),
+                "polygons": json.dumps(polygons),
+                "bboxes": json.dumps(bboxes),
+                "class_labels": json.dumps(class_labels),
+            }
+
+    @staticmethod
+    def get_dataset_cls() -> type[InstanceSegmentationDataset]:
+        return InstanceSegmentationDataset
+
+
+class COCOSplitArgs(PydanticConfig):
+    annotations: PathLike
+    images: PathLike | None = None
+
+
+class COCOInstanceSegmentationDataArgs(TaskDataArgs):
+    """Data arguments for a COCO-format instance segmentation dataset.
+
+    The labels files are COCO JSON annotation files. Images are resolved relative
+    to the annotation file's parent directory, optionally under ``images``.
+    """
+
+    format: Literal["coco"] = "coco"
+    train: COCOSplitArgs
+    val: COCOSplitArgs
+    ignore_classes: set[int] | None = Field(default=None, strict=False)
+    skip_if_annotations_missing: bool = False
+
+    @functools.cached_property
+    def _classes(self) -> dict[int, str]:
+        """Reads and caches the class mapping from the train labels file.
+
+        Always uses the training labels so that train and validation share the same
+        class-to-internal-id mapping.
+        """
+        with open(self.train.annotations) as f:
+            return {c["id"]: c["name"] for c in json.load(f).get("categories", [])}
+
+    def train_imgs_path(self) -> Path:
+        # TODO (simon 03/26): We currently only need this to calculate a hash for the mmap file for the dataset.
+        #  This might not be the best idea as the contents of the file might change.
+        return Path(self.train.annotations).resolve()
+
+    def val_imgs_path(self) -> Path:
+        # TODO (simon 03/26): We currently only need this to calculate a hash for the mmap file for the dataset.
+        #  This might not be the best idea as the contents of the file might change.
+        return Path(self.val.annotations).resolve()
+
+    def get_train_args(self) -> COCOInstanceSegmentationDatasetArgs:
+        """Returns dataset args for the training split."""
+        return COCOInstanceSegmentationDatasetArgs(
+            labels=Path(self.train.annotations),
+            data_dir=Path(self.train.images) if self.train.images is not None else None,
+            classes=self._classes,
+            ignore_classes=self.ignore_classes,
+            skip_if_annotations_missing=self.skip_if_annotations_missing,
+        )
+
+    def get_val_args(self) -> COCOInstanceSegmentationDatasetArgs:
+        """Returns dataset args for the validation split."""
+        return COCOInstanceSegmentationDatasetArgs(
+            labels=Path(self.val.annotations),
+            data_dir=Path(self.val.images) if self.val.images is not None else None,
+            classes=self._classes,
+            ignore_classes=self.ignore_classes,
+            skip_if_annotations_missing=self.skip_if_annotations_missing,
+        )
+
+    @property
+    def included_classes(self) -> dict[int, str]:
+        """Returns included classes."""
+        ignore_classes = set() if self.ignore_classes is None else self.ignore_classes
+        return {
+            class_id: class_name
+            for class_id, class_name in self._classes.items()
+            if class_id not in ignore_classes
+        }
+
+    @property
+    def num_included_classes(self) -> int:
+        return len(self.included_classes)
+
+
+class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
+    """Dataset arguments for a single split of a COCO-format instance segmentation dataset."""
+
+    labels: Path
+    data_dir: Path | None
+    classes: dict[int, str]
+    ignore_classes: set[int] | None
+    skip_if_annotations_missing: bool
+
+    def list_image_info(self) -> Iterable[dict[str, str]]:
+        """Yields image info dicts for each image in the COCO annotation file.
+
+        Polygons are converted from COCO format (pixel coordinates) to normalized
+        [0, 1] coordinates. Bounding boxes are converted from COCO format
+        (x, y, width, height in pixels) to normalized (x_center, y_center, width,
+        height) format. For annotations with multiple polygon segments, the largest
+        segment is used. Images with no annotations are included unless
+        ``skip_if_annotations_missing`` is True.
+        """
+        class_id_to_internal_class_id = (
+            label_helpers.get_class_id_to_internal_class_id_mapping(
+                class_ids=self.classes.keys(),
+                ignore_classes=self.ignore_classes,
+            )
+        )
+
+        with open(self.labels) as f:
+            labels_dict = json.load(f)
+
+        annotations_by_image_id: defaultdict[int, list[dict[str, Any]]] = defaultdict(
+            list
+        )
+        for annotation in labels_dict.get("annotations", []):
+            annotations_by_image_id[annotation["image_id"]].append(annotation)
+
+        image_dir = self.labels.resolve().parent
+        if self.data_dir is not None:
+            image_dir /= self.data_dir
+
+        for image in labels_dict["images"]:
+            image_width_pixel = image["width"]
+            image_height_pixel = image["height"]
+            image_id = image["id"]
+            image_filepath = image_dir / image["file_name"]
+
+            polygons = []
+            bboxes = []
+            class_labels = []
+            if image_id in annotations_by_image_id:
+                for annotation in annotations_by_image_id[image_id]:
+                    segmentation = annotation.get("segmentation", [])
+                    if not segmentation or not isinstance(segmentation, list):
+                        continue
+                    # Take the largest polygon segment.
+                    polygon_px = max(segmentation, key=len)
+                    # Normalize polygon coordinates to [0, 1].
+                    polygon_norm = [
+                        coord / image_width_pixel
+                        if i % 2 == 0
+                        else coord / image_height_pixel
+                        for i, coord in enumerate(polygon_px)
+                    ]
+                    # Convert bbox from [x, y, w, h] pixels to normalized
+                    # [x_center, y_center, w, h]. If bbox is missing, derive it
+                    # from the polygon's axis-aligned bounding box.
+                    if "bbox" in annotation:
+                        left_pixel, top_pixel, width_pixel, height_pixel = annotation[
+                            "bbox"
+                        ]
+                    else:
+                        xs = polygon_px[0::2]
+                        ys = polygon_px[1::2]
+                        left_pixel = min(xs)
+                        top_pixel = min(ys)
+                        width_pixel = max(xs) - left_pixel
+                        height_pixel = max(ys) - top_pixel
+                    x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
+                    y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
+                    width = width_pixel / image_width_pixel
+                    height = height_pixel / image_height_pixel
+
+                    polygons.append(polygon_norm)
+                    bboxes.append([x_center, y_center, width, height])
+                    class_labels.append(annotation["category_id"])
+            else:
+                # TODO (Simon, 04/26): Log warning if annotations do not exist for an image.
+                #   And keep track of how many images are missing annotations.
+                if self.skip_if_annotations_missing:
+                    continue
+
+            # Remove instances with class IDs that are not in the included classes.
             keep = [label in class_id_to_internal_class_id for label in class_labels]
             polygons = list(itertools.compress(polygons, keep))
             bboxes = list(itertools.compress(bboxes, keep))

--- a/src/lightly_train/_data/yolo_helpers.py
+++ b/src/lightly_train/_data/yolo_helpers.py
@@ -60,62 +60,47 @@ def get_image_and_labels_dirs(
         raise ValueError(f"Unknown mode: {mode}")
 
 
-def binary_mask_from_polygon(
-    polygon: NDArrayPolygon, height: int, width: int
-) -> NDArrayBinaryMask:
-    """Convert a YOLO polygon to a binary mask.
+def split_yolo_polygon(polygon: list[float]) -> list[list[float]]:
+    """Split a flat YOLO polygon coordinate list into individual polygon segments.
+
+    A single YOLO polygon line can encode multiple disconnected polygons by
+    closing each sub-polygon with a repeated first point before starting the next.
+    See https://github.com/ultralytics/yolov5/issues/11476#issuecomment-1537281864
 
     Args:
         polygon:
-            Numpy array of shape (n_points*2,) containing the polygon points
-            in normalized coordinates [0, 1].
-        height:
-            Height of the image.
-        width:
-            Width of the image.
+            Flat list of normalized [0, 1] coordinates: [x0, y0, x1, y1, ...].
 
     Returns:
-        Binary mask with shape (H, W) where all points inside the polygon are 1.
+        List of flat coordinate lists, one per sub-polygon.
     """
-    mask = Image.new("1", (width, height), 0)
-    points = [(x * width, y * height) for x, y in zip(polygon[0::2], polygon[1::2])]
-
-    # Split the points into multiple polygons if necessary. A single YOLO polygon line
-    # can contain multiple polygons connected by linking the last point of one polygon
-    # to the first point of the next polygon with a line.
-    # See https://github.com/ultralytics/yolov5/issues/11476#issuecomment-1537281864
-    # for details.
-    polygons = []
-    current_polygon: list[tuple[float, float]] = []
-    prev_point = None
+    points = list(zip(polygon[0::2], polygon[1::2]))
+    segments: list[list[float]] = []
+    current: list[tuple[float, float]] = []
+    prev: tuple[float, float] | None = None
     for point in points:
-        if prev_point == point:
-            # Skip duplicate points
+        if prev == point:
+            # Skip duplicate points.
             continue
-        if len(current_polygon) >= 3 and current_polygon[0] == point:
-            # Polygon is closed if current point matches the first point.
-            # Start a new polygon.
-            current_polygon.append(point)
-            if len(current_polygon) >= 4:
-                polygons.append(current_polygon)
-            current_polygon = []
+        if len(current) >= 3 and current[0] == point:
+            # Current point closes the polygon; start a new one.
+            current.append(point)
+            if len(current) >= 4:
+                segments.append([c for pt in current for c in pt])
+            current = []
         else:
-            current_polygon.append(point)
-        prev_point = point
-
-    # Add last polygon. Only 3 points required as it might not be closed.
-    if len(current_polygon) >= 3:
-        polygons.append(current_polygon)
-
-    for poly in polygons:
-        ImageDraw.Draw(mask).polygon(poly, outline=1, fill=1)
-    return np.array(mask, dtype=np.bool_)
+            current.append(point)
+        prev = point
+    # Add the last (possibly unclosed) polygon.
+    if len(current) >= 3:
+        segments.append([c for pt in current for c in pt])
+    return segments if segments else [polygon]
 
 
-def binary_masks_from_polygons(
+def binary_mask_from_polygon(
     polygons: list[NDArrayPolygon], height: int, width: int
-) -> NDArrayBinaryMasks:
-    """Convert a list of YOLO polygons to a stack of binary masks.
+) -> NDArrayBinaryMask:
+    """Convert a list of polygons for a single instance to a binary mask.
 
     Args:
         polygons:
@@ -127,11 +112,37 @@ def binary_masks_from_polygons(
             Width of the image.
 
     Returns:
-        Stack of binary masks with shape (n_polygons, H, W) where all points
-        inside each polygon are 1.
+        Binary mask with shape (H, W) where all points inside any polygon are 1.
+    """
+    mask = Image.new("1", (width, height), 0)
+    draw = ImageDraw.Draw(mask)
+    for polygon in polygons:
+        points = [(x * width, y * height) for x, y in zip(polygon[0::2], polygon[1::2])]
+        if len(points) >= 3:
+            draw.polygon(points, outline=1, fill=1)
+    return np.array(mask, dtype=np.bool_)
+
+
+def binary_masks_from_polygons(
+    polygons: list[list[NDArrayPolygon]], height: int, width: int
+) -> NDArrayBinaryMasks:
+    """Convert a list of per-instance polygon groups to a stack of binary masks.
+
+    Args:
+        polygons:
+            List of polygon groups, one per instance. Each group is a list of
+            numpy arrays of shape (n_points*2,) in normalized coordinates [0, 1].
+        height:
+            Height of the image.
+        width:
+            Width of the image.
+
+    Returns:
+        Stack of binary masks with shape (n_instances, H, W).
     """
     binary_masks = [
-        binary_mask_from_polygon(polygon, height, width) for polygon in polygons
+        binary_mask_from_polygon(polygon_group, height, width)
+        for polygon_group in polygons
     ]
     if binary_masks:
         return np.stack(binary_masks)

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
@@ -22,6 +22,7 @@ from torch.optim.optimizer import Optimizer
 from lightly_train import _torch_helpers
 from lightly_train._configs.validate import no_auto
 from lightly_train._data.instance_segmentation_dataset import (
+    COCOInstanceSegmentationDataArgs,
     YOLOInstanceSegmentationDataArgs,
 )
 from lightly_train._data.task_data_args import TaskDataArgs
@@ -166,7 +167,7 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
         *,
         model_name: str,
         model_args: DINOv2EoMTInstanceSegmentationTrainArgs,
-        data_args: YOLOInstanceSegmentationDataArgs,
+        data_args: COCOInstanceSegmentationDataArgs | YOLOInstanceSegmentationDataArgs,
         train_transform_args: DINOv2EoMTInstanceSegmentationTrainTransformArgs,
         val_transform_args: DINOv2EoMTInstanceSegmentationValTransformArgs,
         load_weights: bool,

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -22,6 +22,7 @@ from torch.optim.optimizer import Optimizer
 from lightly_train import _torch_helpers
 from lightly_train._configs.validate import no_auto
 from lightly_train._data.instance_segmentation_dataset import (
+    COCOInstanceSegmentationDataArgs,
     YOLOInstanceSegmentationDataArgs,
 )
 from lightly_train._data.task_data_args import TaskDataArgs
@@ -171,7 +172,7 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         *,
         model_name: str,
         model_args: DINOv3EoMTInstanceSegmentationTrainArgs,
-        data_args: YOLOInstanceSegmentationDataArgs,
+        data_args: COCOInstanceSegmentationDataArgs | YOLOInstanceSegmentationDataArgs,
         train_transform_args: DINOv3EoMTInstanceSegmentationTrainTransformArgs,
         val_transform_args: DINOv3EoMTInstanceSegmentationValTransformArgs,
         load_weights: bool,

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -243,27 +243,15 @@ def test_train_instance_segmentation(
 ) -> None:
     out = tmp_path / "out"
     data = tmp_path / "data"
-    # Create dataset with 6 files, including one without a label file (index 4) and
-    # one with an empty label file (index 5).
-    helpers.create_yolo_instance_segmentation_dataset(
-        data,
-        split_first=True,
-        num_files=6,
-        missing_label_indices=[4],
-        empty_label_indices=[5],
-    )
+    helpers.create_coco_instance_segmentation_dataset(data, num_files=4)
 
     # Check training
     lightly_train.train_instance_segmentation(
         out=out,
         data={
-            "path": data,
-            "train": Path("train", "images"),
-            "val": Path("val", "images"),
-            "names": {
-                0: "class_0",
-                1: "class_1",
-            },
+            "format": "coco",
+            "train": {"annotations": str(data / "train.json"), "images": "train"},
+            "val": {"annotations": str(data / "val.json"), "images": "val"},
         },
         model="dinov3/vitt16-notpretrained-eomt",
         model_args={"num_joint_blocks": 1},

--- a/tests/_data/test_file_helpers.py
+++ b/tests/_data/test_file_helpers.py
@@ -489,12 +489,8 @@ def test_open_yolo_instance_segmentation_label(tmp_path: Path) -> None:
         label_path=tmp_path / "label.txt"
     )
     assert len(polygons) == 2
-    np.testing.assert_array_almost_equal(
-        polygons[0], np.array([0.1, 0.1, 0.1, 0.2, 0.2, 0.2])
-    )
-    np.testing.assert_array_almost_equal(
-        polygons[1], np.array([0.3, 0.3, 0.3, 0.4, 0.4, 0.4])
-    )
+    assert polygons[0] == [[0.1, 0.1, 0.1, 0.2, 0.2, 0.2]]
+    assert polygons[1] == [[0.3, 0.3, 0.3, 0.4, 0.4, 0.4]]
     np.testing.assert_array_almost_equal(
         bboxes, np.array([[0.15, 0.15, 0.1, 0.1], [0.35, 0.35, 0.1, 0.1]])
     )

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -13,11 +13,15 @@ from pathlib import Path
 import pytest
 
 from lightly_train._data.instance_segmentation_dataset import (
+    COCOInstanceSegmentationDataArgs,
+    COCOInstanceSegmentationDatasetArgs,
+    COCOSplitArgs,
     YOLOInstanceSegmentationDataArgs,
     YOLOInstanceSegmentationDatasetArgs,
 )
 
 from .. import helpers
+from ..helpers import create_coco_instance_segmentation_dataset
 
 _POLYGON = [0.30, 0.30, 0.45, 0.27, 0.49, 0.50, 0.44, 0.70, 0.31, 0.73, 0.26, 0.50]
 # Bbox is (x_center, y_center, width, height) derived from _POLYGON.
@@ -130,3 +134,181 @@ class TestYOLOInstanceSegmentationDatasetArgs:
             assert json.loads(info["polygons"]) == [_POLYGON]
             assert json.loads(info["bboxes"]) == [_BBOX]
             assert json.loads(info["class_labels"]) == [0]
+
+
+# Polygon in pixel coords (128x128 image), matching create_coco_instance_segmentation_dataset default.
+_COCO_POLYGON_PX = [10.0, 10.0, 40.0, 10.0, 40.0, 50.0, 10.0, 50.0]
+_COCO_POLYGON_NORM = [v / 128 for v in _COCO_POLYGON_PX]
+# Bbox from annotation [x, y, w, h] = [10, 10, 30, 40] → normalized x_center, y_center, w, h.
+_COCO_BBOX = [25 / 128, 30 / 128, 30 / 128, 40 / 128]
+# Bbox derived from polygon (same rectangle, so same result).
+_COCO_BBOX_FROM_POLYGON = [25 / 128, 30 / 128, 30 / 128, 40 / 128]
+
+
+class TestCOCOInstanceSegmentationDataArgs:
+    def test_get_train_args(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(tmp_path)
+        args = COCOInstanceSegmentationDataArgs(
+            train=COCOSplitArgs(
+                annotations=tmp_path / "train.json", images=Path("train")
+            ),
+            val=COCOSplitArgs(annotations=tmp_path / "val.json", images=Path("val")),
+        )
+
+        train_args = args.get_train_args()
+
+        assert train_args.labels == tmp_path / "train.json"
+        assert train_args.data_dir == Path("train")
+
+    def test_get_val_args(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(tmp_path)
+        args = COCOInstanceSegmentationDataArgs(
+            train=COCOSplitArgs(
+                annotations=tmp_path / "train.json", images=Path("train")
+            ),
+            val=COCOSplitArgs(annotations=tmp_path / "val.json", images=Path("val")),
+        )
+
+        val_args = args.get_val_args()
+
+        assert val_args.labels == tmp_path / "val.json"
+        assert val_args.data_dir == Path("val")
+
+    def test_included_classes(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(tmp_path, num_classes=2)
+        args = COCOInstanceSegmentationDataArgs(
+            train=COCOSplitArgs(annotations=tmp_path / "train.json"),
+            val=COCOSplitArgs(annotations=tmp_path / "val.json"),
+            ignore_classes={1},
+        )
+
+        assert args.included_classes == {0: "class_0"}
+        assert args.num_included_classes == 1
+
+
+class TestCOCOInstanceSegmentationDatasetArgs:
+    def test_list_image_info(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(
+            tmp_path=tmp_path,
+            num_files=3,
+            height=128,
+            width=128,
+            num_classes=2,
+        )
+        args = COCOInstanceSegmentationDatasetArgs(
+            labels=tmp_path / "train.json",
+            data_dir=Path("train"),
+            classes={0: "class_0", 1: "class_1"},
+            ignore_classes=None,
+            skip_if_annotations_missing=False,
+        )
+
+        image_info = list(args.list_image_info())
+
+        assert len(image_info) == 3
+        for info in image_info:
+            assert Path(info["image_path"]).exists()
+            assert json.loads(info["polygons"]) == [_COCO_POLYGON_NORM]
+            assert json.loads(info["bboxes"]) == [_COCO_BBOX]
+            assert json.loads(info["class_labels"]) == [0]
+
+    def test_list_image_info__bbox_derived_from_polygon(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(
+            tmp_path=tmp_path,
+            num_files=1,
+            height=128,
+            width=128,
+            annotations_per_image=[
+                [
+                    {
+                        "category_id": 0,
+                        "segmentation": [_COCO_POLYGON_PX],
+                        # no "bbox" key
+                    }
+                ]
+            ],
+        )
+        args = COCOInstanceSegmentationDatasetArgs(
+            labels=tmp_path / "train.json",
+            data_dir=Path("train"),
+            classes={0: "class_0"},
+            ignore_classes=None,
+            skip_if_annotations_missing=False,
+        )
+
+        image_info = list(args.list_image_info())
+
+        assert len(image_info) == 1
+        assert json.loads(image_info[0]["bboxes"]) == [_COCO_BBOX_FROM_POLYGON]
+
+    def test_list_image_info__ignore_classes(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(
+            tmp_path=tmp_path,
+            num_files=2,
+            height=128,
+            width=128,
+            num_classes=2,
+            annotations_per_image=[
+                [
+                    {
+                        "category_id": 0,
+                        "bbox": [10, 10, 30, 40],
+                        "segmentation": [_COCO_POLYGON_PX],
+                    },
+                    {
+                        "category_id": 1,
+                        "bbox": [10, 10, 30, 40],
+                        "segmentation": [_COCO_POLYGON_PX],
+                    },
+                ],
+                [
+                    {
+                        "category_id": 1,
+                        "bbox": [10, 10, 30, 40],
+                        "segmentation": [_COCO_POLYGON_PX],
+                    }
+                ],
+            ],
+        )
+        args = COCOInstanceSegmentationDatasetArgs(
+            labels=tmp_path / "train.json",
+            data_dir=Path("train"),
+            classes={0: "class_0", 1: "class_1"},
+            ignore_classes={1},
+            skip_if_annotations_missing=False,
+        )
+
+        image_info = list(args.list_image_info())
+
+        assert len(image_info) == 2
+        assert json.loads(image_info[0]["class_labels"]) == [0]
+        assert json.loads(image_info[1]["class_labels"]) == []
+
+    def test_list_image_info__skip_if_annotations_missing(self, tmp_path: Path) -> None:
+        create_coco_instance_segmentation_dataset(
+            tmp_path=tmp_path,
+            num_files=2,
+            height=128,
+            width=128,
+            annotations_per_image=[
+                [
+                    {
+                        "category_id": 0,
+                        "bbox": [10, 10, 30, 40],
+                        "segmentation": [_COCO_POLYGON_PX],
+                    }
+                ],
+                [],  # no annotations for second image
+            ],
+        )
+        args = COCOInstanceSegmentationDatasetArgs(
+            labels=tmp_path / "train.json",
+            data_dir=Path("train"),
+            classes={0: "class_0"},
+            ignore_classes=None,
+            skip_if_annotations_missing=True,
+        )
+
+        image_info = list(args.list_image_info())
+
+        assert len(image_info) == 1

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -107,7 +107,7 @@ class TestYOLOInstanceSegmentationDatasetArgs:
         assert len(image_info) == 2
         for info in image_info:
             assert Path(info["image_path"]).exists()
-            assert json.loads(info["polygons"]) == [_POLYGON]
+            assert json.loads(info["polygons"]) == [[_POLYGON]]
             assert json.loads(info["bboxes"]) == [_BBOX]
             assert json.loads(info["class_labels"]) == [0]
 
@@ -131,7 +131,7 @@ class TestYOLOInstanceSegmentationDatasetArgs:
         assert len(image_info) == 3
         for info in image_info:
             assert Path(info["image_path"]).exists()
-            assert json.loads(info["polygons"]) == [_POLYGON]
+            assert json.loads(info["polygons"]) == [[_POLYGON]]
             assert json.loads(info["bboxes"]) == [_BBOX]
             assert json.loads(info["class_labels"]) == [0]
 
@@ -208,7 +208,7 @@ class TestCOCOInstanceSegmentationDatasetArgs:
         assert len(image_info) == 3
         for info in image_info:
             assert Path(info["image_path"]).exists()
-            assert json.loads(info["polygons"]) == [_COCO_POLYGON_NORM]
+            assert json.loads(info["polygons"]) == [[_COCO_POLYGON_NORM]]
             assert json.loads(info["bboxes"]) == [_COCO_BBOX]
             assert json.loads(info["class_labels"]) == [0]
 

--- a/tests/_data/test_yolo_helpers.py
+++ b/tests/_data/test_yolo_helpers.py
@@ -57,6 +57,48 @@ def test_binary_mask_from_polygon__multiple() -> None:
     assert np.all(mask == expected)
 
 
+def test_split_yolo_polygon__single_segment() -> None:
+    """A simple polygon without a closing delimiter stays as one segment."""
+    polygon = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    result = yolo_helpers.split_yolo_polygon(polygon)
+    assert result == [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]]
+
+
+def test_split_yolo_polygon__two_segments() -> None:
+    """Two disconnected polygons separated by a repeated first-point delimiter."""
+    # First polygon: triangle (0.1,0.1)-(0.2,0.1)-(0.2,0.2), closed by repeating
+    # first point. Second polygon: triangle (0.5,0.5)-(0.6,0.5)-(0.6,0.6).
+    polygon = [
+        0.1,
+        0.1,
+        0.2,
+        0.1,
+        0.2,
+        0.2,
+        0.1,
+        0.1,  # first, closed
+        0.5,
+        0.5,
+        0.6,
+        0.5,
+        0.6,
+        0.6,  # second, unclosed
+    ]
+    result = yolo_helpers.split_yolo_polygon(polygon)
+    assert len(result) == 2
+    # First segment includes closing point.
+    assert result[0] == [0.1, 0.1, 0.2, 0.1, 0.2, 0.2, 0.1, 0.1]
+    # Second segment is the remaining triangle.
+    assert result[1] == [0.5, 0.5, 0.6, 0.5, 0.6, 0.6]
+
+
+def test_split_yolo_polygon__too_few_points() -> None:
+    """A polygon with fewer than 3 points is returned as-is (fallback)."""
+    polygon = [0.1, 0.2, 0.3, 0.4]
+    result = yolo_helpers.split_yolo_polygon(polygon)
+    assert result == [polygon]
+
+
 def test_oriented_bbox_from_corners__axis_aligned() -> None:
     """Test conversion of an axis-aligned rectangle."""
     # Rectangle from (0.25, 0.25) to (0.75, 0.75) - a square

--- a/tests/_data/test_yolo_helpers.py
+++ b/tests/_data/test_yolo_helpers.py
@@ -14,7 +14,7 @@ from lightly_train._data import yolo_helpers
 
 def test_binary_mask_from_polygon() -> None:
     poly = np.array([0.1, 0.1, 0.1, 0.5, 0.5, 0.5, 0.5, 0.3, 0.3, 0.3, 0.3, 0.1])
-    mask = yolo_helpers.binary_mask_from_polygon(polygon=poly, height=10, width=10)
+    mask = yolo_helpers.binary_mask_from_polygon(polygons=[poly], height=10, width=10)
     expected = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -34,28 +34,11 @@ def test_binary_mask_from_polygon() -> None:
 
 
 def test_binary_mask_from_polygon__multiple() -> None:
-    poly = np.array(
-        [
-            # First polygon
-            0.0,
-            0.0,
-            0.0,
-            0.3,
-            0.3,
-            0.3,
-            0.0,
-            0.0,
-            # Second polygon
-            0.5,
-            0.5,
-            0.5,
-            0.8,
-            0.8,
-            0.8,  # Last poly doesn't need to be closed
-        ]
+    poly1 = np.array([0.0, 0.0, 0.0, 0.3, 0.3, 0.3])
+    poly2 = np.array([0.5, 0.5, 0.5, 0.8, 0.8, 0.8])
+    mask = yolo_helpers.binary_mask_from_polygon(
+        polygons=[poly1, poly2], height=10, width=10
     )
-    mask = yolo_helpers.binary_mask_from_polygon(polygon=poly, height=10, width=10)
-    print(repr(mask.astype(np.int_)))
     expected = np.array(
         [
             [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -786,6 +786,68 @@ def create_coco_object_detection_dataset(
             json.dump(coco_dict, f)
 
 
+def create_coco_instance_segmentation_dataset(
+    tmp_path: Path,
+    num_files: int = 2,
+    height: int = 128,
+    width: int = 128,
+    num_classes: int = 2,
+    annotations_per_image: list[list[dict[str, Any]]] | None = None,
+) -> None:
+    """Create a minimal COCO instance segmentation dataset.
+
+    Args:
+        annotations_per_image: Per-image list of partial annotation dicts (without
+            "id" and "image_id"). Must have length num_files. If None, defaults to
+            one annotation per image with category_id=0, a bbox, and a polygon.
+    """
+    if annotations_per_image is None:
+        annotations_per_image = [
+            [
+                {
+                    "category_id": 0,
+                    "bbox": [10, 10, 30, 40],
+                    "segmentation": [[10.0, 10.0, 40.0, 10.0, 40.0, 50.0, 10.0, 50.0]],
+                }
+            ]
+            for _ in range(num_files)
+        ]
+
+    classes = {i: f"class_{i}" for i in range(num_classes)}
+
+    for split in ["train", "val"]:
+        image_dir = tmp_path / split
+        image_dir.mkdir(parents=True, exist_ok=True)
+        create_images(image_dir=image_dir, files=num_files, height=height, width=width)
+
+        image_paths = sorted(image_dir.glob("*.png"))
+        categories = [{"id": k, "name": v} for k, v in classes.items()]
+        images = []
+        annotations = []
+        ann_id = 0
+        for idx, img_path in enumerate(image_paths):
+            images.append(
+                {
+                    "id": idx,
+                    "file_name": img_path.name,
+                    "width": width,
+                    "height": height,
+                }
+            )
+            for ann in annotations_per_image[idx]:
+                annotations.append({"id": ann_id, "image_id": idx, **ann})
+                ann_id += 1
+
+        coco_dict = {
+            "images": images,
+            "annotations": annotations,
+            "categories": categories,
+        }
+        annotations_path = tmp_path / f"{split}.json"
+        with open(annotations_path, "w") as f:
+            json.dump(coco_dict, f)
+
+
 def create_coco_panoptic_segmentation_dataset(
     tmp_path: Path,
     num_files: int = 2,


### PR DESCRIPTION
## What has changed and why?

This PR adds support for COCO instance segmentation datasets.

Also, Copilot spotted an error where we for forgot to pass `image_mode` to `file_helpers.open_image_numpy` so I added that.

[Instance Segmentation - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/26923565/Instance.Segmentation.-.LightlyTrain.documentation.pdf)


## How has it been tested?

Added a few unit tests and rewrote one of the integration tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change)
