### PR TITLE
Allow specifying classes from a json file for semantic segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add logging of completed `epoch`s to the console and the loggers.
 - Add `MixUp` augmentation for LTDETR object detection training.
 - Add support for COCO object detection dataset format.
+- Semantic segmentation now allows one to specify classes from a JSON file.
 
 ### Changed
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -441,8 +441,9 @@ We support two mask formats:
 - Single-channel integer masks, where each integer value determines a label
 - Multi-channel masks (e.g., RGB masks), where each pixel value determines a label
 
-Use the `classes` dict in the `data` dict to map class IDs to labels. In this document,
-a **class ID** is a key in the `classes` dictionary and a **label** is its value.
+Use either `classes` or `classes_json` in the `data` dict to map class IDs to labels —
+exactly one of them must be set. In this document, a **class ID** is a key in the
+`classes` dictionary and a **label** is its value.
 
 #### Using Integer Masks
 
@@ -499,6 +500,49 @@ These pixel values are converted to class IDs internally during training. Predic
 are single-channel masks with those class IDs. Again, each label can map to only **one**
 class ID, and you cannot mix integer and tuple-valued labels in a single `classes`
 dictionary.
+
+#### Loading Classes from a JSON File
+
+Instead of specifying `classes` inline, you can load a simple class mapping from a JSON
+file using `classes_json`. The JSON file must map integer class IDs (as strings) to
+class names:
+
+```json
+{
+  "0": "background",
+  "1": "airplane",
+  "2": "car",
+  "3": "bicycle"
+}
+```
+
+Pass the path to this file via `classes_json`:
+
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.train_semantic_segmentation(
+        out="out/my_experiment",
+        model="dinov2/vitl14-eomt",
+        data={
+            "train": {
+                "images": "my_data_dir/train/images",
+                "masks": "my_data_dir/train/masks",
+            },
+            "val": {
+                "images": "my_data_dir/val/images",
+                "masks": "my_data_dir/val/masks",
+            },
+            "classes_json": "my_data_dir/classes.json",  # Path to the JSON class mapping file
+            "ignore_classes": [0],
+        },
+    )
+```
+
+`classes_json` only supports the simple string-value format (equivalent to
+`{class_id: "class_name"}`). For advanced mappings that merge multiple labels into one
+class or use multi-channel pixel values, use `classes` instead.
 
 (semantic-segmentation-model)=
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -503,8 +503,10 @@ dictionary.
 #### Loading Classes from a JSON File
 
 Instead of specifying `classes` inline, you can pass a path to a `.json` file directly
-as the `classes` value. The JSON file must map integer class IDs (as strings) to class
-names:
+as the `classes` value. The JSON file supports the same formats as the inline `classes`
+dict.
+
+**Simple format** — maps each class ID to a name (label defaults to the class ID):
 
 ```json
 {
@@ -512,6 +514,24 @@ names:
   "1": "airplane",
   "2": "car",
   "3": "bicycle"
+}
+```
+
+**Single-channel with explicit labels** — merges multiple mask labels into one class:
+
+```json
+{
+  "0": {"name": "background", "labels": [0, 1]},
+  "1": {"name": "vehicle", "labels": [2, 3]}
+}
+```
+
+**Multi-channel** — maps RGB (or other multi-channel) pixel tuples to class IDs:
+
+```json
+{
+  "0": {"name": "background", "labels": [[0, 0, 0], [255, 255, 255]]},
+  "1": {"name": "road", "labels": [[128, 128, 128]]}
 }
 ```
 
@@ -538,10 +558,6 @@ if __name__ == "__main__":
         },
     )
 ```
-
-Loading from a JSON file only supports the simple string-value format (equivalent to
-`{class_id: "class_name"}`). For advanced mappings that merge multiple labels into one
-class or use multi-channel pixel values, use an inline `classes` dict instead.
 
 (semantic-segmentation-model)=
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -441,9 +441,8 @@ We support two mask formats:
 - Single-channel integer masks, where each integer value determines a label
 - Multi-channel masks (e.g., RGB masks), where each pixel value determines a label
 
