### PR TITLE
Refactor StopPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- Remove `StopPolicy` and use `ActivationPolicy` instead for more fine-grained control
+  over the step-aware augmentations.
+
 ### Fixed
 
 ### Security

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
@@ -222,15 +222,9 @@ class DINOv2LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     scale_jitter: DINOv2LTDETRObjectDetectionScaleJitterArgs | None = Field(
         default_factory=DINOv2LTDETRObjectDetectionScaleJitterArgs
     )
-    mosaic: DINOv2LTDETRObjectDetectionMosaicArgs | None = Field(
-        default_factory=DINOv2LTDETRObjectDetectionMosaicArgs
-    )
-    mixup: DINOv2LTDETRObjectDetectionMixUpArgs | None = Field(
-        default_factory=DINOv2LTDETRObjectDetectionMixUpArgs
-    )
-    copyblend: DINOv2LTDETRObjectDetectionCopyBlendArgs | None = Field(
-        default_factory=DINOv2LTDETRObjectDetectionCopyBlendArgs
-    )
+    mosaic: DINOv2LTDETRObjectDetectionMosaicArgs | None = None
+    mixup: DINOv2LTDETRObjectDetectionMixUpArgs | None = None
+    copyblend: DINOv2LTDETRObjectDetectionCopyBlendArgs | None = None
     # We use the YOLO format internally for now.
     bbox_params: BboxParams = Field(
         default_factory=lambda: BboxParams(

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
@@ -30,7 +30,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import ImageSizeTuple
 
@@ -41,20 +40,40 @@ ALBUMENTATIONS_VERSION_GREATER_EQUAL_2_0_1 = RequirementCache("albumentations>=2
 class DINOv2LTDETRObjectDetectionRandomPhotometricDistortArgs(
     RandomPhotometricDistortArgs
 ):
+    prob: float = 0.5
+
     brightness: tuple[float, float] = (0.875, 1.125)
     contrast: tuple[float, float] = (0.5, 1.5)
     saturation: tuple[float, float] = (0.5, 1.5)
     hue: tuple[float, float] = (-0.05, 0.05)
-    prob: float = 0.5
+
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means photometric distort is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv2LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
     prob: float = 0.5
+
     fill: float = 0.0
     side_range: tuple[float, float] = (1.0, 4.0)
 
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means random zoom out is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
+
 
 class DINOv2LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
+    prob: float = 0.8
+
     min_scale: float = 0.3
     max_scale: float = 1.0
     min_aspect_ratio: float = 0.5
@@ -62,7 +81,14 @@ class DINOv2LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
     sampler_options: Sequence[float] | None = None
     crop_trials: int = 40
     iou_trials: int = 1000
-    prob: float = 0.8
+
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means random IoU crop is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv2LTDETRObjectDetectionRandomFlipArgs(RandomFlipArgs):
@@ -111,30 +137,39 @@ class DINOv2LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     num_scales: int | None = None
     prob: float = 1.0
     divisible_by: int | None = None
-    # stopping step for scale jittering in LTDETR object detection
+
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means scale jitter is always on.
-    step_stop: int | None = (
-        None  # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    )
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv2LTDETRObjectDetectionMixUpArgs(MixUpArgs):
     prob: float = 0.5
+
     # Corresponds to the 4th epoch of the total training run.
-    step_start: int = 25_000  # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
     # Corresponds to the 4 + total_epochs // 2 epoch of the total training run.
-    step_stop: int = 250_000  # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    # None means mixup is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 250_000
 
 
 class DINOv2LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
     prob: float = 0.5
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int = 375_000
+
     area_threshold: int = 100
     num_objects: int = 3
     expand_ratios: tuple[float, float] = (0.1, 0.25)
+
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means copyblend is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv2LTDETRObjectDetectionMosaicArgs(MosaicArgs):
@@ -149,10 +184,13 @@ class DINOv2LTDETRObjectDetectionMosaicArgs(MosaicArgs):
     max_cached_images: int = 50
     random_pop: bool = True
 
+    # Corresponds to the 4th epoch of the total training run.
     # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 15_000
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means mosaic is always on.
     # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int = 150_000
+    step_stop: int | None = 250_000
 
 
 class DINOv2LTDETRObjectDetectionResizeArgs(ResizeArgs):
@@ -178,17 +216,21 @@ class DINOv2LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple | Literal["auto"] = "auto"
-    # TODO: Lionel (09/25): Remove None, once the stop policy is implemented.
-    stop_policy: StopPolicyArgs | None = None
     resize: ResizeArgs | None = Field(
         default_factory=DINOv2LTDETRObjectDetectionResizeArgs
     )
     scale_jitter: DINOv2LTDETRObjectDetectionScaleJitterArgs | None = Field(
         default_factory=DINOv2LTDETRObjectDetectionScaleJitterArgs
     )
-    mosaic: DINOv2LTDETRObjectDetectionMosaicArgs | None = None
-    mixup: DINOv2LTDETRObjectDetectionMixUpArgs | None = None
-    copyblend: DINOv2LTDETRObjectDetectionCopyBlendArgs | None = None
+    mosaic: DINOv2LTDETRObjectDetectionMosaicArgs | None = Field(
+        default_factory=DINOv2LTDETRObjectDetectionMosaicArgs
+    )
+    mixup: DINOv2LTDETRObjectDetectionMixUpArgs | None = Field(
+        default_factory=DINOv2LTDETRObjectDetectionMixUpArgs
+    )
+    copyblend: DINOv2LTDETRObjectDetectionCopyBlendArgs | None = Field(
+        default_factory=DINOv2LTDETRObjectDetectionCopyBlendArgs
+    )
     # We use the YOLO format internally for now.
     bbox_params: BboxParams = Field(
         default_factory=lambda: BboxParams(
@@ -251,7 +293,6 @@ class DINOv2LTDETRObjectDetectionValTransformArgs(ObjectDetectionTransformArgs):
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple | Literal["auto"] = "auto"
-    stop_policy: None = None
     resize: ResizeArgs | None = Field(
         default_factory=DINOv2LTDETRObjectDetectionResizeArgs
     )

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -220,15 +220,9 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     scale_jitter: DINOv3LTDETRObjectDetectionScaleJitterArgs | None = Field(
         default_factory=DINOv3LTDETRObjectDetectionScaleJitterArgs
     )
-    mosaic: DINOv3LTDETRObjectDetectionMosaicArgs | None = Field(
-        default_factory=DINOv3LTDETRObjectDetectionMosaicArgs
-    )
-    mixup: DINOv3LTDETRObjectDetectionMixUpArgs | None = Field(
-        default_factory=DINOv3LTDETRObjectDetectionMixUpArgs
-    )
-    copyblend: DINOv3LTDETRObjectDetectionCopyBlendArgs | None = Field(
-        default_factory=DINOv3LTDETRObjectDetectionCopyBlendArgs
-    )
+    mosaic: DINOv3LTDETRObjectDetectionMosaicArgs | None = None
+    mixup: DINOv3LTDETRObjectDetectionMixUpArgs | None = None
+    copyblend: DINOv3LTDETRObjectDetectionCopyBlendArgs | None = None
     # We use the YOLO format internally for now.
     bbox_params: BboxParams = Field(
         default_factory=lambda: BboxParams(

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -31,7 +31,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import ImageSizeTuple
 
@@ -42,20 +41,40 @@ ALBUMENTATIONS_VERSION_GREATER_EQUAL_2_0_1 = RequirementCache("albumentations>=2
 class DINOv3LTDETRObjectDetectionRandomPhotometricDistortArgs(
     RandomPhotometricDistortArgs
 ):
+    prob: float = 0.5
+
     brightness: tuple[float, float] = (0.875, 1.125)
     contrast: tuple[float, float] = (0.5, 1.5)
     saturation: tuple[float, float] = (0.5, 1.5)
     hue: tuple[float, float] = (-0.05, 0.05)
-    prob: float = 0.5
+
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means photometric distort is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv3LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
     prob: float = 0.5
+
     fill: float = 0.0
     side_range: tuple[float, float] = (1.0, 4.0)
 
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means random zoom out is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
+
 
 class DINOv3LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
+    prob: float = 0.8
+
     min_scale: float = 0.3
     max_scale: float = 1.0
     min_aspect_ratio: float = 0.5
@@ -63,7 +82,14 @@ class DINOv3LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
     sampler_options: Sequence[float] | None = None
     crop_trials: int = 40
     iou_trials: int = 1000
-    prob: float = 0.8
+
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means random IoU crop is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv3LTDETRObjectDetectionRandomFlipArgs(RandomFlipArgs):
@@ -109,30 +135,39 @@ class DINOv3LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     num_scales: int | None = None
     prob: float = 1.0
     divisible_by: int | None = None
-    # stopping step for scale jittering in LTDETR object detection
+
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means scale jitter is always on.
-    step_stop: int | None = (
-        None  # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    )
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv3LTDETRObjectDetectionMixUpArgs(MixUpArgs):
     prob: float = 0.5
+
     # Corresponds to the 4th epoch of the total training run.
-    step_start: int = 25_000  # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
     # Corresponds to the 4 + total_epochs // 2 epoch of the total training run.
-    step_stop: int = 250_000  # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    # None means mixup is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 250_000
 
 
 class DINOv3LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
     prob: float = 0.5
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int = 375_000
+
     area_threshold: int = 100
     num_objects: int = 3
     expand_ratios: tuple[float, float] = (0.1, 0.25)
+
+    # Corresponds to the 4th epoch of the total training run.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means copyblend is always on.
+    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
+    step_stop: int | None = 375_000
 
 
 class DINOv3LTDETRObjectDetectionMosaicArgs(MosaicArgs):
@@ -147,10 +182,13 @@ class DINOv3LTDETRObjectDetectionMosaicArgs(MosaicArgs):
     max_cached_images: int = 50
     random_pop: bool = True
 
+    # Corresponds to the 4th epoch of the total training run.
     # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 15_000
+    step_start: int = 25_000
+    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means mosaic is always on.
     # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int = 150_000
+    step_stop: int | None = 250_000
 
 
 class DINOv3LTDETRObjectDetectionResizeArgs(ResizeArgs):
@@ -176,17 +214,21 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple | Literal["auto"] = "auto"
-    # TODO: Lionel (09/25): Remove None, once the stop policy is implemented.
-    stop_policy: StopPolicyArgs | None = None
     resize: ResizeArgs | None = Field(
         default_factory=DINOv3LTDETRObjectDetectionResizeArgs
     )
     scale_jitter: DINOv3LTDETRObjectDetectionScaleJitterArgs | None = Field(
         default_factory=DINOv3LTDETRObjectDetectionScaleJitterArgs
     )
-    mosaic: DINOv3LTDETRObjectDetectionMosaicArgs | None = None
-    mixup: DINOv3LTDETRObjectDetectionMixUpArgs | None = None
-    copyblend: DINOv3LTDETRObjectDetectionCopyBlendArgs | None = None
+    mosaic: DINOv3LTDETRObjectDetectionMosaicArgs | None = Field(
+        default_factory=DINOv3LTDETRObjectDetectionMosaicArgs
+    )
+    mixup: DINOv3LTDETRObjectDetectionMixUpArgs | None = Field(
+        default_factory=DINOv3LTDETRObjectDetectionMixUpArgs
+    )
+    copyblend: DINOv3LTDETRObjectDetectionCopyBlendArgs | None = Field(
+        default_factory=DINOv3LTDETRObjectDetectionCopyBlendArgs
+    )
     # We use the YOLO format internally for now.
     bbox_params: BboxParams = Field(
         default_factory=lambda: BboxParams(
@@ -249,7 +291,6 @@ class DINOv3LTDETRObjectDetectionValTransformArgs(ObjectDetectionTransformArgs):
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple | Literal["auto"] = "auto"
-    stop_policy: None = None
     resize: ResizeArgs | None = Field(
         default_factory=DINOv3LTDETRObjectDetectionResizeArgs
     )

--- a/src/lightly_train/_task_models/picodet_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/transforms.py
@@ -95,7 +95,6 @@ class PicoDetObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs):
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: tuple[int, int] | Literal["auto"] = "auto"
-    stop_policy: None = None
     resize: ResizeArgs | None = None
     scale_jitter: PicoDetScaleJitterArgs | None = Field(
         default_factory=PicoDetScaleJitterArgs
@@ -201,7 +200,6 @@ class PicoDetObjectDetectionValTransformArgs(ObjectDetectionTransformArgs):
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: tuple[int, int] | Literal["auto"] = "auto"
-    stop_policy: None = None
     resize: ResizeArgs | None = Field(
         default_factory=lambda: ResizeArgs(height="auto", width="auto")
     )

--- a/src/lightly_train/_transforms/object_detection_transform.py
+++ b/src/lightly_train/_transforms/object_detection_transform.py
@@ -46,6 +46,7 @@ from lightly_train._transforms.task_transform import (
     TaskTransformOutput,
 )
 from lightly_train._transforms.transform import (
+    ActivationPolicyArgs,
     ChannelDropArgs,
     CopyBlendArgs,
     MixUpArgs,
@@ -59,7 +60,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import (
     ImageSizeTuple,
@@ -93,16 +93,15 @@ class ObjectDetectionTransformArgs(TaskTransformArgs):
     random_rotate_90: RandomRotate90Args | None
     random_rotate: RandomRotationArgs | None
     image_size: ImageSizeTuple | Literal["auto"]
-    stop_policy: StopPolicyArgs | None
     mixup: MixUpArgs | None = None
     copyblend: CopyBlendArgs | None = None
     mosaic: MosaicArgs | None = None
-    scale_jitter: ScaleJitterArgs | None
+    scale_jitter: ScaleJitterArgs | None = None
     resize: ResizeArgs | None
     bbox_params: BboxParams | None
     normalize: NormalizeArgs | Literal["auto"] | None
 
-    # Necessary for the StopPolicyArgs, which are not serializable by pydantic.
+    # Necessary for BboxParams, which are not serializable by pydantic.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
@@ -117,7 +116,6 @@ class ObjectDetectionTransform(TaskTransform):
     transform_args_cls: type[ObjectDetectionTransformArgs] = (
         ObjectDetectionTransformArgs
     )
-    _MOSAIC_SKIP_TYPES = (RandomZoomOut, RandomIoUCrop)
 
     def __init__(
         self,
@@ -126,119 +124,88 @@ class ObjectDetectionTransform(TaskTransform):
         super().__init__(transform_args=transform_args)
 
         self.transform_args: ObjectDetectionTransformArgs = transform_args
-        self.stop_step = (
-            transform_args.stop_policy.stop_step if transform_args.stop_policy else None
-        )
-
-        # TODO: Lionel (09/25): Implement stopping of certain augmentations after some steps.
-        if self.stop_step is not None:
-            raise NotImplementedError(
-                "Stopping certain augmentations after some steps is not implemented yet."
-            )
-        self.global_step = 0  # Currently hardcoded, will be set from outside.
-        self.stop_ops = (
-            transform_args.stop_policy.ops if transform_args.stop_policy else set()
-        )
-        self.past_stop = False
-
-        self.individual_transforms = []
-
+        self._step = 0
+        self.channel_drop: ChannelDrop | None = None
         if transform_args.channel_drop is not None:
-            self.individual_transforms += [
-                ChannelDrop(
-                    num_channels_keep=transform_args.channel_drop.num_channels_keep,
-                    weight_drop=transform_args.channel_drop.weight_drop,
-                )
-            ]
+            self.channel_drop = ChannelDrop(
+                num_channels_keep=transform_args.channel_drop.num_channels_keep,
+                weight_drop=transform_args.channel_drop.weight_drop,
+            )
 
+        self.photometric_distort: RandomPhotometricDistort | None = None
         if transform_args.photometric_distort is not None:
-            self.individual_transforms += [
-                RandomPhotometricDistort(
-                    brightness=transform_args.photometric_distort.brightness,
-                    contrast=transform_args.photometric_distort.contrast,
-                    saturation=transform_args.photometric_distort.saturation,
-                    hue=transform_args.photometric_distort.hue,
-                    p=transform_args.photometric_distort.prob,
-                )
-            ]
+            self.photometric_distort = RandomPhotometricDistort(
+                brightness=transform_args.photometric_distort.brightness,
+                contrast=transform_args.photometric_distort.contrast,
+                saturation=transform_args.photometric_distort.saturation,
+                hue=transform_args.photometric_distort.hue,
+                p=transform_args.photometric_distort.prob,
+            )
 
+        self.random_zoom_out: RandomZoomOut | None = None
         if transform_args.random_zoom_out is not None:
-            self.individual_transforms += [
-                RandomZoomOut(
-                    fill=transform_args.random_zoom_out.fill,
-                    side_range=transform_args.random_zoom_out.side_range,
-                    p=transform_args.random_zoom_out.prob,
-                )
-            ]
+            self.random_zoom_out = RandomZoomOut(
+                fill=transform_args.random_zoom_out.fill,
+                side_range=transform_args.random_zoom_out.side_range,
+                p=transform_args.random_zoom_out.prob,
+            )
 
+        self.random_iou_crop: RandomIoUCrop | None = None
         if transform_args.random_iou_crop is not None:
-            self.individual_transforms += [
-                RandomIoUCrop(
-                    min_scale=transform_args.random_iou_crop.min_scale,
-                    max_scale=transform_args.random_iou_crop.max_scale,
-                    min_aspect_ratio=transform_args.random_iou_crop.min_aspect_ratio,
-                    max_aspect_ratio=transform_args.random_iou_crop.max_aspect_ratio,
-                    sampler_options=transform_args.random_iou_crop.sampler_options,
-                    crop_trials=transform_args.random_iou_crop.crop_trials,
-                    iou_trials=transform_args.random_iou_crop.iou_trials,
-                    p=transform_args.random_iou_crop.prob,
-                )
-            ]
+            self.random_iou_crop = RandomIoUCrop(
+                min_scale=transform_args.random_iou_crop.min_scale,
+                max_scale=transform_args.random_iou_crop.max_scale,
+                min_aspect_ratio=transform_args.random_iou_crop.min_aspect_ratio,
+                max_aspect_ratio=transform_args.random_iou_crop.max_aspect_ratio,
+                sampler_options=transform_args.random_iou_crop.sampler_options,
+                crop_trials=transform_args.random_iou_crop.crop_trials,
+                iou_trials=transform_args.random_iou_crop.iou_trials,
+                p=transform_args.random_iou_crop.prob,
+            )
 
+        self.horizontal_flip: HorizontalFlip | None = None
+        self.vertical_flip: VerticalFlip | None = None
         if transform_args.random_flip is not None:
             if transform_args.random_flip.horizontal_prob > 0.0:
-                self.individual_transforms += [
-                    HorizontalFlip(p=transform_args.random_flip.horizontal_prob)
-                ]
+                self.horizontal_flip = HorizontalFlip(
+                    p=transform_args.random_flip.horizontal_prob
+                )
             if transform_args.random_flip.vertical_prob > 0.0:
-                self.individual_transforms += [
-                    VerticalFlip(p=transform_args.random_flip.vertical_prob)
-                ]
+                self.vertical_flip = VerticalFlip(
+                    p=transform_args.random_flip.vertical_prob
+                )
 
+        self.random_rotate_90: RandomRotate90 | None = None
         if transform_args.random_rotate_90 is not None:
-            self.individual_transforms += [
-                RandomRotate90(p=transform_args.random_rotate_90.prob)
-            ]
+            self.random_rotate_90 = RandomRotate90(
+                p=transform_args.random_rotate_90.prob
+            )
+
+        self.random_rotate: Rotate | None = None
         if transform_args.random_rotate is not None:
-            self.individual_transforms += [
-                Rotate(
-                    limit=transform_args.random_rotate.degrees,
-                    interpolation=transform_args.random_rotate.interpolation,
-                    p=transform_args.random_rotate.prob,
-                )
-            ]
+            self.random_rotate = Rotate(
+                limit=transform_args.random_rotate.degrees,
+                interpolation=transform_args.random_rotate.interpolation,
+                p=transform_args.random_rotate.prob,
+            )
 
+        self.resize: Resize | None = None
         if transform_args.resize is not None:
-            self.individual_transforms += [
-                Resize(
-                    height=no_auto(transform_args.resize.height),
-                    width=no_auto(transform_args.resize.width),
-                )
-            ]
+            self.resize = Resize(
+                height=no_auto(transform_args.resize.height),
+                width=no_auto(transform_args.resize.width),
+            )
 
-        # Scale to [0, 1].
-        self.individual_transforms += [
-            ToFloat(max_value=255.0),
-        ]
+        self.to_float = ToFloat(max_value=255.0)
 
-        # Only used with ViT-S/16, ViT-T/16+ and ViT-T/16.
+        self.normalize: Normalize | None = None
         if transform_args.normalize is not None:
-            self.individual_transforms += [
-                Normalize(
-                    mean=no_auto(transform_args.normalize).mean,
-                    std=no_auto(transform_args.normalize).std,
-                    max_pixel_value=1.0,  # Already scaled.
-                )
-            ]
+            self.normalize = Normalize(
+                mean=no_auto(transform_args.normalize).mean,
+                std=no_auto(transform_args.normalize).std,
+                max_pixel_value=1.0,  # Already scaled.
+            )
 
-        self.transform = Compose(
-            self.individual_transforms,
-            bbox_params=transform_args.bbox_params,
-        )
-
-        # Mosaic setup.
-        self.individual_transforms_skip_zoomout_ioucrop: list[Any] = []
-        self.transform_skip_zoomout_ioucrop: Compose | None = None
         self.mosaic: MosaicTransform | None = None
         if transform_args.mosaic is not None:
             self.mosaic = MosaicTransform(
@@ -252,25 +219,37 @@ class ObjectDetectionTransform(TaskTransform):
                 random_pop=transform_args.mosaic.random_pop,
             )
 
-        # Build skip pipeline (without RandomZoomOut and RandomIoUCrop) for mosaic.
-        self._build_skip_pipeline()
+        # Rebuilding an albumentations Compose for every sample is unnecessary
+        # because these step-aware sample transforms only change at a few step
+        # boundaries. Cache the effective pipelines and reuse them per worker.
+        self._compose_cache: dict[tuple[bool, bool, bool], Compose] = {}
+        self._current_transform_active_status = (
+            self._get_transform_active_status_at_step(self._step)
+        )
 
-        # Step-aware state for mosaic scheduling.
-        self._step = 0
-        self._current_mosaic_active_status = self._is_mosaic_active_at_step(0)
+    def _is_photometric_distort_active_at_step(self, step: int) -> bool:
+        return (
+            self.photometric_distort is not None
+            and self.transform_args.photometric_distort is not None
+            and self.transform_args.photometric_distort.prob > 0.0
+            and self.transform_args.photometric_distort.is_active(step)
+        )
 
-    def _build_skip_pipeline(self) -> None:
-        """Build the skip pipeline (without RandomZoomOut and RandomIoUCrop) for mosaic."""
-        if self.mosaic is not None:
-            self.individual_transforms_skip_zoomout_ioucrop = [
-                t
-                for t in self.individual_transforms
-                if not isinstance(t, self._MOSAIC_SKIP_TYPES)
-            ]
-            self.transform_skip_zoomout_ioucrop = Compose(
-                self.individual_transforms_skip_zoomout_ioucrop,
-                bbox_params=self.transform_args.bbox_params,
-            )
+    def _is_random_zoom_out_active_at_step(self, step: int) -> bool:
+        return (
+            self.random_zoom_out is not None
+            and self.transform_args.random_zoom_out is not None
+            and self.transform_args.random_zoom_out.prob > 0.0
+            and self.transform_args.random_zoom_out.is_active(step)
+        )
+
+    def _is_random_iou_crop_active_at_step(self, step: int) -> bool:
+        return (
+            self.random_iou_crop is not None
+            and self.transform_args.random_iou_crop is not None
+            and self.transform_args.random_iou_crop.prob > 0.0
+            and self.transform_args.random_iou_crop.is_active(step)
+        )
 
     def _is_mosaic_active_at_step(self, step: int) -> bool:
         if (
@@ -279,11 +258,7 @@ class ObjectDetectionTransform(TaskTransform):
             or self.transform_args.mosaic.prob <= 0.0
         ):
             return False
-        return (
-            self.transform_args.mosaic.step_start
-            <= step
-            < self.transform_args.mosaic.step_stop
-        )
+        return self.transform_args.mosaic.is_active(step)
 
     def _should_apply_mosaic(self) -> bool:
         return (
@@ -291,65 +266,148 @@ class ObjectDetectionTransform(TaskTransform):
             and np.random.random() < self.transform_args.mosaic.prob  # type: ignore[union-attr]
         )
 
+    def _get_transform_active_status_at_step(
+        self, step: int
+    ) -> tuple[bool, bool, bool, bool]:
+        return (
+            self._is_photometric_distort_active_at_step(step),
+            self._is_random_zoom_out_active_at_step(step),
+            self._is_random_iou_crop_active_at_step(step),
+            self._is_mosaic_active_at_step(step),
+        )
+
+    def _is_step_start_or_stop_configured(
+        self, activation_policy: ActivationPolicyArgs | None
+    ) -> bool:
+        if activation_policy is None:
+            return False
+        return (
+            activation_policy.step_start != 0 or activation_policy.step_stop is not None
+        )
+
+    def _get_transform_cache_key(
+        self, *, step: int, skip_zoomout_ioucrop: bool
+    ) -> tuple[bool, bool, bool]:
+        return (
+            self._is_photometric_distort_active_at_step(step),
+            (
+                self._is_random_zoom_out_active_at_step(step)
+                and not skip_zoomout_ioucrop
+            ),
+            (
+                self._is_random_iou_crop_active_at_step(step)
+                and not skip_zoomout_ioucrop
+            ),
+        )
+
+    def _build_transform(self, key: tuple[bool, bool, bool]) -> Compose:
+        photometric_distort_active, random_zoom_out_active, random_iou_crop_active = key
+        transforms: list[Any] = []
+
+        if self.channel_drop is not None:
+            transforms.append(self.channel_drop)
+        if photometric_distort_active:
+            transforms.append(self.photometric_distort)  # type: ignore[arg-type]
+        if random_zoom_out_active:
+            transforms.append(self.random_zoom_out)  # type: ignore[arg-type]
+        if random_iou_crop_active:
+            transforms.append(self.random_iou_crop)  # type: ignore[arg-type]
+        if self.horizontal_flip is not None:
+            transforms.append(self.horizontal_flip)
+        if self.vertical_flip is not None:
+            transforms.append(self.vertical_flip)
+        if self.random_rotate_90 is not None:
+            transforms.append(self.random_rotate_90)
+        if self.random_rotate is not None:
+            transforms.append(self.random_rotate)
+        if self.resize is not None:
+            transforms.append(self.resize)
+        transforms.append(self.to_float)
+        if self.normalize is not None:
+            transforms.append(self.normalize)
+
+        return Compose(
+            transforms,
+            bbox_params=self.transform_args.bbox_params,
+        )
+
+    def _get_transform_from_cache(self, *, skip_zoomout_ioucrop: bool) -> Compose:
+        cache_key = self._get_transform_cache_key(
+            step=self._step,
+            skip_zoomout_ioucrop=skip_zoomout_ioucrop,
+        )
+        if cache_key not in self._compose_cache:
+            # Mosaic samples need the current active pipeline without
+            # RandomZoomOut/RandomIoUCrop, so keep that variant cached too.
+            self._compose_cache[cache_key] = self._build_transform(cache_key)
+        return self._compose_cache[cache_key]
+
     def set_step(self, step: int) -> None:
         self._step = step
 
     def uses_step_dependent_worker_state(self) -> bool:
         return (
-            self.mosaic is not None
-            and self.transform_args.mosaic is not None
-            and self.transform_args.mosaic.prob > 0.0
+            (
+                self.transform_args.photometric_distort is not None
+                and self.transform_args.photometric_distort.prob > 0.0
+                and self._is_step_start_or_stop_configured(
+                    self.transform_args.photometric_distort
+                )
+            )
+            or (
+                self.transform_args.random_zoom_out is not None
+                and self.transform_args.random_zoom_out.prob > 0.0
+                and self._is_step_start_or_stop_configured(
+                    self.transform_args.random_zoom_out
+                )
+            )
+            or (
+                self.transform_args.random_iou_crop is not None
+                and self.transform_args.random_iou_crop.prob > 0.0
+                and self._is_step_start_or_stop_configured(
+                    self.transform_args.random_iou_crop
+                )
+            )
+            or (
+                self.transform_args.mosaic is not None
+                and self.transform_args.mosaic.prob > 0.0
+                and self._is_step_start_or_stop_configured(self.transform_args.mosaic)
+            )
         )
 
     def requires_dataloader_reinitialization(self) -> bool:
         return (
-            self._is_mosaic_active_at_step(self._step)
-            != self._current_mosaic_active_status
+            self._get_transform_active_status_at_step(self._step)
+            != self._current_transform_active_status
         )
 
     def mark_dataloader_as_reinitialized(self) -> None:
-        self._current_mosaic_active_status = self._is_mosaic_active_at_step(self._step)
+        self._current_transform_active_status = (
+            self._get_transform_active_status_at_step(self._step)
+        )
 
     def __call__(
         self, input: ObjectDetectionTransformInput
     ) -> ObjectDetectionTransformOutput:
-        # Adjust transform after stop_step is reached.
-        if (
-            self.stop_step is not None
-            and self.global_step >= self.stop_step
-            and not self.past_stop
-        ):
-            self.individual_transforms = [
-                t for t in self.individual_transforms if type(t) not in self.stop_ops
-            ]
-            self.transform = Compose(
-                self.individual_transforms,
-                bbox_params=self.transform_args.bbox_params,
-            )
-            self._build_skip_pipeline()
-            self.past_stop = True
-
         image = input["image"]
         bboxes = input["bboxes"]
         class_labels = input["class_labels"]
 
         if self._should_apply_mosaic():
-            assert self.mosaic is not None
-            assert self.transform_skip_zoomout_ioucrop is not None
-            image, bboxes, class_labels = self.mosaic(image, bboxes, class_labels)
+            image, bboxes, class_labels = self.mosaic(image, bboxes, class_labels)  # type: ignore[misc]
+
             # MosaicTransform clips boxes to the canvas but keeps degenerate boxes
             # (zero width/height). Filter them before passing to albumentations.
             if len(bboxes) > 0:
                 valid = (bboxes[:, 2] > 0) & (bboxes[:, 3] > 0)
                 bboxes = bboxes[valid]
                 class_labels = class_labels[valid]
-            transformed = self.transform_skip_zoomout_ioucrop(
-                image=image, bboxes=bboxes, class_labels=class_labels
-            )
+
+            transform = self._get_transform_from_cache(skip_zoomout_ioucrop=True)
         else:
-            transformed = self.transform(
-                image=image, bboxes=bboxes, class_labels=class_labels
-            )
+            transform = self._get_transform_from_cache(skip_zoomout_ioucrop=False)
+
+        transformed = transform(image=image, bboxes=bboxes, class_labels=class_labels)
 
         # Some albumentations versions return lists of tuples instead of arrays.
         bboxes = transformed["bboxes"]
@@ -427,11 +485,7 @@ class ObjectDetectionCollateFunction(TaskCollateFunction):
             or self.transform_args.mixup.prob <= 0.0
         ):
             return False
-        return (
-            self.transform_args.mixup.step_start
-            <= step
-            < self.transform_args.mixup.step_stop
-        )
+        return self.transform_args.mixup.is_active(step)
 
     def _is_copyblend_active_at_step(self, step: int) -> bool:
         if (
@@ -440,11 +494,7 @@ class ObjectDetectionCollateFunction(TaskCollateFunction):
             or self.transform_args.copyblend.prob <= 0.0
         ):
             return False
-        return (
-            self.transform_args.copyblend.step_start
-            <= step
-            < self.transform_args.copyblend.step_stop
-        )
+        return self.transform_args.copyblend.is_active(step)
 
     def _is_scale_jitter_active_at_step(self, step: int) -> bool:
         if (
@@ -454,11 +504,7 @@ class ObjectDetectionCollateFunction(TaskCollateFunction):
             <= 0.0  # TODO (Yutong, 04/26): there is never a scale jitter prob used in LTDETR. Remove it.
         ):
             return False
-
-        scale_jitter_step_stop = self.transform_args.scale_jitter.step_stop
-        if scale_jitter_step_stop is None:
-            return True
-        return step < scale_jitter_step_stop
+        return self.transform_args.scale_jitter.is_active(step)
 
     def _should_apply_mixup(self) -> bool:
         return (
@@ -499,11 +545,19 @@ class ObjectDetectionCollateFunction(TaskCollateFunction):
                 self.mixup is not None
                 and self.transform_args.mixup is not None
                 and self.transform_args.mixup.prob > 0.0
+                and (
+                    self.transform_args.mixup.step_start != 0
+                    or self.transform_args.mixup.step_stop is not None
+                )
             )
             or (
                 self.copyblend is not None
                 and self.transform_args.copyblend is not None
                 and self.transform_args.copyblend.prob > 0.0
+                and (
+                    self.transform_args.copyblend.step_start != 0
+                    or self.transform_args.copyblend.step_stop is not None
+                )
             )
         )
 

--- a/src/lightly_train/_transforms/oriented_object_detection_transform.py
+++ b/src/lightly_train/_transforms/oriented_object_detection_transform.py
@@ -66,15 +66,6 @@ class OrientedObjectDetectionTransform(TaskTransform):
 
         self.transform_args: OrientedObjectDetectionTransformArgs = transform_args
 
-        self.stop_step = (
-            transform_args.stop_policy.stop_step if transform_args.stop_policy else None
-        )
-        self.global_step = 0
-        self.stop_ops = (
-            transform_args.stop_policy.ops if transform_args.stop_policy else set()
-        )
-        self.past_stop = False
-
         transforms_list: list[v2.Transform] = []
 
         if transform_args.channel_drop is not None:
@@ -163,28 +154,16 @@ class OrientedObjectDetectionTransform(TaskTransform):
                 )
             )
 
-        self.transform_list = transforms_list
         self.transform = v2.Compose(transforms_list)
 
     def __call__(
         self, input: OrientedObjectDetectionTransformInput
     ) -> OrientedObjectDetectionTransformOutput:
-        transform = self.transform
-
-        if (
-            self.stop_step is not None
-            and self.global_step >= self.stop_step
-            and not self.past_stop
-        ):
-            transform = v2.Compose(
-                [t for t in self.transform_list if type(t) not in self.stop_ops]
-            )
-
         image = input["image"]
         bboxes = input["bboxes"]
         class_labels = input["class_labels"]
 
-        transformed_image, transformed_bboxes = transform(image, bboxes)
+        transformed_image, transformed_bboxes = self.transform(image, bboxes)
 
         return {
             "image": transformed_image,

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -200,6 +200,8 @@ class ScaleJitterArgs(PydanticConfig):
     num_scales: int | None
     prob: float = Field(ge=0.0, le=1.0)
     divisible_by: int | None
+
+    # ScaleJitter does not have `step_start`, only `step_stop`.
     step_stop: int | None = Field(default=None, gt=0)
 
     @property

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -12,17 +12,14 @@ from collections.abc import Iterable, Sequence
 from typing import (
     Any,
     Literal,
-    Set,
     Type,
     TypeVar,
 )
 
 import cv2
 import pydantic
-from albumentations import BasicTransform
 from lightly.transforms.utils import IMAGENET_NORMALIZE
-from pydantic import ConfigDict, Field, field_validator, model_validator
-from torchvision.transforms import v2
+from pydantic import Field, field_validator, model_validator
 
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._configs.validate import no_auto
@@ -67,7 +64,25 @@ class RandomFlipArgs(PydanticConfig):
     vertical_prob: float = 0.0
 
 
-class RandomIoUCropArgs(PydanticConfig):
+class ActivationPolicyArgs(PydanticConfig):
+    step_start: int = Field(default=0, ge=0)
+    step_stop: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def validate_step_window(self) -> ActivationPolicyArgs:
+        if self.step_stop is not None and self.step_start >= self.step_stop:
+            raise ValueError("activation policy requires step_start < step_stop.")
+        return self
+
+    def is_active(self, step: int) -> bool:
+        if step < self.step_start:
+            return False
+        if self.step_stop is None:
+            return True
+        return step < self.step_stop
+
+
+class RandomIoUCropArgs(ActivationPolicyArgs):
     min_scale: float
     max_scale: float
     min_aspect_ratio: float
@@ -78,7 +93,7 @@ class RandomIoUCropArgs(PydanticConfig):
     prob: float = Field(ge=0.0, le=1.0)
 
 
-class RandomPhotometricDistortArgs(PydanticConfig):
+class RandomPhotometricDistortArgs(ActivationPolicyArgs):
     brightness: tuple[float, float] = Field(strict=False)
     contrast: tuple[float, float] = Field(strict=False)
     saturation: tuple[float, float] = Field(strict=False)
@@ -104,7 +119,7 @@ class RandomRotationArgs(PydanticConfig):
         return v
 
 
-class RandomZoomOutArgs(PydanticConfig):
+class RandomZoomOutArgs(ActivationPolicyArgs):
     prob: float = Field(ge=0.0, le=1.0)
     fill: float
     side_range: tuple[float, float] = Field(strict=False)
@@ -185,7 +200,7 @@ class ScaleJitterArgs(PydanticConfig):
     num_scales: int | None
     prob: float = Field(ge=0.0, le=1.0)
     divisible_by: int | None
-    step_stop: int | None = None
+    step_stop: int | None = Field(default=None, gt=0)
 
     @property
     def scale_range(self) -> tuple[float, float] | None:
@@ -193,35 +208,24 @@ class ScaleJitterArgs(PydanticConfig):
             return self.min_scale, self.max_scale
         return None
 
+    def is_active(self, step: int) -> bool:
+        if self.step_stop is None:
+            return True
+        return step < self.step_stop
 
-class MixUpArgs(PydanticConfig):
+
+class MixUpArgs(ActivationPolicyArgs):
     prob: float = Field(ge=0.0, le=1.0)
-    step_start: int = Field(ge=0)
-    step_stop: int = Field(gt=0)
-
-    @model_validator(mode="after")
-    def validate_step_window(self) -> MixUpArgs:
-        if self.step_start >= self.step_stop:
-            raise ValueError("mixup requires step_start < step_stop.")
-        return self
 
 
-class CopyBlendArgs(PydanticConfig):
+class CopyBlendArgs(ActivationPolicyArgs):
     prob: float = Field(ge=0.0, le=1.0)
-    step_start: int = Field(ge=0)
-    step_stop: int = Field(gt=0)
     area_threshold: int = Field(ge=0)
     num_objects: int = Field(gt=0)
     expand_ratios: tuple[float, float] = Field(strict=False)
 
-    @model_validator(mode="after")
-    def validate_step_window(self) -> CopyBlendArgs:
-        if self.step_start >= self.step_stop:
-            raise ValueError("copyblend requires step_start < step_stop.")
-        return self
 
-
-class MosaicArgs(PydanticConfig):
+class MosaicArgs(ActivationPolicyArgs):
     prob: float = Field(ge=0.0, le=1.0)
 
     output_size: int = Field(gt=0)
@@ -233,13 +237,8 @@ class MosaicArgs(PydanticConfig):
     max_cached_images: int = Field(gt=0)
     random_pop: bool
 
-    step_start: int = Field(ge=0)
-    step_stop: int = Field(gt=0)
-
     @model_validator(mode="after")
     def validate_ranges(self) -> MosaicArgs:
-        if self.step_start >= self.step_stop:
-            raise ValueError("mosaic requires step_start < step_stop.")
         if (
             self.scaling_range[0] <= 0.0
             or self.scaling_range[1] < self.scaling_range[0]
@@ -250,13 +249,6 @@ class MosaicArgs(PydanticConfig):
         if any(v < 0.0 for v in self.translation_range):
             raise ValueError("mosaic translation_range values must be non-negative.")
         return self
-
-
-class StopPolicyArgs(PydanticConfig):
-    stop_step: int
-    ops: Set[type[BasicTransform] | type[v2.Transform]]
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class SmallestMaxSizeArgs(PydanticConfig):

--- a/tests/_data/test_object_detection_dataset.py
+++ b/tests/_data/test_object_detection_dataset.py
@@ -33,7 +33,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import ImageSizeTuple
 
@@ -50,7 +49,6 @@ class DummyTransformArgs(ObjectDetectionTransformArgs):
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple = (32, 32)
-    stop_policy: StopPolicyArgs | None = None
     scale_jitter: ScaleJitterArgs | None = None
     resize: ResizeArgs | None = None
     normalize: NormalizeArgs | Literal["auto"] | None = None

--- a/tests/_data/test_yolo_oriented_object_detection_dataset.py
+++ b/tests/_data/test_yolo_oriented_object_detection_dataset.py
@@ -34,7 +34,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import ImageSizeTuple
 
@@ -57,7 +56,6 @@ class DummyTransformArgs(OrientedObjectDetectionTransformArgs):
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple = (32, 32)
-    stop_policy: StopPolicyArgs | None = None
     scale_jitter: ScaleJitterArgs | None = None
     resize: ResizeArgs | None = None
     normalize: NormalizeArgs | Literal["auto"] | None = None

--- a/tests/_transforms/test_object_detection_transform.py
+++ b/tests/_transforms/test_object_detection_transform.py
@@ -22,7 +22,6 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import
     DINOv3LTDETRObjectDetectionScaleJitterArgs,
     DINOv3LTDETRObjectDetectionTrainTransformArgs,
 )
-from lightly_train._transforms.channel_drop import ChannelDrop
 from lightly_train._transforms.object_detection_transform import (
     ObjectDetectionCollateFunction,
     ObjectDetectionTransform,
@@ -41,7 +40,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import ObjectDetectionDatasetItem
 
@@ -65,25 +63,41 @@ def _get_random_rotate_args() -> RandomRotationArgs:
     return RandomRotationArgs(prob=0.4, degrees=30.0)
 
 
-def _get_photometric_distort_args() -> RandomPhotometricDistortArgs:
+def _get_photometric_distort_args(
+    *,
+    step_start: int = 0,
+    step_stop: int | None = None,
+) -> RandomPhotometricDistortArgs:
     return RandomPhotometricDistortArgs(
         brightness=(0.8, 1.2),
         contrast=(0.8, 1.2),
         saturation=(0.8, 1.2),
         hue=(-0.1, 0.1),
         prob=0.5,
+        step_start=step_start,
+        step_stop=step_stop,
     )
 
 
-def _get_random_zoom_out_args() -> RandomZoomOutArgs:
+def _get_random_zoom_out_args(
+    *,
+    step_start: int = 0,
+    step_stop: int | None = None,
+) -> RandomZoomOutArgs:
     return RandomZoomOutArgs(
         prob=0.5,
         fill=0.0,
         side_range=(1.0, 1.5),
+        step_start=step_start,
+        step_stop=step_stop,
     )
 
 
-def _get_random_iou_crop_args() -> RandomIoUCropArgs:
+def _get_random_iou_crop_args(
+    *,
+    step_start: int = 0,
+    step_stop: int | None = None,
+) -> RandomIoUCropArgs:
     return RandomIoUCropArgs(
         min_scale=0.3,
         max_scale=1.0,
@@ -93,33 +107,8 @@ def _get_random_iou_crop_args() -> RandomIoUCropArgs:
         crop_trials=40,
         iou_trials=1000,
         prob=1.0,
-    )
-
-
-def _get_bbox_params() -> BboxParams:
-    return BboxParams(
-        format="yolo",
-        label_fields=["class_labels"],
-        min_area=0,
-        min_visibility=0.0,
-    )
-
-
-def _get_stop_policy_args() -> StopPolicyArgs:
-    return StopPolicyArgs(
-        stop_step=500_000,
-        ops={ChannelDrop},
-    )
-
-
-def _get_scale_jitter_args() -> ScaleJitterArgs:
-    return ScaleJitterArgs(
-        sizes=None,
-        min_scale=0.76,
-        max_scale=1.27,
-        num_scales=13,
-        prob=1.0,
-        divisible_by=14,
+        step_start=step_start,
+        step_stop=step_stop,
     )
 
 
@@ -130,15 +119,30 @@ def _get_resize_args() -> ResizeArgs:
     )
 
 
-def _get_normalize_args() -> NormalizeArgs:
-    return NormalizeArgs()
+def _get_scale_jitter_args(
+    *,
+    step_stop: int | None = None,
+) -> DINOv3LTDETRObjectDetectionScaleJitterArgs:
+    return DINOv3LTDETRObjectDetectionScaleJitterArgs(
+        sizes=None,
+        min_scale=0.76,
+        max_scale=1.27,
+        num_scales=13,
+        prob=1.0,
+        divisible_by=14,
+        step_stop=step_stop,
+    )
 
 
-def _get_mosaic_args() -> MosaicArgs:
+def _get_mosaic_args(
+    *,
+    step_start: int = 0,
+    step_stop: int | None = 100,
+) -> MosaicArgs:
     return MosaicArgs(
         prob=1.0,
-        step_start=0,
-        step_stop=100,
+        step_start=step_start,
+        step_stop=step_stop,
         output_size=32,
         max_size=None,
         rotation_range=10.0,
@@ -150,8 +154,48 @@ def _get_mosaic_args() -> MosaicArgs:
     )
 
 
+def _get_normalize_args() -> NormalizeArgs:
+    return NormalizeArgs()
+
+
+def _get_mixup_args(
+    *,
+    step_start: int,
+    step_stop: int,
+) -> DINOv3LTDETRObjectDetectionMixUpArgs:
+    return DINOv3LTDETRObjectDetectionMixUpArgs(
+        prob=1.0,
+        step_start=step_start,
+        step_stop=step_stop,
+    )
+
+
+def _get_copyblend_args(
+    *,
+    step_start: int,
+    step_stop: int,
+) -> DINOv3LTDETRObjectDetectionCopyBlendArgs:
+    return DINOv3LTDETRObjectDetectionCopyBlendArgs(
+        prob=1.0,
+        step_start=step_start,
+        step_stop=step_stop,
+        area_threshold=1,
+        num_objects=1,
+        expand_ratios=(0.1, 0.25),
+    )
+
+
 def _get_image_size() -> tuple[int, int]:
     return (64, 64)
+
+
+def _get_bbox_params() -> BboxParams:
+    return BboxParams(
+        format="yolo",
+        label_fields=["class_labels"],
+        min_area=0,
+        min_visibility=0.0,
+    )
 
 
 PossibleArgsTuple = (
@@ -162,10 +206,9 @@ PossibleArgsTuple = (
     [None, _get_random_flip_args()],
     [None, _get_random_rotate_90_args()],
     [None, _get_random_rotate_args()],
-    # TODO: Lionel (09/25) Add StopPolicyArgs test cases.
-    [None, _get_scale_jitter_args()],
     [None, _get_resize_args()],
     [None, _get_normalize_args()],
+    [None, _get_scale_jitter_args()],
     [None, _get_mosaic_args()],
 )
 
@@ -174,7 +217,7 @@ possible_tuples = list(itertools.product(*PossibleArgsTuple))
 
 class TestObjectDetectionTransform:
     @pytest.mark.parametrize(
-        "channel_drop, photometric_distort, random_zoom_out, random_iou_crop, random_flip, random_rotate_90, random_rotate, scale_jitter, resize, normalize, mosaic",
+        "channel_drop, photometric_distort, random_zoom_out, random_iou_crop, random_flip, random_rotate_90, random_rotate, resize, normalize, scale_jitter, mosaic",
         possible_tuples,
     )
     def test___all_args_combinations(
@@ -194,7 +237,6 @@ class TestObjectDetectionTransform:
         image_size = _get_image_size()
         bbox_params = _get_bbox_params()
 
-        stop_policy = None  # TODO: Lionel (09/25) Pass as function argument.
         transform_args = ObjectDetectionTransformArgs(
             channel_drop=channel_drop,
             num_channels=3,
@@ -206,7 +248,6 @@ class TestObjectDetectionTransform:
             random_rotate=random_rotate,
             image_size=image_size,
             bbox_params=bbox_params,
-            stop_policy=stop_policy,
             resize=resize,
             scale_jitter=scale_jitter,
             normalize=normalize,
@@ -241,31 +282,29 @@ class TestObjectDetectionTransform:
         transform_args = ObjectDetectionTransformArgs(
             channel_drop=None,
             num_channels=3,
-            photometric_distort=None,
-            random_zoom_out=_get_random_zoom_out_args(),
-            random_iou_crop=_get_random_iou_crop_args(),
+            photometric_distort=_get_photometric_distort_args(
+                step_start=1,
+                step_stop=5,
+            ),
+            random_zoom_out=_get_random_zoom_out_args(
+                step_start=2,
+                step_stop=6,
+            ),
+            random_iou_crop=_get_random_iou_crop_args(
+                step_start=3,
+                step_stop=7,
+            ),
             random_flip=_get_random_flip_args(),
             random_rotate_90=None,
             random_rotate=None,
             image_size=_get_image_size(),
             bbox_params=_get_bbox_params(),
-            stop_policy=None,
             resize=_get_resize_args(),
-            scale_jitter=None,
-            normalize=None,
-            mosaic=MosaicArgs(
-                prob=0.5,
-                step_start=2,
-                step_stop=5,
-                output_size=320,
-                max_size=None,
-                rotation_range=10.0,
-                translation_range=(0.1, 0.1),
-                scaling_range=(0.5, 1.5),
-                fill_value=0,
-                max_cached_images=50,
-                random_pop=True,
+            mosaic=_get_mosaic_args(
+                step_start=4,
+                step_stop=8,
             ),
+            normalize=None,
         )
         transform_args.resolve_auto(model_init_args={})
         transform = ObjectDetectionTransform(transform_args)
@@ -273,18 +312,50 @@ class TestObjectDetectionTransform:
         # step 0: no reinit needed
         assert transform.requires_dataloader_reinitialization() is False
 
-        # step 2: mosaic activates -> reinit True, mark, then False
+        # step 1: photometric_distort activates
+        transform.set_step(1)
+        assert transform.requires_dataloader_reinitialization() is True
+        transform.mark_dataloader_as_reinitialized()
+        assert transform.requires_dataloader_reinitialization() is False
+
+        # step 2: random_zoom_out activates
         transform.set_step(2)
         assert transform.requires_dataloader_reinitialization() is True
         transform.mark_dataloader_as_reinitialized()
         assert transform.requires_dataloader_reinitialization() is False
 
-        # step 4: still active -> no reinit
-        transform.set_step(4)
+        # step 3: random_iou_crop activates
+        transform.set_step(3)
+        assert transform.requires_dataloader_reinitialization() is True
+        transform.mark_dataloader_as_reinitialized()
         assert transform.requires_dataloader_reinitialization() is False
 
-        # step 5: mosaic deactivates -> reinit True, mark, then False
+        # step 4: mosaic activates
+        transform.set_step(4)
+        assert transform.requires_dataloader_reinitialization() is True
+        transform.mark_dataloader_as_reinitialized()
+        assert transform.requires_dataloader_reinitialization() is False
+
+        # step 5: photometric_distort deactivates
         transform.set_step(5)
+        assert transform.requires_dataloader_reinitialization() is True
+        transform.mark_dataloader_as_reinitialized()
+        assert transform.requires_dataloader_reinitialization() is False
+
+        # step 6: random_zoom_out deactivates
+        transform.set_step(6)
+        assert transform.requires_dataloader_reinitialization() is True
+        transform.mark_dataloader_as_reinitialized()
+        assert transform.requires_dataloader_reinitialization() is False
+
+        # step 7: random_iou_crop deactivates
+        transform.set_step(7)
+        assert transform.requires_dataloader_reinitialization() is True
+        transform.mark_dataloader_as_reinitialized()
+        assert transform.requires_dataloader_reinitialization() is False
+
+        # step 8: mosaic deactivates
+        transform.set_step(8)
         assert transform.requires_dataloader_reinitialization() is True
         transform.mark_dataloader_as_reinitialized()
         assert transform.requires_dataloader_reinitialization() is False
@@ -303,7 +374,6 @@ class TestObjectDetectionCollateFunction:
             random_rotate=_get_random_rotate_args(),
             image_size=_get_image_size(),
             bbox_params=_get_bbox_params(),
-            stop_policy=_get_stop_policy_args(),
             scale_jitter=_get_scale_jitter_args(),
             resize=_get_resize_args(),
             normalize=_get_normalize_args(),
@@ -342,27 +412,16 @@ class TestObjectDetectionCollateFunction:
         transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs(
             image_size=_get_image_size(),
             bbox_params=_get_bbox_params(),
-            mixup=DINOv3LTDETRObjectDetectionMixUpArgs(
-                prob=1.0,
+            mixup=_get_mixup_args(
                 step_start=1,
                 step_stop=2,
             ),
-            copyblend=DINOv3LTDETRObjectDetectionCopyBlendArgs(
-                prob=1.0,
+            copyblend=_get_copyblend_args(
                 step_start=2,
                 step_stop=4,
-                area_threshold=1,
-                num_objects=1,
-                expand_ratios=(0.1, 0.25),
             ),
-            scale_jitter=DINOv3LTDETRObjectDetectionScaleJitterArgs(
+            scale_jitter=_get_scale_jitter_args(
                 step_stop=3,
-                sizes=[(32, 32)],
-                min_scale=None,
-                max_scale=None,
-                num_scales=None,
-                prob=1.0,
-                divisible_by=None,
             ),
         )
         transform_args.resolve_auto(model_init_args={})

--- a/tests/_transforms/test_oriented_object_detection_transform.py
+++ b/tests/_transforms/test_oriented_object_detection_transform.py
@@ -17,7 +17,6 @@ import torchvision.tv_tensors as tv_tensors
 from albumentations import BboxParams
 from lightning_utilities.core.imports import RequirementCache
 
-from lightly_train._transforms.channel_drop import ChannelDrop
 from lightly_train._transforms.oriented_object_detection_transform import (
     OrientedObjectDetectionCollateFunction,
     OrientedObjectDetectionTransform,
@@ -35,7 +34,6 @@ from lightly_train._transforms.transform import (
     RandomZoomOutArgs,
     ResizeArgs,
     ScaleJitterArgs,
-    StopPolicyArgs,
 )
 from lightly_train.types import OrientedObjectDetectionDatasetItem
 
@@ -92,13 +90,6 @@ def _get_bbox_params() -> BboxParams:
     )
 
 
-def _get_stop_policy_args() -> StopPolicyArgs:
-    return StopPolicyArgs(
-        stop_step=500_000,
-        ops={ChannelDrop},
-    )
-
-
 def _get_scale_jitter_args() -> ScaleJitterArgs:
     return ScaleJitterArgs(
         sizes=None,
@@ -133,7 +124,6 @@ PossibleArgsTuple = (
     [None, _get_random_flip_args()],
     [None, _get_random_rotate_90_args()],
     [None, _get_random_rotate_args()],
-    # TODO: Lionel (09/25) Add StopPolicyArgs test cases.
     [None, _get_scale_jitter_args()],
     [None, _get_resize_args()],
     [None, _get_normalize_args()],
@@ -166,7 +156,6 @@ class TestOrientedObjectDetectionTransform:
     ) -> None:
         image_size = _get_image_size()
         bbox_params = _get_bbox_params()
-        stop_policy = None  # TODO: Lionel (09/25) Pass as function argument.
         transform_args = OrientedObjectDetectionTransformArgs(
             channel_drop=channel_drop,
             num_channels=3,
@@ -178,7 +167,6 @@ class TestOrientedObjectDetectionTransform:
             random_rotate=random_rotate,
             image_size=image_size,
             bbox_params=bbox_params,
-            stop_policy=stop_policy,
             resize=resize,
             scale_jitter=scale_jitter,
             normalize=normalize,
@@ -224,7 +212,6 @@ class TestOrientedObjectDetectionTransform:
             random_rotate=_get_random_rotate_args(),
             image_size=_get_image_size(),
             bbox_params=_get_bbox_params(),
-            stop_policy=_get_stop_policy_args(),
             scale_jitter=_get_scale_jitter_args(),
             resize=_get_resize_args(),
             normalize=_get_normalize_args(),


### PR DESCRIPTION
## What has changed and why?

Remove `StopPolicy` and use an `ActivationPolicy` to control the start and stop for all the sample-level and batch-level transformations, including
 - Refactoring the corresponding arguments and implementation of `ObjectDetectionTransform`
 - Adding the missing start and stop mechanism for `RandomPhotometricDistort`, `RandomZoomOut` and `RandomIoUCrop`

Also
- Make the step-aware augmentation transforms default to be used. Also fix the wrong defaults.
- Add comments to the `step_start` and `step_stop` parameter to explain the default setup.
- Update relevant tests and also refactor `test_object_detection_transfrom` accordingly.

## How has it been tested?

- Unit tests
- Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
