### PR TITLE
Add EUPE support

### DIFF
--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -159,11 +159,6 @@ MODEL_NAME_TO_INFO: dict[str, _DINOv3ModelInfo] = {
         default_weights="https://huggingface.co/facebook/EUPE-ViT-B/resolve/main/EUPE-ViT-B.pt?download=true",
         local_path="dinov3_vitb16_eupe_lvd1689.pth",
     ),
-    "vitl16-eupe": _DINOv3ModelInfo(
-        builder=backbones.dinov3_vitl16,
-        default_weights="https://huggingface.co/facebook/EUPE-ViT-L/resolve/main/EUPE-ViT-L.pt?download=true",
-        local_path="dinov3_vitl16_eupe_lvd1689.pth",
-    ),
     "convnext-small-eupe": _DINOv3ModelInfo(
         builder=backbones.dinov3_convnext_small,
         default_weights="https://huggingface.co/facebook/EUPE-ConvNeXt-S/resolve/main/EUPE-ConvNeXt-S.pt?download=true",
@@ -173,11 +168,6 @@ MODEL_NAME_TO_INFO: dict[str, _DINOv3ModelInfo] = {
         builder=backbones.dinov3_convnext_base,
         default_weights="https://huggingface.co/facebook/EUPE-ConvNeXt-B/resolve/main/EUPE-ConvNeXt-B.pt?download=true",
         local_path="dinov3_convnext_base_eupe_lvd1689.pth",
-    ),
-    "convnext-large-eupe": _DINOv3ModelInfo(
-        builder=backbones.dinov3_convnext_large,
-        default_weights="https://huggingface.co/facebook/EUPE-ConvNeXt-L/resolve/main/EUPE-ConvNeXt-L.pt?download=true",
-        local_path="dinov3_convnext_large_eupe_lvd1689.pth",
     ),
 }
 

--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -143,6 +143,42 @@ MODEL_NAME_TO_INFO: dict[str, _DINOv3ModelInfo] = {
         default_weights="https://lightly-train-checkpoints.s3.us-east-1.amazonaws.com/dinov3/dinov3_convnext_large_lvd1689m.pth",
         local_path="dinov3_convnext_large_lvd1689m.pth",
     ),
+    # EUPE models
+    "vitt16-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_vitt16,
+        default_weights="https://huggingface.co/facebook/EUPE-ViT-T/resolve/main/EUPE-ViT-T.pt?download=true",
+        local_path="dinov3_vitt16_eupe_lvd1689.pth",
+    ),
+    "vits16-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_vits16,
+        default_weights="https://huggingface.co/facebook/EUPE-ViT-S/resolve/main/EUPE-ViT-S.pt?download=true",
+        local_path="dinov3_vits16_eupe_lvd1689.pth",
+    ),
+    "vitb16-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_vitb16,
+        default_weights="https://huggingface.co/facebook/EUPE-ViT-B/resolve/main/EUPE-ViT-B.pt?download=true",
+        local_path="dinov3_vitb16_eupe_lvd1689.pth",
+    ),
+    "vitl16-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_vitl16,
+        default_weights="https://huggingface.co/facebook/EUPE-ViT-L/resolve/main/EUPE-ViT-L.pt?download=true",
+        local_path="dinov3_vitl16_eupe_lvd1689.pth",
+    ),
+    "convnext-small-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_convnext_small,
+        default_weights="https://huggingface.co/facebook/EUPE-ConvNeXt-S/resolve/main/EUPE-ConvNeXt-S.pt?download=true",
+        local_path="dinov3_convnext_small_eupe_lvd1689.pth",
+    ),
+    "convnext-base-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_convnext_base,
+        default_weights="https://huggingface.co/facebook/EUPE-ConvNeXt-B/resolve/main/EUPE-ConvNeXt-B.pt?download=true",
+        local_path="dinov3_convnext_base_eupe_lvd1689.pth",
+    ),
+    "convnext-large-eupe": _DINOv3ModelInfo(
+        builder=backbones.dinov3_convnext_large,
+        default_weights="https://huggingface.co/facebook/EUPE-ConvNeXt-L/resolve/main/EUPE-ConvNeXt-L.pt?download=true",
+        local_path="dinov3_convnext_large_eupe_lvd1689.pth",
+    ),
 }
 
 