-Use either `classes` or `classes_json` in the `data` dict to map class IDs to labels —
-exactly one of them must be set. In this document, a **class ID** is a key in the
-`classes` dictionary and a **label** is its value.
+Use `classes` in the `data` dict to map class IDs to labels. In this document, a **class
+ID** is a key in the `classes` dictionary and a **label** is its value.
 
 #### Using Integer Masks
 
@@ -503,9 +502,9 @@ dictionary.
 
 #### Loading Classes from a JSON File
 
-Instead of specifying `classes` inline, you can load a simple class mapping from a JSON
-file using `classes_json`. The JSON file must map integer class IDs (as strings) to
-class names:
+Instead of specifying `classes` inline, you can pass a path to a `.json` file directly
+as the `classes` value. The JSON file must map integer class IDs (as strings) to class
+names:
 
 ```json
 {
@@ -516,7 +515,7 @@ class names:
 }
 ```
 
-Pass the path to this file via `classes_json`:
+Pass the path to this file as `classes`:
 
 ```python
 import lightly_train
@@ -534,15 +533,15 @@ if __name__ == "__main__":
                 "images": "my_data_dir/val/images",
                 "masks": "my_data_dir/val/masks",
             },
-            "classes_json": "my_data_dir/classes.json",  # Path to the JSON class mapping file
+            "classes": "my_data_dir/classes.json",  # Path to the JSON class mapping file
             "ignore_classes": [0],
         },
     )
 ```
 
-`classes_json` only supports the simple string-value format (equivalent to
+Loading from a JSON file only supports the simple string-value format (equivalent to
 `{class_id: "class_name"}`). For advanced mappings that merge multiple labels into one
-class or use multi-channel pixel values, use `classes` instead.
+class or use multi-channel pixel values, use an inline `classes` dict instead.
 
 (semantic-segmentation-model)=
 

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -330,8 +330,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
                 raise ValueError(f"Failed to read classes file '{path}': {e}") from e
             if not isinstance(data, dict):
                 raise ValueError(
-                    f"Expected '{path}' to contain a JSON object ({{...}}), "
-                    f"got {type(data).__name__}."
+                    f"Expected '{path}' to contain a JSON dict, got {type(data).__name__}."
                 )
             classes = {int(k): v for k, v in data.items()}
 

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -7,13 +7,14 @@
 #
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Iterable, Union
 
 import numpy as np
 import torch
-from pydantic import AliasChoices, Field, TypeAdapter, field_validator
+from pydantic import AliasChoices, Field, TypeAdapter, field_validator, model_validator
 from torch import Tensor
 
 from lightly_train._configs.config import PydanticConfig
@@ -306,8 +307,23 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     ignore_index: ClassVar[int] = -100
     train: SplitArgs
     val: SplitArgs
-    classes: dict[int, ClassInfo]
+    classes: dict[int, ClassInfo] | None = None
+    classes_json: PathLike | None = None
     ignore_classes: set[int] | None = Field(default=None, strict=False)
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_classes_xor_classes_json(cls, values: Any) -> Any:
+        has_classes = values.get("classes") is not None
+        has_classes_json = values.get("classes_json") is not None
+        if has_classes == has_classes_json:
+            raise ValueError("Exactly one of 'classes' or 'classes_json' must be set.")
+        if has_classes_json:
+            path = Path(values["classes_json"])
+            with open(path) as f:
+                data: dict[str, str] = json.load(f)
+            values["classes"] = {int(k): v for k, v in data.items()}
+        return values
 
     def train_imgs_path(self) -> Path:
         return Path(self.train.images)

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -334,6 +334,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
                 )
             classes = {int(k): v for k, v in data.items()}
 
+        # We need strict=False, as otherwise the lists from JSON file cannot be coherced into a MultiChannelClassInfo.
         classes_validated = TypeAdapter(
             Dict[int, Union[str, SingleChannelClassInfo, MultiChannelClassInfo]]
         ).validate_python(classes, strict=False)

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Iterable, Union
+from typing import Any, ClassVar, Dict, Iterable, Union, cast
 
 import numpy as np
 import torch
