### PR TITLE
Bump min RF-DETR version to 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ notebook = [
 # Note: rfdetr, or one of its dependencies, installs opencv-python and opencv-python-headless
 # which can result in conflicts.
 rfdetr = [
-    "rfdetr>=1.3.0,<1.6.0", # TODO (Lionel, 03/26): Remove upper bound once unit test are fixed.
+    "rfdetr>=1.4.1,<1.6.0", # TODO (Lionel, 03/26): Remove upper bound once unit test are fixed.
     "onnxruntime>=1.21.0", # onnxruntime is required for onnxsim, which is required for rfdetr
 ]
 super-gradients = [


### PR DESCRIPTION
## What has changed and why?

This PR increases the min version for the `rfdetr` dependency to `1.4.1`.

This is necessary, because `rfdetr < 1.6` is not compatible with `transformers >= 5.0`. But `rfdetr < 1.4.1` does bot put an upper limit on `transformers`. 

## How has it been tested?

Relying on the existing tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
