### PR TITLE
Resolve default start and stop step based on total number of steps automatically.

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -1382,6 +1382,19 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
             num_workers=config.num_workers,
             loader_args=config.loader_args,
         )
+        # Resolve step-based augmentation schedule now that dataloader length
+        # and gradient accumulation steps are known.
+        if hasattr(train_transform_args, "resolve_step_schedule"):
+            train_transform_args.resolve_step_schedule(
+                total_steps=no_auto(config.steps),
+                train_num_batches=len(train_dataloader),
+                gradient_accumulation_steps=no_auto(config.gradient_accumulation_steps),
+            )
+            logger.debug(
+                f"Resolved train transform args after step schedule resolution: "
+                f"{helpers.pretty_format_args(train_transform_args.model_dump())}"
+            )
+
         config.logger_args = helpers.get_logger_args(
             steps=config.steps,
             val_steps=len(val_dataloader),

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
@@ -16,6 +16,7 @@ from pydantic import Field
 from lightly_train._transforms.object_detection_transform import (
     ObjectDetectionTransform,
     ObjectDetectionTransformArgs,
+    resolve_ltdetr_step_schedule,
 )
 from lightly_train._transforms.transform import (
     CopyBlendArgs,
@@ -47,13 +48,11 @@ class DINOv2LTDETRObjectDetectionRandomPhotometricDistortArgs(
     saturation: tuple[float, float] = (0.5, 1.5)
     hue: tuple[float, float] = (-0.05, 0.05)
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means photometric distort is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
@@ -62,13 +61,11 @@ class DINOv2LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
     fill: float = 0.0
     side_range: tuple[float, float] = (1.0, 4.0)
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means random zoom out is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
@@ -82,13 +79,11 @@ class DINOv2LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
     crop_trials: int = 40
     iou_trials: int = 1000
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means random IoU crop is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionRandomFlipArgs(RandomFlipArgs):
@@ -138,22 +133,19 @@ class DINOv2LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     prob: float = 1.0
     divisible_by: int | None = None
 
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means scale jitter is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionMixUpArgs(MixUpArgs):
     prob: float = 0.5
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the 4 + total_epochs // 2 epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
     # None means mixup is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 250_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
@@ -163,13 +155,11 @@ class DINOv2LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
     num_objects: int = 3
     expand_ratios: tuple[float, float] = (0.1, 0.25)
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
-    # None means copyblend is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means copy blend is always on.
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionMosaicArgs(MosaicArgs):
@@ -184,13 +174,11 @@ class DINOv2LTDETRObjectDetectionMosaicArgs(MosaicArgs):
     max_cached_images: int = 50
     random_pop: bool = True
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
     # None means mosaic is always on.
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 250_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv2LTDETRObjectDetectionResizeArgs(ResizeArgs):
@@ -275,6 +263,26 @@ class DINOv2LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                     self.num_channels = 3
                 else:
                     self.num_channels = len(self.normalize.mean)
+
+    def resolve_step_schedule(
+        self,
+        total_steps: int,
+        train_num_batches: int,
+        gradient_accumulation_steps: int,
+    ) -> None:
+        """Resolve ``"auto"`` step_start / step_stop values.
+
+        Uses fixed epoch counts from the DEIMv2 training regime:
+        - Warmup: 4 epochs (augmentations start here)
+        - No-aug: last 12 epochs (most augmentations stop here)
+        - Mixup/mosaic stop earlier: at epoch ``4 + floor(total_epochs) // 2``
+        """
+        resolve_ltdetr_step_schedule(
+            args=self,
+            total_steps=total_steps,
+            train_num_batches=train_num_batches,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+        )
 
 
 class DINOv2LTDETRObjectDetectionValTransformArgs(ObjectDetectionTransformArgs):

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
@@ -48,9 +48,11 @@ class DINOv2LTDETRObjectDetectionRandomPhotometricDistortArgs(
     saturation: tuple[float, float] = (0.5, 1.5)
     hue: tuple[float, float] = (-0.05, 0.05)
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means photometric distort is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -61,9 +63,11 @@ class DINOv2LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
     fill: float = 0.0
     side_range: tuple[float, float] = (1.0, 4.0)
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means random zoom out is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -79,9 +83,11 @@ class DINOv2LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
     crop_trials: int = 40
     iou_trials: int = 1000
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means random IoU crop is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -133,7 +139,8 @@ class DINOv2LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     prob: float = 1.0
     divisible_by: int | None = None
 
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means scale jitter is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -141,9 +148,11 @@ class DINOv2LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
 class DINOv2LTDETRObjectDetectionMixUpArgs(MixUpArgs):
     prob: float = 0.5
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
+    # "auto" uses a compressed short-run schedule for <= 12 epochs and
+    # transitions to the midpoint rule on longer runs.
     # None means mixup is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -155,9 +164,11 @@ class DINOv2LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
     num_objects: int = 3
     expand_ratios: tuple[float, float] = (0.1, 0.25)
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means copy blend is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -174,9 +185,11 @@ class DINOv2LTDETRObjectDetectionMosaicArgs(MosaicArgs):
     max_cached_images: int = 50
     random_pop: bool = True
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
+    # "auto" uses a compressed short-run schedule for <= 12 epochs and
+    # transitions to the midpoint rule on longer runs.
     # None means mosaic is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
@@ -272,10 +272,7 @@ class DINOv2LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     ) -> None:
         """Resolve ``"auto"`` step_start / step_stop values.
 
-        Uses fixed epoch counts from the DEIMv2 training regime:
-        - Warmup: 4 epochs (augmentations start here)
-        - No-aug: last 12 epochs (most augmentations stop here)
-        - Mixup/mosaic stop earlier: at epoch ``4 + floor(total_epochs) // 2``
+        See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
         """
         resolve_ltdetr_step_schedule(
             args=self,

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/transforms.py
@@ -210,9 +210,15 @@ class DINOv2LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     scale_jitter: DINOv2LTDETRObjectDetectionScaleJitterArgs | None = Field(
         default_factory=DINOv2LTDETRObjectDetectionScaleJitterArgs
     )
-    mosaic: DINOv2LTDETRObjectDetectionMosaicArgs | None = None
-    mixup: DINOv2LTDETRObjectDetectionMixUpArgs | None = None
-    copyblend: DINOv2LTDETRObjectDetectionCopyBlendArgs | None = None
+    mosaic: DINOv2LTDETRObjectDetectionMosaicArgs | None = Field(
+        default_factory=DINOv2LTDETRObjectDetectionMosaicArgs
+    )
+    mixup: DINOv2LTDETRObjectDetectionMixUpArgs | None = Field(
+        default_factory=DINOv2LTDETRObjectDetectionMixUpArgs
+    )
+    copyblend: DINOv2LTDETRObjectDetectionCopyBlendArgs | None = Field(
+        default_factory=DINOv2LTDETRObjectDetectionCopyBlendArgs
+    )
     # We use the YOLO format internally for now.
     bbox_params: BboxParams = Field(
         default_factory=lambda: BboxParams(

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -49,9 +49,11 @@ class DINOv3LTDETRObjectDetectionRandomPhotometricDistortArgs(
     saturation: tuple[float, float] = (0.5, 1.5)
     hue: tuple[float, float] = (-0.05, 0.05)
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means photometric distort is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -62,9 +64,11 @@ class DINOv3LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
     fill: float = 0.0
     side_range: tuple[float, float] = (1.0, 4.0)
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means random zoom out is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -80,9 +84,11 @@ class DINOv3LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
     crop_trials: int = 40
     iou_trials: int = 1000
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means random IoU crop is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -131,7 +137,8 @@ class DINOv3LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     prob: float = 1.0
     divisible_by: int | None = None
 
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means scale jitter is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -139,9 +146,11 @@ class DINOv3LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
 class DINOv3LTDETRObjectDetectionMixUpArgs(MixUpArgs):
     prob: float = 0.5
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
+    # "auto" uses a compressed short-run schedule for <= 12 epochs and
+    # transitions to the midpoint rule on longer runs.
     # None means mixup is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -153,9 +162,11 @@ class DINOv3LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
     num_objects: int = 3
     expand_ratios: tuple[float, float] = (0.1, 0.25)
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
     # None means copy blend is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -172,9 +183,11 @@ class DINOv3LTDETRObjectDetectionMosaicArgs(MosaicArgs):
     max_cached_images: int = 50
     random_pop: bool = True
 
-    # "auto" corresponds to the 4th epoch of the total training run.
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
     step_start: int | Literal["auto"] = "auto"
-    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
+    # "auto" uses a compressed short-run schedule for <= 12 epochs and
+    # transitions to the midpoint rule on longer runs.
     # None means mosaic is always on.
     step_stop: int | Literal["auto"] | None = "auto"
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -270,10 +270,7 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     ) -> None:
         """Resolve ``"auto"`` step_start / step_stop values.
 
-        Uses fixed epoch counts from the DEIMv2 training regime:
-        - Warmup: 4 epochs (augmentations start here)
-        - No-aug: last 12 epochs (most augmentations stop here)
-        - Mixup/mosaic stop earlier: at epoch ``4 + floor(total_epochs) // 2``
+        See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
         """
         resolve_ltdetr_step_schedule(
             args=self,

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -208,9 +208,15 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     scale_jitter: DINOv3LTDETRObjectDetectionScaleJitterArgs | None = Field(
         default_factory=DINOv3LTDETRObjectDetectionScaleJitterArgs
     )
-    mosaic: DINOv3LTDETRObjectDetectionMosaicArgs | None = None
-    mixup: DINOv3LTDETRObjectDetectionMixUpArgs | None = None
-    copyblend: DINOv3LTDETRObjectDetectionCopyBlendArgs | None = None
+    mosaic: DINOv3LTDETRObjectDetectionMosaicArgs | None = Field(
+        default_factory=DINOv3LTDETRObjectDetectionMosaicArgs
+    )
+    mixup: DINOv3LTDETRObjectDetectionMixUpArgs | None = Field(
+        default_factory=DINOv3LTDETRObjectDetectionMixUpArgs
+    )
+    copyblend: DINOv3LTDETRObjectDetectionCopyBlendArgs | None = Field(
+        default_factory=DINOv3LTDETRObjectDetectionCopyBlendArgs
+    )
     # We use the YOLO format internally for now.
     bbox_params: BboxParams = Field(
         default_factory=lambda: BboxParams(

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -16,6 +16,7 @@ from pydantic import Field
 from lightly_train._transforms.object_detection_transform import (
     ObjectDetectionTransform,
     ObjectDetectionTransformArgs,
+    resolve_ltdetr_step_schedule,
 )
 from lightly_train._transforms.transform import (
     ChannelDropArgs,
@@ -48,13 +49,11 @@ class DINOv3LTDETRObjectDetectionRandomPhotometricDistortArgs(
     saturation: tuple[float, float] = (0.5, 1.5)
     hue: tuple[float, float] = (-0.05, 0.05)
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means photometric distort is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
@@ -63,13 +62,11 @@ class DINOv3LTDETRObjectDetectionRandomZoomOutArgs(RandomZoomOutArgs):
     fill: float = 0.0
     side_range: tuple[float, float] = (1.0, 4.0)
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means random zoom out is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
@@ -83,13 +80,11 @@ class DINOv3LTDETRObjectDetectionRandomIoUCropArgs(RandomIoUCropArgs):
     crop_trials: int = 40
     iou_trials: int = 1000
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means random IoU crop is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionRandomFlipArgs(RandomFlipArgs):
@@ -136,22 +131,19 @@ class DINOv3LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     prob: float = 1.0
     divisible_by: int | None = None
 
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
     # None means scale jitter is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionMixUpArgs(MixUpArgs):
     prob: float = 0.5
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the 4 + total_epochs // 2 epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
     # None means mixup is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 250_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
@@ -161,13 +153,11 @@ class DINOv3LTDETRObjectDetectionCopyBlendArgs(CopyBlendArgs):
     num_objects: int = 3
     expand_ratios: tuple[float, float] = (0.1, 0.25)
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
-    # None means copyblend is always on.
-    # TODO (Yutong 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 375_000
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # None means copy blend is always on.
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionMosaicArgs(MosaicArgs):
@@ -182,13 +172,11 @@ class DINOv3LTDETRObjectDetectionMosaicArgs(MosaicArgs):
     max_cached_images: int = 50
     random_pop: bool = True
 
-    # Corresponds to the 4th epoch of the total training run.
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_start: int = 25_000
-    # Corresponds to the total_epochs - no_aug_epoch of the total training run.
+    # "auto" corresponds to the 4th epoch of the total training run.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" corresponds to the 4 + total_epochs // 2 epoch of the total training run.
     # None means mosaic is always on.
-    # TODO(Yutong, 04/26): Update step_start and step_stop based on the actual number of training steps.
-    step_stop: int | None = 250_000
+    step_stop: int | Literal["auto"] | None = "auto"
 
 
 class DINOv3LTDETRObjectDetectionResizeArgs(ResizeArgs):
@@ -273,6 +261,26 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                     self.num_channels = 3
                 else:
                     self.num_channels = len(self.normalize.mean)
+
+    def resolve_step_schedule(
+        self,
+        total_steps: int,
+        train_num_batches: int,
+        gradient_accumulation_steps: int,
+    ) -> None:
+        """Resolve ``"auto"`` step_start / step_stop values.
+
+        Uses fixed epoch counts from the DEIMv2 training regime:
+        - Warmup: 4 epochs (augmentations start here)
+        - No-aug: last 12 epochs (most augmentations stop here)
+        - Mixup/mosaic stop earlier: at epoch ``4 + floor(total_epochs) // 2``
+        """
+        resolve_ltdetr_step_schedule(
+            args=self,
+            total_steps=total_steps,
+            train_num_batches=train_num_batches,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+        )
 
 
 class DINOv3LTDETRObjectDetectionValTransformArgs(ObjectDetectionTransformArgs):

--- a/src/lightly_train/_transforms/object_detection_transform.py
+++ b/src/lightly_train/_transforms/object_detection_transform.py
@@ -7,6 +7,8 @@
 #
 from __future__ import annotations
 
+import logging
+import math
 from typing import Any, Literal
 
 import numpy as np
@@ -110,6 +112,97 @@ class ObjectDetectionTransformArgs(TaskTransformArgs):
     def resolve_incompatible(self) -> None:
         # TODO: Lionel (09/25): Add checks for incompatible args.
         pass
+
+
+_logger = logging.getLogger(__name__)
+
+# DEIMv2 training regime: fixed epoch counts that do not scale.
+_WARMUP_EPOCHS = 4
+_NO_AUG_EPOCHS = 12
+
+
+def resolve_ltdetr_step_schedule(
+    args: ObjectDetectionTransformArgs,
+    total_steps: int,
+    train_num_batches: int,
+    gradient_accumulation_steps: int,
+) -> None:
+    """Resolve ``"auto"`` step_start / step_stop on LTDETR augmentation args.
+
+    Epoch-to-step conversion uses the actual dataloader length so that the
+    augmentation windows adapt to different dataset sizes and batch sizes.
+    """
+    steps_per_epoch = train_num_batches / gradient_accumulation_steps
+    total_epochs = total_steps / steps_per_epoch
+
+    auto_start = math.floor(_WARMUP_EPOCHS * steps_per_epoch)
+    # Clamp to >= 1 so the value passes the step_stop > 0 validator.
+    # Invalid windows (stop <= start) are caught and disabled below.
+    auto_aug_step_stop = max(
+        1, math.floor(max(0, total_epochs - _NO_AUG_EPOCHS) * steps_per_epoch)
+    )
+    auto_flat_step_stop = max(
+        1, math.floor((_WARMUP_EPOCHS + int(total_epochs) // 2) * steps_per_epoch)
+    )
+
+    # Resolve each augmentation field. We pre-check the final window before
+    # assigning so that Pydantic's validate_assignment never sees an invalid
+    # step_stop <= step_start pair.
+    _resolve_aug_fields(
+        args=args,
+        field_names=(
+            "photometric_distort",
+            "random_zoom_out",
+            "random_iou_crop",
+            "copyblend",
+        ),
+        auto_start=auto_start,
+        auto_stop=auto_aug_step_stop,
+    )
+    _resolve_aug_fields(
+        args=args,
+        field_names=("mixup", "mosaic"),
+        auto_start=auto_start,
+        auto_stop=auto_flat_step_stop,
+    )
+
+    # Scale jitter: only has step_stop, no step_start.
+    if args.scale_jitter is not None and args.scale_jitter.step_stop == "auto":
+        args.scale_jitter.step_stop = auto_aug_step_stop
+
+
+def _resolve_aug_fields(
+    args: ObjectDetectionTransformArgs,
+    field_names: tuple[str, ...],
+    auto_start: int,
+    auto_stop: int,
+) -> None:
+    for field_name in field_names:
+        aug = getattr(args, field_name, None)
+        if aug is None:
+            continue
+
+        resolved_start = auto_start if aug.step_start == "auto" else aug.step_start
+        resolved_stop = auto_stop if aug.step_stop == "auto" else aug.step_stop
+
+        # Check if the resolved window is valid before assigning.
+        if (
+            isinstance(resolved_start, int)
+            and isinstance(resolved_stop, int)
+            and resolved_stop <= resolved_start
+        ):
+            _logger.warning(
+                f"Auto-derived step window for {field_name} has "
+                f"step_stop ({resolved_stop}) <= step_start ({resolved_start}). "
+                f"Disabling {field_name} for this run."
+            )
+            setattr(args, field_name, None)
+            continue
+
+        if aug.step_start == "auto":
+            aug.step_start = resolved_start
+        if aug.step_stop == "auto":
+            aug.step_stop = resolved_stop
 
 
 class ObjectDetectionTransform(TaskTransform):

--- a/src/lightly_train/_transforms/object_detection_transform.py
+++ b/src/lightly_train/_transforms/object_detection_transform.py
@@ -116,9 +116,11 @@ class ObjectDetectionTransformArgs(TaskTransformArgs):
 
 _logger = logging.getLogger(__name__)
 
-# DEIMv2 training regime: fixed epoch counts that do not scale.
+# Matched upstream schedule profile for LTDETR.
 _WARMUP_EPOCHS = 4
-_NO_AUG_EPOCHS = 12
+_SHORT_RUN_TOTAL_EPOCHS = 12
+_REFERENCE_TOTAL_EPOCHS = 72
+_REFERENCE_NO_AUG_EPOCHS = 12
 
 
 def resolve_ltdetr_step_schedule(
@@ -129,23 +131,77 @@ def resolve_ltdetr_step_schedule(
 ) -> None:
     """Resolve ``"auto"`` step_start / step_stop on LTDETR augmentation args.
 
-    Epoch-to-step conversion uses the actual dataloader length so that the
-    augmentation windows adapt to different dataset sizes and batch sizes.
+    The algorithm converts internal epoch semantics into concrete step
+    boundaries using the actual dataloader length so that augmentation windows
+    adapt to different dataset sizes and batch sizes.
+
+    The calculation works in five stages:
+
+    1. Compute the effective number of optimizer steps per epoch as
+       ``train_num_batches / gradient_accumulation_steps``.
+    2. Derive the effective training length in epochs as
+       ``total_steps / steps_per_epoch``
+    3. Scale the canonical LTDETR no-augmentation tail from the matched upstream profile
+    (``_REFERENCE_TOTAL_EPOCHS`` / ``_REFERENCE_NO_AUG_EPOCHS``) and scaled
+        proportionally to the actual run length::
+        no_aug_epochs_resolved = max(
+            1,
+            min(
+                _REFERENCE_NO_AUG_EPOCHS,
+                round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
+            ),
+        )
+    4. Convert the epoch recipe into three epoch boundaries:
+        - epoch_stop_resolved = total_epochs - no_aug_epochs_resolved
+        - short runs with ``total_epochs <= _SHORT_RUN_TOTAL_EPOCHS`` compress to
+            ``epoch_start = min(_WARMUP_EPOCHS, floor(total_epochs / 3))`` and
+            ``epoch_flat = min(epoch_stop, 2 * epoch_start)``
+        - longer runs keep ``epoch_start = _WARMUP_EPOCHS`` and use
+            ``epoch_flat = _WARMUP_EPOCHS + floor(epoch_stop / 2)``
+    5. Convert each epoch boundary back to integer steps with
+       ``floor(epoch * steps_per_epoch)``.
+
+    The resolved step windows are then assigned as follows:
+    - ``photometric_distort``, ``random_zoom_out``, ``random_iou_crop``, and
+      ``copyblend`` use ``[step_start, step_stop)``
+    - ``mixup`` and ``mosaic`` use ``[step_start, step_flat)``
+    - ``scale_jitter`` is stop-only and uses ``[0, step_stop)``
+
+    Collapsed windows are treated as disabling the augmentation instead of causing an error:
+    - ``step_stop <= step_start``: disable photometric_distort,
+      random_zoom_out, random_iou_crop, and copyblend.
+    - ``step_flat <= step_start``: disable mixup and mosaic.
+    - ``step_stop <= 0``: disable scale_jitter.
+    - An empty window is never clamped to ``step_stop = 1``; the
+      augmentation is disabled instead.
     """
     steps_per_epoch = train_num_batches / gradient_accumulation_steps
     total_epochs = total_steps / steps_per_epoch
 
-    auto_start = math.floor(_WARMUP_EPOCHS * steps_per_epoch)
-    # Clamp to >= 1 so the value passes the step_stop > 0 validator.
-    # Invalid windows (stop <= start) are caught and disabled below.
-    auto_aug_step_stop = max(
-        1, math.floor(max(0, total_epochs - _NO_AUG_EPOCHS) * steps_per_epoch)
+    # Resolve no-aug tail from matched upstream profile.
+    no_aug_epochs_resolved = max(
+        1,
+        min(
+            _REFERENCE_NO_AUG_EPOCHS,
+            round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
+        ),
     )
-    auto_flat_step_stop = max(
-        1, math.floor((_WARMUP_EPOCHS + int(total_epochs) // 2) * steps_per_epoch)
-    )
+    epoch_stop_resolved = total_epochs - no_aug_epochs_resolved
 
-    # Resolve each augmentation field. We pre-check the final window before
+    # Compute epoch_start and epoch_flat with short-run compression.
+    if total_epochs <= _SHORT_RUN_TOTAL_EPOCHS:
+        epoch_start_resolved = min(_WARMUP_EPOCHS, math.floor(total_epochs / 3))
+        epoch_flat_resolved = min(epoch_stop_resolved, 2 * epoch_start_resolved)
+    else:
+        epoch_start_resolved = _WARMUP_EPOCHS
+        epoch_flat_resolved = _WARMUP_EPOCHS + math.floor(epoch_stop_resolved / 2)
+
+    # Convert epoch boundaries to steps.
+    step_start_resolved = math.floor(epoch_start_resolved * steps_per_epoch)
+    step_stop_resolved = math.floor(epoch_stop_resolved * steps_per_epoch)
+    step_flat_resolved = math.floor(epoch_flat_resolved * steps_per_epoch)
+
+    # Resolve each augmentation field.  We pre-check the final window before
     # assigning so that Pydantic's validate_assignment never sees an invalid
     # step_stop <= step_start pair.
     _resolve_aug_fields(
@@ -156,53 +212,61 @@ def resolve_ltdetr_step_schedule(
             "random_iou_crop",
             "copyblend",
         ),
-        auto_start=auto_start,
-        auto_stop=auto_aug_step_stop,
+        step_start_resolved=step_start_resolved,
+        step_stop_resolved=step_stop_resolved,
     )
     _resolve_aug_fields(
         args=args,
         field_names=("mixup", "mosaic"),
-        auto_start=auto_start,
-        auto_stop=auto_flat_step_stop,
+        step_start_resolved=step_start_resolved,
+        step_stop_resolved=step_flat_resolved,
     )
 
     # Scale jitter: only has step_stop, no step_start.
     if args.scale_jitter is not None and args.scale_jitter.step_stop == "auto":
-        args.scale_jitter.step_stop = auto_aug_step_stop
+        if step_stop_resolved <= 0:
+            _logger.warning(
+                "Auto-derived step window for scale_jitter has "
+                f"step_stop ({step_stop_resolved}) <= 0. "
+                "Disabling scale_jitter for this run."
+            )
+            args.scale_jitter = None
+        else:
+            args.scale_jitter.step_stop = step_stop_resolved
 
 
 def _resolve_aug_fields(
     args: ObjectDetectionTransformArgs,
     field_names: tuple[str, ...],
-    auto_start: int,
-    auto_stop: int,
+    step_start_resolved: int,
+    step_stop_resolved: int,
 ) -> None:
     for field_name in field_names:
         aug = getattr(args, field_name, None)
         if aug is None:
             continue
 
-        resolved_start = auto_start if aug.step_start == "auto" else aug.step_start
-        resolved_stop = auto_stop if aug.step_stop == "auto" else aug.step_stop
+        step_start = step_start_resolved if aug.step_start == "auto" else aug.step_start
+        step_stop = step_stop_resolved if aug.step_stop == "auto" else aug.step_stop
 
         # Check if the resolved window is valid before assigning.
         if (
-            isinstance(resolved_start, int)
-            and isinstance(resolved_stop, int)
-            and resolved_stop <= resolved_start
+            isinstance(step_start, int)
+            and isinstance(step_stop, int)
+            and step_stop <= step_start
         ):
             _logger.warning(
                 f"Auto-derived step window for {field_name} has "
-                f"step_stop ({resolved_stop}) <= step_start ({resolved_start}). "
+                f"step_stop ({step_stop}) <= step_start ({step_start}). "
                 f"Disabling {field_name} for this run."
             )
             setattr(args, field_name, None)
             continue
 
         if aug.step_start == "auto":
-            aug.step_start = resolved_start
+            aug.step_start = step_start
         if aug.step_stop == "auto":
-            aug.step_stop = resolved_stop
+            aug.step_stop = step_stop
 
 
 class ObjectDetectionTransform(TaskTransform):

--- a/src/lightly_train/_transforms/object_detection_transform.py
+++ b/src/lightly_train/_transforms/object_detection_transform.py
@@ -131,70 +131,71 @@ def resolve_ltdetr_step_schedule(
 ) -> None:
     """Resolve ``"auto"`` step_start / step_stop on LTDETR augmentation args.
 
-    The algorithm converts internal epoch semantics into concrete step
-    boundaries using the actual dataloader length so that augmentation windows
-    adapt to different dataset sizes and batch sizes.
+    The algorithm converts LTDETR's epoch-based schedule into concrete step
+    boundaries using the effective number of optimizer steps per epoch,
+    ``train_num_batches / gradient_accumulation_steps``.
 
-    The calculation works in five stages:
+    The calculation works in four stages:
 
-    1. Compute the effective number of optimizer steps per epoch as
-       ``train_num_batches / gradient_accumulation_steps``.
-    2. Derive the effective training length in epochs as
-       ``total_steps / steps_per_epoch``
-    3. Scale the canonical LTDETR no-augmentation tail from the matched upstream profile
-    (``_REFERENCE_TOTAL_EPOCHS`` / ``_REFERENCE_NO_AUG_EPOCHS``) and scaled
-        proportionally to the actual run length::
-        no_aug_epochs_resolved = max(
-            1,
-            min(
-                _REFERENCE_NO_AUG_EPOCHS,
-                round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
-            ),
-        )
-    4. Convert the epoch recipe into three epoch boundaries:
-        - epoch_stop_resolved = total_epochs - no_aug_epochs_resolved
-        - short runs with ``total_epochs <= _SHORT_RUN_TOTAL_EPOCHS`` compress to
-            ``epoch_start = min(_WARMUP_EPOCHS, floor(total_epochs / 3))`` and
-            ``epoch_flat = min(epoch_stop, 2 * epoch_start)``
-        - longer runs keep ``epoch_start = _WARMUP_EPOCHS`` and use
-            ``epoch_flat = _WARMUP_EPOCHS + floor(epoch_stop / 2)``
-    5. Convert each epoch boundary back to integer steps with
+    1. Derive the effective training length in epochs as
+       ``total_steps / steps_per_epoch``.
+    2. Scale the canonical LTDETR no-augmentation tail from the matched
+       upstream profile:
+
+           no_aug_epochs_resolved = min(
+               _REFERENCE_NO_AUG_EPOCHS,
+               round(
+                   total_epochs
+                   * _REFERENCE_NO_AUG_EPOCHS
+                   / _REFERENCE_TOTAL_EPOCHS
+               ),
+           )
+
+    3. Convert that recipe into three epoch boundaries:
+       - ``epoch_stop_resolved = total_epochs - no_aug_epochs_resolved``
+       - short runs with ``total_epochs <= _SHORT_RUN_TOTAL_EPOCHS`` compress
+         the warmup to
+         ``floor(total_epochs / (_SHORT_RUN_TOTAL_EPOCHS / _WARMUP_EPOCHS))``
+         and set ``epoch_flat_resolved`` to
+         ``min(epoch_stop_resolved, epoch_start_resolved + floor(total_epochs / 2))``
+       - longer runs keep ``epoch_start_resolved = _WARMUP_EPOCHS`` and use
+         ``epoch_flat_resolved = _WARMUP_EPOCHS + floor(total_epochs / 2)``
+    4. Convert each epoch boundary back to integer steps with
        ``floor(epoch * steps_per_epoch)``.
 
-    The resolved step windows are then assigned as follows:
+    Only fields whose boundary is ``"auto"`` are rewritten:
     - ``photometric_distort``, ``random_zoom_out``, ``random_iou_crop``, and
-      ``copyblend`` use ``[step_start, step_stop)``
-    - ``mixup`` and ``mosaic`` use ``[step_start, step_flat)``
-    - ``scale_jitter`` is stop-only and uses ``[0, step_stop)``
+      ``copyblend`` use [``step_start_resolved``, ``step_stop_resolved``)
+    - ``mixup`` and ``mosaic`` use [``step_start_resolved``, ``step_flat_resolved``)
+    - ``scale_jitter`` only resolves ``step_stop_resolved``
 
-    Collapsed windows are treated as disabling the augmentation instead of causing an error:
-    - ``step_stop <= step_start``: disable photometric_distort,
-      random_zoom_out, random_iou_crop, and copyblend.
-    - ``step_flat <= step_start``: disable mixup and mosaic.
-    - ``step_stop <= 0``: disable scale_jitter.
-    - An empty window is never clamped to ``step_stop = 1``; the
-      augmentation is disabled instead.
+    If an augmentation's final integer window is empty, it is disabled instead
+    of clamped to a minimum length. In practice this means:
+    - ``step_stop <= step_start`` disables the corresponding augmentation field
+    - ``scale_jitter`` is disabled when its resolved auto ``step_stop <= 0``
     """
     steps_per_epoch = train_num_batches / gradient_accumulation_steps
     total_epochs = total_steps / steps_per_epoch
 
     # Resolve no-aug tail from matched upstream profile.
-    no_aug_epochs_resolved = max(
-        1,
-        min(
-            _REFERENCE_NO_AUG_EPOCHS,
-            round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
-        ),
+    no_aug_epochs_resolved = min(
+        _REFERENCE_NO_AUG_EPOCHS,
+        round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
     )
     epoch_stop_resolved = total_epochs - no_aug_epochs_resolved
 
     # Compute epoch_start and epoch_flat with short-run compression.
     if total_epochs <= _SHORT_RUN_TOTAL_EPOCHS:
-        epoch_start_resolved = min(_WARMUP_EPOCHS, math.floor(total_epochs / 3))
-        epoch_flat_resolved = min(epoch_stop_resolved, 2 * epoch_start_resolved)
+        epoch_start_resolved = math.floor(
+            total_epochs / (_SHORT_RUN_TOTAL_EPOCHS / _WARMUP_EPOCHS)
+        )
+        epoch_flat_resolved = min(
+            epoch_stop_resolved,
+            epoch_start_resolved + math.floor(total_epochs / 2),
+        )
     else:
         epoch_start_resolved = _WARMUP_EPOCHS
-        epoch_flat_resolved = _WARMUP_EPOCHS + math.floor(epoch_stop_resolved / 2)
+        epoch_flat_resolved = _WARMUP_EPOCHS + math.floor(total_epochs / 2)
 
     # Convert epoch boundaries to steps.
     step_start_resolved = math.floor(epoch_start_resolved * steps_per_epoch)

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -65,19 +65,37 @@ class RandomFlipArgs(PydanticConfig):
 
 
 class ActivationPolicyArgs(PydanticConfig):
-    step_start: int = Field(default=0, ge=0)
-    step_stop: int | None = Field(default=None, gt=0)
+    step_start: int | Literal["auto"] = 0
+    step_stop: int | Literal["auto"] | None = None
+
+    @field_validator("step_start")
+    @classmethod
+    def validate_step_start(cls, v: int | str) -> int | str:
+        if isinstance(v, int) and v < 0:
+            raise ValueError("step_start must be >= 0.")
+        return v
+
+    @field_validator("step_stop")
+    @classmethod
+    def validate_step_stop(cls, v: int | str | None) -> int | str | None:
+        if isinstance(v, int) and v <= 0:
+            raise ValueError("step_stop must be > 0.")
+        return v
 
     @model_validator(mode="after")
     def validate_step_window(self) -> ActivationPolicyArgs:
+        if self.step_start == "auto" or self.step_stop == "auto":
+            return self
         if self.step_stop is not None and self.step_start >= self.step_stop:
             raise ValueError("activation policy requires step_start < step_stop.")
         return self
 
     def is_active(self, step: int) -> bool:
+        if self.step_start == "auto":
+            return False
         if step < self.step_start:
             return False
-        if self.step_stop is None:
+        if self.step_stop is None or self.step_stop == "auto":
             return True
         return step < self.step_stop
 
@@ -202,7 +220,14 @@ class ScaleJitterArgs(PydanticConfig):
     divisible_by: int | None
 
     # ScaleJitter does not have `step_start`, only `step_stop`.
-    step_stop: int | None = Field(default=None, gt=0)
+    step_stop: int | Literal["auto"] | None = None
+
+    @field_validator("step_stop")
+    @classmethod
+    def validate_step_stop(cls, v: int | str | None) -> int | str | None:
+        if isinstance(v, int) and v <= 0:
+            raise ValueError("step_stop must be > 0.")
+        return v
 
     @property
     def scale_range(self) -> tuple[float, float] | None:
@@ -211,7 +236,7 @@ class ScaleJitterArgs(PydanticConfig):
         return None
 
     def is_active(self, step: int) -> bool:
-        if self.step_stop is None:
+        if self.step_stop is None or self.step_stop == "auto":
             return True
         return step < self.step_stop
 

--- a/tests/_transforms/test_object_detection_transform.py
+++ b/tests/_transforms/test_object_detection_transform.py
@@ -27,6 +27,7 @@ from lightly_train._transforms.object_detection_transform import (
     ObjectDetectionTransform,
     ObjectDetectionTransformArgs,
     ObjectDetectionTransformInput,
+    resolve_ltdetr_step_schedule,
 )
 from lightly_train._transforms.transform import (
     ChannelDropArgs,
@@ -198,6 +199,13 @@ def _get_bbox_params() -> BboxParams:
     )
 
 
+def _get_ltdetr_train_transform_args() -> DINOv3LTDETRObjectDetectionTrainTransformArgs:
+    return DINOv3LTDETRObjectDetectionTrainTransformArgs(
+        image_size=_get_image_size(),
+        bbox_params=_get_bbox_params(),
+    )
+
+
 PossibleArgsTuple = (
     [None, _get_channel_drop_args()],
     [None, _get_photometric_distort_args()],
@@ -213,6 +221,57 @@ PossibleArgsTuple = (
 )
 
 possible_tuples = list(itertools.product(*PossibleArgsTuple))
+
+
+@pytest.mark.parametrize(
+    ("total_steps", "expected_step_start", "expected_step_flat", "expected_step_stop"),
+    [
+        (100, 0, 0, 100),
+        (200, 0, 100, 200),
+        (300, 100, 200, 300),
+        (400, 100, 300, 300),
+        (1200, 400, 1000, 1000),
+        (7200, 400, 4000, 6000),
+    ],
+)
+def test_resolve_ltdetr_step_schedule__resolved_windows(
+    total_steps: int,
+    expected_step_start: int,
+    expected_step_flat: int,
+    expected_step_stop: int,
+) -> None:
+    transform_args = _get_ltdetr_train_transform_args()
+    transform_args.resolve_auto(model_init_args={})
+
+    resolve_ltdetr_step_schedule(
+        args=transform_args,
+        total_steps=total_steps,
+        train_num_batches=100,
+        gradient_accumulation_steps=1,
+    )
+
+    for aug in (
+        transform_args.photometric_distort,
+        transform_args.random_zoom_out,
+        transform_args.random_iou_crop,
+        transform_args.copyblend,
+    ):
+        assert aug is not None
+        assert aug.step_start == expected_step_start
+        assert aug.step_stop == expected_step_stop
+
+    if expected_step_flat > expected_step_start:
+        for mix_aug in (transform_args.mixup, transform_args.mosaic):
+            assert mix_aug is not None
+            assert mix_aug.step_start == expected_step_start
+            assert mix_aug.step_stop == expected_step_flat
+    else:
+        assert transform_args.mixup is None
+        assert transform_args.mosaic is None
+
+    scale_jitter = transform_args.scale_jitter
+    assert scale_jitter is not None
+    assert scale_jitter.step_stop == expected_step_stop
 
 
 class TestObjectDetectionTransform:


### PR DESCRIPTION
## What has changed and why?

As the title suggests. See the docstrings of `resolve_ltdetr_step_schedule` for more details how it is handled.

Also enabled augmentations by default.

## How has it been tested?

- Unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