@@ -307,7 +307,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     ignore_index: ClassVar[int] = -100
     train: SplitArgs
     val: SplitArgs
-    classes: dict[int, ClassInfo]
+    classes: dict[int, ClassInfo] | PathLike
     ignore_classes: set[int] | None = Field(default=None, strict=False)
 
     def train_imgs_path(self) -> Path:
@@ -417,9 +417,10 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def included_classes(self) -> dict[int, str]:
         """Returns classes (AFTER mapping) that are not ignored with the name."""
         ignore_classes = set() if self.ignore_classes is None else self.ignore_classes
+        classes = cast(dict[int, ClassInfo], self.classes)
 
         result = {}
-        for class_id, class_info in self.classes.items():
+        for class_id, class_info in classes.items():
             if class_id not in ignore_classes:
                 result[class_id] = class_info.name
 
@@ -438,7 +439,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.train.images),
             mask_dir_or_file=str(self.train.masks),
-            classes=self.classes,
+            classes=cast(dict[int, ClassInfo], self.classes),
             ignore_classes=self.ignore_classes,
             ignore_index=self.ignore_index,
         )
@@ -449,7 +450,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.val.images),
             mask_dir_or_file=str(self.val.masks),
-            classes=self.classes,
+            classes=cast(dict[int, ClassInfo], self.classes),
             ignore_classes=self.ignore_classes,
             ignore_index=self.ignore_index,
         )

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -417,7 +417,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def included_classes(self) -> dict[int, str]:
         """Returns classes (AFTER mapping) that are not ignored with the name."""
         ignore_classes = set() if self.ignore_classes is None else self.ignore_classes
-        classes = cast(dict[int, ClassInfo], self.classes)
+        classes = cast(Dict[int, ClassInfo], self.classes)
 
         result = {}
         for class_id, class_info in classes.items():
@@ -439,7 +439,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.train.images),
             mask_dir_or_file=str(self.train.masks),
-            classes=cast(dict[int, ClassInfo], self.classes),
+            classes=cast(Dict[int, ClassInfo], self.classes),
             ignore_classes=self.ignore_classes,
             ignore_index=self.ignore_index,
         )
@@ -450,7 +450,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.val.images),
             mask_dir_or_file=str(self.val.masks),
-            classes=cast(dict[int, ClassInfo], self.classes),
+            classes=cast(Dict[int, ClassInfo], self.classes),
             ignore_classes=self.ignore_classes,
             ignore_index=self.ignore_index,
         )

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar, Dict, Iterable, Union
 
 import numpy as np
 import torch
-from pydantic import AliasChoices, Field, TypeAdapter, field_validator, model_validator
+from pydantic import AliasChoices, Field, TypeAdapter, field_validator
 from torch import Tensor
 
 from lightly_train._configs.config import PydanticConfig
@@ -307,21 +307,8 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     ignore_index: ClassVar[int] = -100
     train: SplitArgs
     val: SplitArgs
-    classes: dict[int, ClassInfo] | PathLike
+    classes: dict[int, ClassInfo]
     ignore_classes: set[int] | None = Field(default=None, strict=False)
-
-    @model_validator(mode="before")
-    @classmethod
-    def load_classes_from_path(cls, values: Any) -> Any:
-        classes = values.get("classes")
-        if isinstance(classes, (str, Path)):
-            path = Path(classes)
-            if path.suffix != ".json":
-                raise ValueError(f"'classes' path must be a .json file, got: '{path}'")
-            with open(path) as f:
-                data: dict[str, str] = json.load(f)
-            values["classes"] = {int(k): v for k, v in data.items()}
-        return values
 
     def train_imgs_path(self) -> Path:
         return Path(self.train.images)
@@ -331,12 +318,26 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
 
     @field_validator("classes", mode="before")
     @classmethod