--- a/src/lightly_train/_models/dinov3/dinov3_src/hub/backbones.py
+++ b/src/lightly_train/_models/dinov3/dinov3_src/hub/backbones.py
@@ -169,6 +169,13 @@ def _make_dinov3_vit(
                 original_conv_weight, patch_size
             )
             state_dict[key] = new_conv_weight
+
+        state_dict = {
+            key: value
+            for key, value in state_dict.items()
+            if "projectors.heads.dinov3radio"
+            not in key  # remove EUPE-specific projector weights
+        }
         model.load_state_dict(state_dict, strict=True)
     else:
         model.init_weights()
@@ -237,6 +244,12 @@ def _make_dinov3_convnext(
             logger.info(f"Loading DINOv3 checkpoint from '{url}'")
             state_dict = torch.hub.load_state_dict_from_url(url, map_location="cpu")
 
+        state_dict = {
+            key: value
+            for key, value in state_dict.items()
+            if "projectors.heads.dinov3radio"
+            not in key  # remove EUPE-specific projector weights
+        }
         model.load_state_dict(state_dict, strict=True)
     return model
 

--- a/src/lightly_train/_models/dinov3/dinov3_src/hub/backbones.py
+++ b/src/lightly_train/_models/dinov3/dinov3_src/hub/backbones.py
@@ -173,8 +173,8 @@ def _make_dinov3_vit(
         state_dict = {
             key: value
             for key, value in state_dict.items()
-            if "projectors.heads.dinov3radio"
-            not in key  # remove EUPE-specific projector weights
+            # remove EUPE-specific projector weights
+            if "projectors.heads.dinov3radio" not in key
         }
         model.load_state_dict(state_dict, strict=True)
     else:
@@ -247,8 +247,8 @@ def _make_dinov3_convnext(
         state_dict = {
             key: value
             for key, value in state_dict.items()
-            if "projectors.heads.dinov3radio"
-            not in key  # remove EUPE-specific projector weights
+            # remove EUPE-specific projector weights
+            if "projectors.heads.dinov3radio" not in key
         }
         model.load_state_dict(state_dict, strict=True)
     return model

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -524,6 +524,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         }
         config_name = parsed_name["backbone_name"].replace("-notpretrained", "")
         config_name = config_name.replace("-noreg", "")
+        config_name = config_name.replace("-eupe", "")
         config_cls, wrapper_cls = config_mapping[config_name]
         config = config_cls()
 


### PR DESCRIPTION
## What has changed and why?

Adds support for the new [EUPE models from Meta](https://github.com/facebookresearch/EUPE). 

Usage is very simple. Instead of `model="dinov3/vits16"` for pretraining or `model="dinov3/vits16-ltdetr"` for fine-tuning you can now use `model="dinov3/vits16-eupe"` for pretraining with EUPE or `model="dinov3/vits16-eupe-ltdetr"` for fine-tuning.

I'll add docs/changelog in a follow up once #691 is merged. 


Distillation
```
import lightly_train

if __name__ == "__main__":
    lightly_train.pretrain(
        out="out/my_experiment",
        data="my_data_dir",
        model="dinov3/vitt16",
        method="distillation",
        method_args={
            "teacher": "dinov3/vitb16-eupe", # Distill from EUPE ViT-B/16
        },
    )
```

Fine-tuning
```
import lightly_train

if __name__ == "__main__":
    lightly_train.train_semantic_segmentation(
        out="out/my_experiment",
        model="dinov3/vits16-eupe-eomt",
        data={...},
    )
```

## How has it been tested?

* Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