-    def validate_classes(
-        cls, classes: dict[int, str | dict[str, Any]]
-    ) -> dict[int, ClassInfo]:
+    def validate_classes(cls, classes: Any) -> dict[int, ClassInfo]:
+        if isinstance(classes, (str, Path)):
+            path = Path(classes)
+            if path.suffix != ".json":
+                raise ValueError(f"'classes' path must be a .json file, got: '{path}'")
+            try:
+                with path.open(encoding="utf-8") as f:
+                    data = json.load(f)
+            except OSError as e:
+                raise ValueError(f"Failed to read classes file '{path}': {e}") from e
+            if not isinstance(data, dict):
+                raise ValueError(
+                    f"Expected '{path}' to contain a JSON object ({{...}}), "
+                    f"got {type(data).__name__}."
+                )
+            classes = {int(k): v for k, v in data.items()}
+
         classes_validated = TypeAdapter(
             Dict[int, Union[str, SingleChannelClassInfo, MultiChannelClassInfo]]
-        ).validate_python(classes)
+        ).validate_python(classes, strict=False)
 
         # Convert to ClassInfo objects and perform consistency checks.
         class_infos: dict[int, ClassInfo] = {}
@@ -416,7 +417,6 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def included_classes(self) -> dict[int, str]:
         """Returns classes (AFTER mapping) that are not ignored with the name."""
         ignore_classes = set() if self.ignore_classes is None else self.ignore_classes
-        assert isinstance(self.classes, dict)  # mypy
 
         result = {}
         for class_id, class_info in self.classes.items():
@@ -435,7 +435,6 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def get_train_args(
         self,
     ) -> MaskSemanticSegmentationDatasetArgs:
-        assert isinstance(self.classes, dict)  # mypy
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.train.images),
             mask_dir_or_file=str(self.train.masks),
@@ -447,7 +446,6 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def get_val_args(
         self,
     ) -> MaskSemanticSegmentationDatasetArgs:
-        assert isinstance(self.classes, dict)  # mypy
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.val.images),
             mask_dir_or_file=str(self.val.masks),

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -307,19 +307,17 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     ignore_index: ClassVar[int] = -100
     train: SplitArgs
     val: SplitArgs
-    classes: dict[int, ClassInfo] | None = None
-    classes_json: PathLike | None = None
+    classes: dict[int, ClassInfo] | PathLike
     ignore_classes: set[int] | None = Field(default=None, strict=False)
 
     @model_validator(mode="before")
     @classmethod
-    def check_classes_xor_classes_json(cls, values: Any) -> Any:
-        has_classes = values.get("classes") is not None
-        has_classes_json = values.get("classes_json") is not None
-        if has_classes == has_classes_json:
-            raise ValueError("Exactly one of 'classes' or 'classes_json' must be set.")
-        if has_classes_json:
-            path = Path(values["classes_json"])
+    def load_classes_from_path(cls, values: Any) -> Any:
+        classes = values.get("classes")
+        if isinstance(classes, (str, Path)):
+            path = Path(classes)
+            if path.suffix != ".json":
+                raise ValueError(f"'classes' path must be a .json file, got: '{path}'")
             with open(path) as f:
                 data: dict[str, str] = json.load(f)
             values["classes"] = {int(k): v for k, v in data.items()}
@@ -418,6 +416,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def included_classes(self) -> dict[int, str]:
         """Returns classes (AFTER mapping) that are not ignored with the name."""
         ignore_classes = set() if self.ignore_classes is None else self.ignore_classes
+        assert isinstance(self.classes, dict)  # mypy
 
         result = {}
         for class_id, class_info in self.classes.items():
@@ -436,6 +435,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def get_train_args(
         self,
     ) -> MaskSemanticSegmentationDatasetArgs:
+        assert isinstance(self.classes, dict)  # mypy
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.train.images),
             mask_dir_or_file=str(self.train.masks),
@@ -447,6 +447,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def get_val_args(
         self,
     ) -> MaskSemanticSegmentationDatasetArgs:
+        assert isinstance(self.classes, dict)  # mypy
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.val.images),
             mask_dir_or_file=str(self.val.masks),

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -336,6 +336,52 @@ class TestMaskSemanticSegmentationDataArgs:
 
         assert dataset_args.included_classes == expected_included
 
+    def test_classes_json(self, tmp_path: Path) -> None:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        json_file = tmp_path / "classes.json"
+        json_file.write_text('{"0": "background", "1": "airplane", "2": "car"}')
+
+        dataset_args = MaskSemanticSegmentationDataArgs(
+            train=SplitArgs(images=image_dir, masks=mask_dir),
+            val=SplitArgs(images=image_dir, masks=mask_dir),
+            classes_json=json_file,
+        )
+
+        assert dataset_args.included_classes == {
+            0: "background",
+            1: "airplane",
+            2: "car",
+        }
+
+    def test_classes_and_classes_json_both_set_raises(self, tmp_path: Path) -> None:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        json_file = tmp_path / "classes.json"
+        json_file.write_text('{"0": "background"}')
+
+        with pytest.raises(
+            ValueError, match="Exactly one of 'classes' or 'classes_json' must be set."
+        ):
+            MaskSemanticSegmentationDataArgs(
+                train=SplitArgs(images=image_dir, masks=mask_dir),
+                val=SplitArgs(images=image_dir, masks=mask_dir),
+                classes={0: "background"},
+                classes_json=json_file,
+            )
+
+    def test_neither_classes_nor_classes_json_raises(self, tmp_path: Path) -> None:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+
+        with pytest.raises(
+            ValueError, match="Exactly one of 'classes' or 'classes_json' must be set."
+        ):
+            MaskSemanticSegmentationDataArgs(
+                train=SplitArgs(images=image_dir, masks=mask_dir),
+                val=SplitArgs(images=image_dir, masks=mask_dir),
+            )
+
 
 class TestMaskSemanticSegmentationDatasetArgs:
     def test_mask_dir_or_file__filename_template_string(self, tmp_path: Path) -> None:

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -121,7 +121,6 @@ class TestMaskSemanticSegmentationDataArgs:
         )
 
         # Check that all inputs were converted to ClassInfo objects
-        assert isinstance(dataset_args.classes, dict)
         assert set(dataset_args.classes.keys()) == set(expected_checks.keys()), (
             "Class IDs don't match"
         )
@@ -176,7 +175,6 @@ class TestMaskSemanticSegmentationDataArgs:
         )
 
         # Check that all inputs were converted to ClassInfo objects
-        assert isinstance(dataset_args.classes, dict)
         assert set(dataset_args.classes.keys()) == set(expected_checks.keys()), (
             "Class IDs don't match"
         )
@@ -347,7 +345,7 @@ class TestMaskSemanticSegmentationDataArgs:
         dataset_args = MaskSemanticSegmentationDataArgs(
             train=SplitArgs(images=image_dir, masks=mask_dir),
             val=SplitArgs(images=image_dir, masks=mask_dir),
-            classes=json_file,
+            classes=json_file,  # type: ignore[arg-type]
         )
 
         assert dataset_args.included_classes == {
@@ -355,6 +353,61 @@ class TestMaskSemanticSegmentationDataArgs:
             1: "airplane",
             2: "car",
         }
+
+    def test_classes_json_single_channel_with_explicit_labels(
+        self, tmp_path: Path
+    ) -> None:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        json_file = tmp_path / "classes.json"
+        json_file.write_text(
+            '{"0": {"name": "background", "labels": [0, 1]}, "1": {"name": "vehicle", "labels": [2, 3]}}'
+        )
+
+        dataset_args = MaskSemanticSegmentationDataArgs(
+            train=SplitArgs(images=image_dir, masks=mask_dir),
+            val=SplitArgs(images=image_dir, masks=mask_dir),
+            classes=json_file,  # type: ignore[arg-type]
+        )
+
+        assert isinstance(dataset_args.classes[0], SingleChannelClassInfo)
+        assert dataset_args.classes[0].name == "background"
+        assert dataset_args.classes[0].labels == {0, 1}
+        assert dataset_args.classes[1].name == "vehicle"
+        assert dataset_args.classes[1].labels == {2, 3}
+
+    def test_classes_json_multi_channel(self, tmp_path: Path) -> None:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        json_file = tmp_path / "classes.json"
+        json_file.write_text(
+            '{"0": {"name": "background", "labels": [[0, 0, 0], [255, 255, 255]]}, "1": {"name": "road", "labels": [[128, 128, 128]]}}'
+        )
+
+        dataset_args = MaskSemanticSegmentationDataArgs(
+            train=SplitArgs(images=image_dir, masks=mask_dir),
+            val=SplitArgs(images=image_dir, masks=mask_dir),
+            classes=json_file,  # type: ignore[arg-type]
+        )
+
+        assert isinstance(dataset_args.classes[0], MultiChannelClassInfo)
+        assert dataset_args.classes[0].name == "background"
+        assert dataset_args.classes[0].labels == {(0, 0, 0), (255, 255, 255)}
+        assert dataset_args.classes[1].name == "road"
+        assert dataset_args.classes[1].labels == {(128, 128, 128)}
+
+    def test_classes_json_not_a_mapping_raises(self, tmp_path: Path) -> None:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        json_file = tmp_path / "classes.json"
+        json_file.write_text("[0, 1, 2]")
+
+        with pytest.raises(ValueError, match="Expected '.*' to contain a JSON object"):
+            MaskSemanticSegmentationDataArgs(
+                train=SplitArgs(images=image_dir, masks=mask_dir),
+                val=SplitArgs(images=image_dir, masks=mask_dir),
+                classes=json_file,  # type: ignore[arg-type]
+            )
 
     def test_classes_json_wrong_extension_raises(self, tmp_path: Path) -> None:
         image_dir = tmp_path / "images"
@@ -365,7 +418,7 @@ class TestMaskSemanticSegmentationDataArgs:
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes=txt_file,
+                classes=txt_file,  # type: ignore[arg-type]
             )
 
 

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -406,7 +406,7 @@ class TestMaskSemanticSegmentationDataArgs:
         json_file = tmp_path / "classes.json"
         json_file.write_text("[0, 1, 2]")
 
-        with pytest.raises(ValueError, match="Expected '.*' to contain a JSON object"):
+        with pytest.raises(ValueError, match="Expected '.*' to contain a JSON dict"):
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -121,6 +121,7 @@ class TestMaskSemanticSegmentationDataArgs:
         )
 
         # Check that all inputs were converted to ClassInfo objects
+        assert isinstance(dataset_args.classes, dict)
         assert set(dataset_args.classes.keys()) == set(expected_checks.keys()), (
             "Class IDs don't match"
         )
@@ -175,6 +176,7 @@ class TestMaskSemanticSegmentationDataArgs:
         )
 
         # Check that all inputs were converted to ClassInfo objects
+        assert isinstance(dataset_args.classes, dict)
         assert set(dataset_args.classes.keys()) == set(expected_checks.keys()), (
             "Class IDs don't match"
         )
@@ -345,7 +347,7 @@ class TestMaskSemanticSegmentationDataArgs:
         dataset_args = MaskSemanticSegmentationDataArgs(
             train=SplitArgs(images=image_dir, masks=mask_dir),
             val=SplitArgs(images=image_dir, masks=mask_dir),
-            classes=json_file,  # type: ignore[arg-type]
+            classes=json_file,
         )
 
         assert dataset_args.included_classes == {
@@ -367,9 +369,10 @@ class TestMaskSemanticSegmentationDataArgs:
         dataset_args = MaskSemanticSegmentationDataArgs(
             train=SplitArgs(images=image_dir, masks=mask_dir),
             val=SplitArgs(images=image_dir, masks=mask_dir),
-            classes=json_file,  # type: ignore[arg-type]
+            classes=json_file,
         )
 
+        assert isinstance(dataset_args.classes, dict)
         assert isinstance(dataset_args.classes[0], SingleChannelClassInfo)
         assert dataset_args.classes[0].name == "background"
         assert dataset_args.classes[0].labels == {0, 1}
@@ -387,9 +390,10 @@ class TestMaskSemanticSegmentationDataArgs:
         dataset_args = MaskSemanticSegmentationDataArgs(
             train=SplitArgs(images=image_dir, masks=mask_dir),
             val=SplitArgs(images=image_dir, masks=mask_dir),
-            classes=json_file,  # type: ignore[arg-type]
+            classes=json_file,
         )
 
+        assert isinstance(dataset_args.classes, dict)
         assert isinstance(dataset_args.classes[0], MultiChannelClassInfo)
         assert dataset_args.classes[0].name == "background"
         assert dataset_args.classes[0].labels == {(0, 0, 0), (255, 255, 255)}
@@ -406,7 +410,7 @@ class TestMaskSemanticSegmentationDataArgs:
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes=json_file,  # type: ignore[arg-type]
+                classes=json_file,
             )
 
     def test_classes_json_wrong_extension_raises(self, tmp_path: Path) -> None:
@@ -418,7 +422,7 @@ class TestMaskSemanticSegmentationDataArgs:
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes=txt_file,  # type: ignore[arg-type]
+                classes=txt_file,
             )
 
 

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -121,6 +121,7 @@ class TestMaskSemanticSegmentationDataArgs:
         )
 
         # Check that all inputs were converted to ClassInfo objects
+        assert isinstance(dataset_args.classes, dict)
         assert set(dataset_args.classes.keys()) == set(expected_checks.keys()), (
             "Class IDs don't match"
         )
@@ -175,6 +176,7 @@ class TestMaskSemanticSegmentationDataArgs:
         )
 
         # Check that all inputs were converted to ClassInfo objects
+        assert isinstance(dataset_args.classes, dict)
         assert set(dataset_args.classes.keys()) == set(expected_checks.keys()), (
             "Class IDs don't match"
         )
@@ -345,7 +347,7 @@ class TestMaskSemanticSegmentationDataArgs:
         dataset_args = MaskSemanticSegmentationDataArgs(
             train=SplitArgs(images=image_dir, masks=mask_dir),
             val=SplitArgs(images=image_dir, masks=mask_dir),
-            classes_json=json_file,
+            classes=json_file,
         )
 
         assert dataset_args.included_classes == {
@@ -354,32 +356,16 @@ class TestMaskSemanticSegmentationDataArgs:
             2: "car",
         }
 
-    def test_classes_and_classes_json_both_set_raises(self, tmp_path: Path) -> None:
+    def test_classes_json_wrong_extension_raises(self, tmp_path: Path) -> None:
         image_dir = tmp_path / "images"
         mask_dir = tmp_path / "masks"
-        json_file = tmp_path / "classes.json"
-        json_file.write_text('{"0": "background"}')
+        txt_file = tmp_path / "classes.txt"
 
-        with pytest.raises(
-            ValueError, match="Exactly one of 'classes' or 'classes_json' must be set."
-        ):
+        with pytest.raises(ValueError, match="'classes' path must be a .json file"):
             MaskSemanticSegmentationDataArgs(
                 train=SplitArgs(images=image_dir, masks=mask_dir),
                 val=SplitArgs(images=image_dir, masks=mask_dir),
-                classes={0: "background"},
-                classes_json=json_file,
-            )
-
-    def test_neither_classes_nor_classes_json_raises(self, tmp_path: Path) -> None:
-        image_dir = tmp_path / "images"
-        mask_dir = tmp_path / "masks"
-
-        with pytest.raises(
-            ValueError, match="Exactly one of 'classes' or 'classes_json' must be set."
-        ):
-            MaskSemanticSegmentationDataArgs(
-                train=SplitArgs(images=image_dir, masks=mask_dir),
-                val=SplitArgs(images=image_dir, masks=mask_dir),
+                classes=txt_file,
             )
 
 


### PR DESCRIPTION
## What has changed and why?

This PR allows one to specify the classes for semantic segmentation from a json file.

This was done in order to import semantic segmentation datasets exported from Lightly Studio.

For consistency, we might add the same functionality in the future for other tasks/datasets.


[Semantic Segmentation - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/26703961/Semantic.Segmentation.-.LightlyTrain.documentation.pdf)



## How has it been tested?

Added two unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
