### PR TITLE
Better hash for data mmap hash

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -1275,9 +1275,9 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
         model_init_args["model_name"] = config.model
 
     with helpers.get_dataset_temp_mmap_path(
-        fabric=fabric, data=config.data.train_imgs_path(), out=config.out
+        fabric=fabric, data_hash=config.data.train_data_mmap_hash(), out=config.out
     ) as train_mmap_filepath, helpers.get_dataset_temp_mmap_path(
-        fabric=fabric, data=config.data.val_imgs_path(), out=config.out
+        fabric=fabric, data_hash=config.data.val_data_mmap_hash(), out=config.out
     ) as val_mmap_filepath:
         # Build datasets without a transform first. We need to know
         # `len(train_dataloader)` (which depends only on the dataset + batch

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -489,17 +489,13 @@ def get_dataset_temp_mmap_path(
 ) -> Generator[Path, Any, Any]:
     """Generate file in temporary directory to be used for memory-mapping the dataset.
 
-    Creates a unique filename for the memory-mapped file based on the `out` or `data`
-    arguments. We use those arguments as they are consistent across all ranks on the
-    same node for the same run. Additionally, we can cache the file if required, since
-    the hash directly reflects the used config.
-
-    Use the same file on all ranks across all nodes, unless the filesystem is not shared.
+    Creates a unique filename for the memory-mapped file based on ``out`` and
+    ``data_hash``. The caller is responsible for producing a ``data_hash`` that
+    uniquely identifies the dataset configuration. The same file is used on all
+    ranks across all nodes, unless the filesystem is not shared.
     """
     if Env.LIGHTLY_TRAIN_MMAP_REUSE_FILE.value:
-        # Use data as identifier to share the mmap file across multiple runs.
-        # NOTE(Guarin, 09/25): Hash of data might be slow if data is a long list of
-        # filenames or directories.
+        # Use data_hash as identifier to share the mmap file across multiple runs.
         identifier = data_hash
     else:
         # Use out as identifier to create a unique mmap file for each run. We assume

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -484,7 +484,7 @@ def _unlink_and_ignore(path: Path) -> None:
 @contextlib.contextmanager
 def get_dataset_temp_mmap_path(
     fabric: Fabric,
-    data: PathLike,
+    data_hash: str,
     out: PathLike,
 ) -> Generator[Path, Any, Any]:
     """Generate file in temporary directory to be used for memory-mapping the dataset.
@@ -500,11 +500,11 @@ def get_dataset_temp_mmap_path(
         # Use data as identifier to share the mmap file across multiple runs.
         # NOTE(Guarin, 09/25): Hash of data might be slow if data is a long list of
         # filenames or directories.
-        identifier = str(Path(data).resolve())
+        identifier = data_hash
     else:
         # Use out as identifier to create a unique mmap file for each run. We assume
         # that only one run is using a specific out directory at a time.
-        identifier = str(Path(out).resolve()) + str(Path(data).resolve())
+        identifier = str(Path(out).resolve()) + data_hash
 
     mmap_filepath = (cache.get_data_cache_dir() / get_sha256(identifier)).with_suffix(
         ".mmap"

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -500,7 +500,7 @@ def get_dataset_temp_mmap_path(
     else:
         # Use out as identifier to create a unique mmap file for each run. We assume
         # that only one run is using a specific out directory at a time.
-        identifier = str(Path(out).resolve()) + data_hash
+        identifier = str((str(Path(out).resolve()), data_hash))
 
     mmap_filepath = (cache.get_data_cache_dir() / get_sha256(identifier)).with_suffix(
         ".mmap"

--- a/src/lightly_train/_data/coco_object_detection_dataset.py
+++ b/src/lightly_train/_data/coco_object_detection_dataset.py
@@ -18,8 +18,7 @@ from typing import Literal
 from pydantic import Field
 
 from lightly_train._configs.config import PydanticConfig
-from lightly_train._data import label_helpers
-from lightly_train._data.file_helpers import resolve_coco_images_dir
+from lightly_train._data import file_helpers, label_helpers
 from lightly_train._data.object_detection_dataset import ObjectDetectionDataset
 from lightly_train._data.task_data_args import TaskDataArgs
 from lightly_train._data.task_dataset import TaskDatasetArgs
@@ -57,28 +56,32 @@ class COCOObjectDetectionDataArgs(TaskDataArgs):
 
     def train_data_mmap_hash(self) -> str:
         annotations_path = Path(self.train.annotations).resolve()
-        images_dir = resolve_coco_images_dir(annotations_path, self.train.images)
+        images_dir = file_helpers.resolve_coco_images_dir(
+            annotations_path, self.train.images
+        )
 
         return str(
             (
                 annotations_path,
                 annotations_path.stat().st_mtime,
                 images_dir,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_annotations_missing,
             )
         )
 
     def val_data_mmap_hash(self) -> str:
         annotations_path = Path(self.val.annotations).resolve()
-        images_dir = resolve_coco_images_dir(annotations_path, self.val.images)
+        images_dir = file_helpers.resolve_coco_images_dir(
+            annotations_path, self.val.images
+        )
 
         return str(
             (
                 annotations_path,
                 annotations_path.stat().st_mtime,
                 images_dir,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_annotations_missing,
             )
         )
@@ -148,7 +151,7 @@ class COCOObjectDetectionDatasetArgs(TaskDatasetArgs):
         for annotation in annotations:
             annotations_by_image_id[annotation["image_id"]].append(annotation)
 
-        image_dir = resolve_coco_images_dir(self.labels, self.data_dir)
+        image_dir = file_helpers.resolve_coco_images_dir(self.labels, self.data_dir)
 
         for image in labels_dict["images"]:
             image_width_pixel = image["width"]

--- a/src/lightly_train/_data/coco_object_detection_dataset.py
+++ b/src/lightly_train/_data/coco_object_detection_dataset.py
@@ -57,9 +57,8 @@ class COCOObjectDetectionDataArgs(TaskDataArgs):
 
     def train_data_mmap_hash(self) -> str:
         annotations_path = Path(self.train.annotations).resolve()
-        images_dir = resolve_coco_images_dir(
-            annotations_path, Path(self.train.images) if self.train.images else None
-        )
+        images_dir = resolve_coco_images_dir(annotations_path, self.train.images)
+
         return str(
             (
                 annotations_path,
@@ -71,10 +70,9 @@ class COCOObjectDetectionDataArgs(TaskDataArgs):
         )
 
     def val_data_mmap_hash(self) -> str:
-        annotations_path = Path(self.train.annotations).resolve()
-        images_dir = resolve_coco_images_dir(
-            annotations_path, Path(self.train.images) if self.train.images else None
-        )
+        annotations_path = Path(self.val.annotations).resolve()
+        images_dir = resolve_coco_images_dir(annotations_path, self.val.images)
+
         return str(
             (
                 annotations_path,

--- a/src/lightly_train/_data/coco_object_detection_dataset.py
+++ b/src/lightly_train/_data/coco_object_detection_dataset.py
@@ -19,6 +19,7 @@ from pydantic import Field
 
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._data import label_helpers
+from lightly_train._data.file_helpers import resolve_coco_images_dir
 from lightly_train._data.object_detection_dataset import ObjectDetectionDataset
 from lightly_train._data.task_data_args import TaskDataArgs
 from lightly_train._data.task_dataset import TaskDatasetArgs
@@ -54,15 +55,35 @@ class COCOObjectDetectionDataArgs(TaskDataArgs):
         with open(self.train.annotations) as f:
             return {c["id"]: c["name"] for c in json.load(f).get("categories", [])}
 
-    def train_imgs_path(self) -> Path:
-        # TODO (simon 03/26): We currently only need this to calculate a hash for the mmap file for the dataset.
-        #  This might not be the best idea as the contents of the file might change.
-        return Path(self.train.annotations).resolve()
+    def train_data_mmap_hash(self) -> str:
+        annotations_path = Path(self.train.annotations).resolve()
+        images_dir = resolve_coco_images_dir(
+            annotations_path, Path(self.train.images) if self.train.images else None
+        )
+        return str(
+            (
+                annotations_path,
+                annotations_path.stat().st_mtime,
+                images_dir,
+                self.ignore_classes,
+                self.skip_if_annotations_missing,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        # TODO (simon 03/26): We currently only need this to calculate a hash for the mmap file for the dataset.
-        #  This might not be the best idea as the contents of the file might change.
-        return Path(self.val.annotations).resolve()
+    def val_data_mmap_hash(self) -> str:
+        annotations_path = Path(self.train.annotations).resolve()
+        images_dir = resolve_coco_images_dir(
+            annotations_path, Path(self.train.images) if self.train.images else None
+        )
+        return str(
+            (
+                annotations_path,
+                annotations_path.stat().st_mtime,
+                images_dir,
+                self.ignore_classes,
+                self.skip_if_annotations_missing,
+            )
+        )
 
     def get_train_args(
         self,
@@ -129,9 +150,7 @@ class COCOObjectDetectionDatasetArgs(TaskDatasetArgs):
         for annotation in annotations:
             annotations_by_image_id[annotation["image_id"]].append(annotation)
 
-        image_dir = self.labels.resolve().parent
-        if self.data_dir is not None:
-            image_dir /= self.data_dir
+        image_dir = resolve_coco_images_dir(self.labels, self.data_dir)
 
         for image in labels_dict["images"]:
             image_width_pixel = image["width"]

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -502,3 +502,10 @@ def _iter_yolo_label_lines(label_path: Path) -> Iterable[str]:
                 continue
             lines.add(line)
             yield line
+
+
+def resolve_coco_images_dir(annotations: Path, images_dir: Path | None) -> Path:
+    result = annotations.resolve().parent
+    if images_dir is not None:
+        result = (result / images_dir).resolve()
+    return result

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -507,6 +507,11 @@ def _iter_yolo_label_lines(label_path: Path) -> Iterable[str]:
 def resolve_coco_images_dir(
     annotations_path: PathLike, images_dir: PathLike | None
 ) -> Path:
+    """Resolve the images directory for a COCO dataset.
+
+    Returns the parent directory of the annotations file. If ``images_dir`` is
+    given, it is joined relative to that parent and resolved.
+    """
     result = Path(annotations_path).resolve().parent
     if images_dir is not None:
         result = (result / images_dir).resolve()

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -504,8 +504,10 @@ def _iter_yolo_label_lines(label_path: Path) -> Iterable[str]:
             yield line
 
 
-def resolve_coco_images_dir(annotations: Path, images_dir: Path | None) -> Path:
-    result = annotations.resolve().parent
+def resolve_coco_images_dir(
+    annotations_path: PathLike, images_dir: PathLike | None
+) -> Path:
+    result = Path(annotations_path).resolve().parent
     if images_dir is not None:
         result = (result / images_dir).resolve()
     return result

--- a/src/lightly_train/_data/image_classification_dataset.py
+++ b/src/lightly_train/_data/image_classification_dataset.py
@@ -118,6 +118,10 @@ class ImageClassificationDataArgs(TaskDataArgs):
                 self.classes,
                 self.label_delimiter,
                 sorted(self.ignore_classes) if self.ignore_classes else None,
+                self.classification_task,
+                self.csv_image_column,
+                self.csv_label_column,
+                self.csv_label_type,
             )
         )
 
@@ -128,6 +132,10 @@ class ImageClassificationDataArgs(TaskDataArgs):
                 self.classes,
                 self.label_delimiter,
                 sorted(self.ignore_classes) if self.ignore_classes else None,
+                self.classification_task,
+                self.csv_image_column,
+                self.csv_label_column,
+                self.csv_label_type,
             )
         )
 

--- a/src/lightly_train/_data/image_classification_dataset.py
+++ b/src/lightly_train/_data/image_classification_dataset.py
@@ -117,17 +117,17 @@ class ImageClassificationDataArgs(TaskDataArgs):
                 Path(self.train).resolve(),
                 self.classes,
                 self.label_delimiter,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 
     def val_data_mmap_hash(self) -> str:
         return str(
             (
-                Path(self.train).resolve(),
+                Path(self.val).resolve(),
                 self.classes,
                 self.label_delimiter,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 

--- a/src/lightly_train/_data/image_classification_dataset.py
+++ b/src/lightly_train/_data/image_classification_dataset.py
@@ -111,11 +111,25 @@ class ImageClassificationDataArgs(TaskDataArgs):
 
     classification_task: Literal["multiclass", "multilabel"]
 
-    def train_imgs_path(self) -> Path:
-        return Path(self.train)
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.train).resolve(),
+                self.classes,
+                self.label_delimiter,
+                self.ignore_classes,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        return Path(self.val)
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.train).resolve(),
+                self.classes,
+                self.label_delimiter,
+                self.ignore_classes,
+            )
+        )
 
     def get_train_args(
         self,

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -171,7 +171,7 @@ class YOLOInstanceSegmentationDataArgs(TaskDataArgs):
             (
                 (Path(self.path) / self.train).resolve(),
                 self.names,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_label_file_missing,
             )
         )
@@ -179,9 +179,9 @@ class YOLOInstanceSegmentationDataArgs(TaskDataArgs):
     def val_data_mmap_hash(self) -> str:
         return str(
             (
-                (Path(self.path) / self.train).resolve(),
+                (Path(self.path) / self.val).resolve(),
                 self.names,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_label_file_missing,
             )
         )

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -166,11 +166,25 @@ class YOLOInstanceSegmentationDataArgs(TaskDataArgs):
     ignore_classes: set[int] | None = Field(default=None, strict=False)
     skip_if_label_file_missing: bool = False
 
-    def train_imgs_path(self) -> Path:
-        return Path(self.path) / self.train
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                (Path(self.path) / self.train).resolve(),
+                self.names,
+                self.ignore_classes,
+                self.skip_if_label_file_missing,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        return Path(self.path) / self.val
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                (Path(self.path) / self.train).resolve(),
+                self.names,
+                self.ignore_classes,
+                self.skip_if_label_file_missing,
+            )
+        )
 
     @pydantic.field_validator("train", "val", mode="after")
     def validate_paths(cls, v: PathLike) -> Path:

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -334,15 +334,35 @@ class COCOInstanceSegmentationDataArgs(TaskDataArgs):
         with open(self.train.annotations) as f:
             return {c["id"]: c["name"] for c in json.load(f).get("categories", [])}
 
-    def train_imgs_path(self) -> Path:
-        # TODO (simon 03/26): We currently only need this to calculate a hash for the mmap file for the dataset.
-        #  This might not be the best idea as the contents of the file might change.
-        return Path(self.train.annotations).resolve()
+    def train_data_mmap_hash(self) -> str:
+        annotations_path = Path(self.train.annotations).resolve()
+        images_dir = file_helpers.resolve_coco_images_dir(
+            annotations_path, self.train.images
+        )
+        return str(
+            (
+                annotations_path,
+                annotations_path.stat().st_mtime,
+                images_dir,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
+                self.skip_if_annotations_missing,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        # TODO (simon 03/26): We currently only need this to calculate a hash for the mmap file for the dataset.
-        #  This might not be the best idea as the contents of the file might change.
-        return Path(self.val.annotations).resolve()
+    def val_data_mmap_hash(self) -> str:
+        annotations_path = Path(self.val.annotations).resolve()
+        images_dir = file_helpers.resolve_coco_images_dir(
+            annotations_path, self.val.images
+        )
+        return str(
+            (
+                annotations_path,
+                annotations_path.stat().st_mtime,
+                images_dir,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
+                self.skip_if_annotations_missing,
+            )
+        )
 
     def get_train_args(self) -> COCOInstanceSegmentationDatasetArgs:
         """Returns dataset args for the training split."""

--- a/src/lightly_train/_data/mask_panoptic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_panoptic_segmentation_dataset.py
@@ -322,19 +322,25 @@ class MaskPanopticSegmentationDataArgs(TaskDataArgs):
     ignore_classes: set[int] | None = Field(default=None, strict=False)
 
     def train_data_mmap_hash(self) -> str:
+        annotations_path = Path(self.train.annotations).resolve()
         return str(
             (
                 Path(self.train.images).resolve(),
                 Path(self.train.masks).resolve(),
+                annotations_path,
+                annotations_path.stat().st_mtime,
                 sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 
     def val_data_mmap_hash(self) -> str:
+        annotations_path = Path(self.val.annotations).resolve()
         return str(
             (
                 Path(self.val.images).resolve(),
                 Path(self.val.masks).resolve(),
+                annotations_path,
+                annotations_path.stat().st_mtime,
                 sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )

--- a/src/lightly_train/_data/mask_panoptic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_panoptic_segmentation_dataset.py
@@ -321,11 +321,23 @@ class MaskPanopticSegmentationDataArgs(TaskDataArgs):
     val: SplitArgs
     ignore_classes: set[int] | None = Field(default=None, strict=False)
 
-    def train_imgs_path(self) -> Path:
-        return Path(self.train.images)
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.train.images).resolve(),
+                Path(self.train.masks).resolve(),
+                self.ignore_classes,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        return Path(self.val.images)
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.val.images).resolve(),
+                Path(self.val.masks).resolve(),
+                self.ignore_classes,
+            )
+        )
 
     @cached_property
     def classes(self) -> dict[int, ClassInfo]:

--- a/src/lightly_train/_data/mask_panoptic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_panoptic_segmentation_dataset.py
@@ -326,7 +326,7 @@ class MaskPanopticSegmentationDataArgs(TaskDataArgs):
             (
                 Path(self.train.images).resolve(),
                 Path(self.train.masks).resolve(),
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 
@@ -335,7 +335,7 @@ class MaskPanopticSegmentationDataArgs(TaskDataArgs):
             (
                 Path(self.val.images).resolve(),
                 Path(self.val.masks).resolve(),
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -319,11 +319,25 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     classes: dict[int, ClassInfo] | PathLike
     ignore_classes: set[int] | None = Field(default=None, strict=False)
 
-    def train_imgs_path(self) -> Path:
-        return Path(self.train.images)
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.train.images).resolve(),
+                Path(self.train.masks).resolve(),
+                self.classes,
+                self.ignore_classes,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        return Path(self.val.images)
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.val.images).resolve(),
+                Path(self.val.masks).resolve(),
+                self.classes,
+                self.ignore_classes,
+            )
+        )
 
     @field_validator("classes", mode="before")
     @classmethod

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -325,7 +325,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
                 Path(self.train.images).resolve(),
                 Path(self.train.masks).resolve(),
                 self.classes,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 
@@ -335,7 +335,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
                 Path(self.val.images).resolve(),
                 Path(self.val.masks).resolve(),
                 self.classes,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
 

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -319,12 +319,26 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     classes: dict[int, ClassInfo] | PathLike
     ignore_classes: set[int] | None = Field(default=None, strict=False)
 
+    def _deterministic_classes_str(self) -> str:
+        """Serialize classes deterministically for hashing.
+
+        ClassInfo contains set fields (e.g., labels: set[int]) whose str()
+        representation is not deterministic across processes due to hash
+        randomization. We serialize to JSON with sorted sets and keys instead.
+        """
+        classes = cast(Dict[int, ClassInfo], self.classes)
+        return json.dumps(
+            {str(k): v.model_dump() for k, v in sorted(classes.items())},
+            sort_keys=True,
+            default=lambda x: sorted(x, key=str) if isinstance(x, set) else x,
+        )
+
     def train_data_mmap_hash(self) -> str:
         return str(
             (
                 Path(self.train.images).resolve(),
                 Path(self.train.masks).resolve(),
-                self.classes,
+                self._deterministic_classes_str(),
                 sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )
@@ -334,7 +348,7 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
             (
                 Path(self.val.images).resolve(),
                 Path(self.val.masks).resolve(),
-                self.classes,
+                self._deterministic_classes_str(),
                 sorted(self.ignore_classes) if self.ignore_classes else None,
             )
         )

--- a/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
+++ b/src/lightly_train/_data/mask_semantic_segmentation_dataset.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, ClassVar, Dict, Iterable, Union, cast
+from typing import Any, ClassVar, Dict, Iterable, Union
 
 import numpy as np
 import torch
@@ -326,7 +326,12 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
         representation is not deterministic across processes due to hash
         randomization. We serialize to JSON with sorted sets and keys instead.
         """
-        classes = cast(Dict[int, ClassInfo], self.classes)
+        if not isinstance(self.classes, dict):
+            raise TypeError(
+                f"Expected 'classes' to be a dict after validation, "
+                f"got {type(self.classes).__name__}"
+            )
+        classes = self.classes
         return json.dumps(
             {str(k): v.model_dump() for k, v in sorted(classes.items())},
             sort_keys=True,
@@ -454,7 +459,12 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def included_classes(self) -> dict[int, str]:
         """Returns classes (AFTER mapping) that are not ignored with the name."""
         ignore_classes = set() if self.ignore_classes is None else self.ignore_classes
-        classes = cast(Dict[int, ClassInfo], self.classes)
+        if not isinstance(self.classes, dict):
+            raise TypeError(
+                f"Expected 'classes' to be a dict after validation, "
+                f"got {type(self.classes).__name__}"
+            )
+        classes = self.classes
 
         result = {}
         for class_id, class_info in classes.items():
@@ -473,10 +483,15 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def get_train_args(
         self,
     ) -> MaskSemanticSegmentationDatasetArgs:
+        if not isinstance(self.classes, dict):
+            raise TypeError(
+                f"Expected 'classes' to be a dict after validation, "
+                f"got {type(self.classes).__name__}"
+            )
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.train.images),
             mask_dir_or_file=str(self.train.masks),
-            classes=cast(Dict[int, ClassInfo], self.classes),
+            classes=self.classes,
             ignore_classes=self.ignore_classes,
             ignore_index=self.ignore_index,
         )
@@ -484,10 +499,15 @@ class MaskSemanticSegmentationDataArgs(TaskDataArgs):
     def get_val_args(
         self,
     ) -> MaskSemanticSegmentationDatasetArgs:
+        if not isinstance(self.classes, dict):
+            raise TypeError(
+                f"Expected 'classes' to be a dict after validation, "
+                f"got {type(self.classes).__name__}"
+            )
         return MaskSemanticSegmentationDatasetArgs(
             image_dir=Path(self.val.images),
             mask_dir_or_file=str(self.val.masks),
-            classes=cast(Dict[int, ClassInfo], self.classes),
+            classes=self.classes,
             ignore_classes=self.ignore_classes,
             ignore_index=self.ignore_index,
         )

--- a/src/lightly_train/_data/task_data_args.py
+++ b/src/lightly_train/_data/task_data_args.py
@@ -7,8 +7,6 @@
 #
 from __future__ import annotations
 
-from pathlib import Path
-
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._data.task_dataset import TaskDatasetArgs
 
@@ -18,10 +16,20 @@ class TaskDataArgs(PydanticConfig):
     def included_classes(self) -> dict[int, str]:
         raise NotImplementedError()
 
-    def train_imgs_path(self) -> Path:
+    def train_data_mmap_hash(self) -> str:
+        """Return a str that can be hashed that should identify the train dataset so that image_info
+        does not need to be recomputed on restarts.
+
+        Should be fast and not read the whole dataset while still trying to be as accurate as possible.
+        """
         raise NotImplementedError()
 
-    def val_imgs_path(self) -> Path:
+    def val_data_mmap_hash(self) -> str:
+        """Return a str that can be hashed that should identify the val dataset so that image_info
+        does not need to be recomputed on restarts.
+
+        Should be fast and not read the whole dataset while still trying to be as accurate as possible.
+        """
         raise NotImplementedError()
 
     def get_train_args(

--- a/src/lightly_train/_data/yolo_object_detection_dataset.py
+++ b/src/lightly_train/_data/yolo_object_detection_dataset.py
@@ -39,7 +39,7 @@ class YOLOObjectDetectionDataArgs(TaskDataArgs):
             (
                 (Path(self.path) / self.train).resolve(),
                 self.names,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_label_file_missing,
             )
         )
@@ -49,7 +49,7 @@ class YOLOObjectDetectionDataArgs(TaskDataArgs):
             (
                 (Path(self.path) / self.val).resolve(),
                 self.names,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_label_file_missing,
             )
         )

--- a/src/lightly_train/_data/yolo_object_detection_dataset.py
+++ b/src/lightly_train/_data/yolo_object_detection_dataset.py
@@ -34,11 +34,25 @@ class YOLOObjectDetectionDataArgs(TaskDataArgs):
     ignore_classes: set[int] | None = Field(default=None, strict=False)
     skip_if_label_file_missing: bool = False
 
-    def train_imgs_path(self) -> Path:
-        return Path(self.train)
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                (Path(self.path) / self.train).resolve(),
+                self.names,
+                self.ignore_classes,
+                self.skip_if_label_file_missing,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        return Path(self.val)
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                (Path(self.path) / self.val).resolve(),
+                self.names,
+                self.ignore_classes,
+                self.skip_if_label_file_missing,
+            )
+        )
 
     @pydantic.field_validator("train", "val", mode="after")
     def validate_paths(cls, v: PathLike) -> Path:

--- a/src/lightly_train/_data/yolo_oriented_object_detection_dataset.py
+++ b/src/lightly_train/_data/yolo_oriented_object_detection_dataset.py
@@ -168,11 +168,25 @@ class YOLOOrientedObjectDetectionDataArgs(TaskDataArgs):
     ignore_classes: set[int] | None = Field(default=None, strict=False)
     skip_if_label_file_missing: bool = False
 
-    def train_imgs_path(self) -> Path:
-        return Path(self.train)
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                (Path(self.path) / self.train).resolve(),
+                self.names,
+                self.ignore_classes,
+                self.skip_if_label_file_missing,
+            )
+        )
 
-    def val_imgs_path(self) -> Path:
-        return Path(self.val)
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                (Path(self.path) / self.val).resolve(),
+                self.names,
+                self.ignore_classes,
+                self.skip_if_label_file_missing,
+            )
+        )
 
     @pydantic.field_validator("train", "val", mode="after")
     def validate_paths(cls, v: PathLike) -> Path:

--- a/src/lightly_train/_data/yolo_oriented_object_detection_dataset.py
+++ b/src/lightly_train/_data/yolo_oriented_object_detection_dataset.py
@@ -173,7 +173,7 @@ class YOLOOrientedObjectDetectionDataArgs(TaskDataArgs):
             (
                 (Path(self.path) / self.train).resolve(),
                 self.names,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_label_file_missing,
             )
         )
@@ -183,7 +183,7 @@ class YOLOOrientedObjectDetectionDataArgs(TaskDataArgs):
             (
                 (Path(self.path) / self.val).resolve(),
                 self.names,
-                self.ignore_classes,
+                sorted(self.ignore_classes) if self.ignore_classes else None,
                 self.skip_if_label_file_missing,
             )
         )

--- a/tests/_data/test_coco_object_detection_dataset.py
+++ b/tests/_data/test_coco_object_detection_dataset.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import json
-import time
+import os
 from pathlib import Path
 
 from lightly_train._data.coco_object_detection_dataset import (
@@ -71,8 +71,7 @@ class TestCOCOObjectDetectionDatasetArgs:
     def test_mmap_hash_changes_when_annotations_modified(self, tmp_path: Path) -> None:
         args = self._make_args(tmp_path)
         hash_before = args.train_data_mmap_hash()
-        # Ensure mtime changes (some filesystems have 1s resolution).
-        time.sleep(1)
         annotations_path = tmp_path / "train.json"
-        annotations_path.write_text(annotations_path.read_text())
+        st = annotations_path.stat()
+        os.utime(annotations_path, (st.st_atime, st.st_mtime + 1))
         assert args.train_data_mmap_hash() != hash_before

--- a/tests/_data/test_coco_object_detection_dataset.py
+++ b/tests/_data/test_coco_object_detection_dataset.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 from lightly_train._data.coco_object_detection_dataset import (
@@ -54,3 +55,24 @@ class TestCOCOObjectDetectionDatasetArgs:
                 [0.125, 0.5, 0.0, 1.0],
             ]
             assert json.loads(image_info[2]["class_labels"]) == [0, 1]
+
+    def _make_args(self, tmp_path: Path) -> COCOObjectDetectionDataArgs:
+        create_coco_object_detection_dataset(tmp_path=tmp_path)
+        return COCOObjectDetectionDataArgs(
+            train=SplitArgs(annotations=tmp_path / "train.json", images=Path("train")),
+            val=SplitArgs(annotations=tmp_path / "val.json", images=Path("val")),
+        )
+
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()
+
+    def test_mmap_hash_changes_when_annotations_modified(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        hash_before = args.train_data_mmap_hash()
+        # Ensure mtime changes (some filesystems have 1s resolution).
+        time.sleep(1)
+        annotations_path = tmp_path / "train.json"
+        annotations_path.write_text(annotations_path.read_text())
+        assert args.train_data_mmap_hash() != hash_before

--- a/tests/_data/test_coco_object_detection_dataset.py
+++ b/tests/_data/test_coco_object_detection_dataset.py
@@ -56,7 +56,10 @@ class TestCOCOObjectDetectionDatasetArgs:
             ]
             assert json.loads(image_info[2]["class_labels"]) == [0, 1]
 
-    def _make_args(self, tmp_path: Path) -> COCOObjectDetectionDataArgs:
+
+class TestCOCOObjectDetectionMmapHash:
+    @staticmethod
+    def _make_args(tmp_path: Path) -> COCOObjectDetectionDataArgs:
         create_coco_object_detection_dataset(tmp_path=tmp_path)
         return COCOObjectDetectionDataArgs(
             train=SplitArgs(annotations=tmp_path / "train.json", images=Path("train")),

--- a/tests/_data/test_image_classification_dataset.py
+++ b/tests/_data/test_image_classification_dataset.py
@@ -314,3 +314,22 @@ class TestImageClassificationDataset:
 def _get_transform() -> DummyTaskTransform:
     transform_args = IdentityTaskTransformArgs()
     return DummyTaskTransform(transform_args=transform_args)
+
+
+class TestImageClassificationMmapHash:
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        classes = {0: "class_0", 1: "class_1"}
+        helpers.create_multiclass_image_classification_dataset(
+            tmp_path=tmp_path,
+            class_names=list(classes.values()),
+            num_files_per_class=2,
+            height=32,
+            width=32,
+        )
+        args = ImageClassificationMulticlassDataArgs(
+            train=tmp_path / "train",
+            val=tmp_path / "val",
+            classes=classes,
+        )
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -21,7 +22,10 @@ from lightly_train._data.instance_segmentation_dataset import (
 )
 
 from .. import helpers
-from ..helpers import create_coco_instance_segmentation_dataset
+from ..helpers import (
+    create_coco_instance_segmentation_dataset,
+    create_yolo_instance_segmentation_dataset,
+)
 
 _POLYGON = [0.30, 0.30, 0.45, 0.27, 0.49, 0.50, 0.44, 0.70, 0.31, 0.73, 0.26, 0.50]
 # Bbox is (x_center, y_center, width, height) derived from _POLYGON.
@@ -312,3 +316,45 @@ class TestCOCOInstanceSegmentationDatasetArgs:
         image_info = list(args.list_image_info())
 
         assert len(image_info) == 1
+
+
+class TestYOLOInstanceSegmentationMmapHash:
+    @staticmethod
+    def _make_args(tmp_path: Path) -> YOLOInstanceSegmentationDataArgs:
+        create_yolo_instance_segmentation_dataset(tmp_path=tmp_path, split_first=True)
+        return YOLOInstanceSegmentationDataArgs(
+            path=tmp_path,
+            train="train/images",
+            val="val/images",
+            names=_CLASSES,
+        )
+
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()
+
+
+class TestCOCOInstanceSegmentationMmapHash:
+    @staticmethod
+    def _make_args(tmp_path: Path) -> COCOInstanceSegmentationDataArgs:
+        create_coco_instance_segmentation_dataset(tmp_path)
+        return COCOInstanceSegmentationDataArgs(
+            train=COCOSplitArgs(
+                annotations=tmp_path / "train.json", images=Path("train")
+            ),
+            val=COCOSplitArgs(annotations=tmp_path / "val.json", images=Path("val")),
+        )
+
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()
+
+    def test_mmap_hash_changes_when_annotations_modified(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        hash_before = args.train_data_mmap_hash()
+        annotations_path = tmp_path / "train.json"
+        st = annotations_path.stat()
+        os.utime(annotations_path, (st.st_atime, st.st_mtime + 1))
+        assert args.train_data_mmap_hash() != hash_before

--- a/tests/_data/test_mask_panoptic_segmentation_dataset.py
+++ b/tests/_data/test_mask_panoptic_segmentation_dataset.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+import os
+from pathlib import Path
+
+from lightly_train._data.mask_panoptic_segmentation_dataset import (
+    MaskPanopticSegmentationDataArgs,
+    SplitArgs,
+)
+
+from .. import helpers
+
+
+class TestMaskPanopticSegmentationMmapHash:
+    @staticmethod
+    def _make_args(tmp_path: Path) -> MaskPanopticSegmentationDataArgs:
+        helpers.create_coco_panoptic_segmentation_dataset(tmp_path)
+        return MaskPanopticSegmentationDataArgs(
+            train=SplitArgs(
+                images=tmp_path / "images" / "train",
+                masks=tmp_path / "annotations" / "train",
+                annotations=tmp_path / "annotations" / "train.json",
+            ),
+            val=SplitArgs(
+                images=tmp_path / "images" / "val",
+                masks=tmp_path / "annotations" / "val",
+                annotations=tmp_path / "annotations" / "val.json",
+            ),
+        )
+
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()
+
+    def test_mmap_hash_changes_when_annotations_modified(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        hash_before = args.train_data_mmap_hash()
+        annotations_path = tmp_path / "annotations" / "train.json"
+        st = annotations_path.stat()
+        os.utime(annotations_path, (st.st_atime, st.st_mtime + 1))
+        assert args.train_data_mmap_hash() != hash_before

--- a/tests/_data/test_mask_semantic_segmentation_dataset.py
+++ b/tests/_data/test_mask_semantic_segmentation_dataset.py
@@ -33,6 +33,7 @@ from lightly_train._transforms.transform import (
 )
 
 from .. import helpers
+from ..helpers import create_images, create_semantic_segmentation_masks
 
 
 def _dummy_transform(num_channels: int = 3) -> SemanticSegmentationTransform:
@@ -863,3 +864,46 @@ class TestMaskSemanticSegmentationDataset:
         )
 
         assert dataset.class_id_to_internal_class_id == expected_mapping
+
+
+class TestMaskSemanticSegmentationDataArgsMmapHash:
+    @staticmethod
+    def _make_args(tmp_path: Path) -> MaskSemanticSegmentationDataArgs:
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        create_images(image_dir=image_dir, files=2, height=32, width=32)
+        create_semantic_segmentation_masks(
+            mask_dir=mask_dir, files=2, height=32, width=32, num_classes=2
+        )
+        return MaskSemanticSegmentationDataArgs(
+            train=SplitArgs(images=image_dir, masks=mask_dir),
+            val=SplitArgs(images=image_dir, masks=mask_dir),
+            classes={
+                0: SingleChannelClassInfo(name="background", labels={0}),
+                1: SingleChannelClassInfo(name="foreground", labels={1}),
+            },
+        )
+
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        args = self._make_args(tmp_path)
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()
+
+    def test_mmap_hash_with_set_labels_is_deterministic(self, tmp_path: Path) -> None:
+        """ClassInfo with set fields must produce the same hash across calls."""
+        image_dir = tmp_path / "images"
+        mask_dir = tmp_path / "masks"
+        create_images(image_dir=image_dir, files=2, height=32, width=32)
+        create_semantic_segmentation_masks(
+            mask_dir=mask_dir, files=2, height=32, width=32, num_classes=3
+        )
+        args = MaskSemanticSegmentationDataArgs(
+            train=SplitArgs(images=image_dir, masks=mask_dir),
+            val=SplitArgs(images=image_dir, masks=mask_dir),
+            classes={
+                0: SingleChannelClassInfo(name="bg", labels={0, 10, 20}),
+                1: SingleChannelClassInfo(name="fg", labels={1, 11, 21}),
+            },
+        )
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()

--- a/tests/_data/test_yolo_object_detection_dataset.py
+++ b/tests/_data/test_yolo_object_detection_dataset.py
@@ -83,3 +83,16 @@ class TestYOLOObjectDetectionDatasetArgs:
             class_labels = json.loads(info["class_labels"])
             assert bboxes == [[0.375, 0.5, 0.25, 0.5]]
             assert class_labels == [1]
+
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        create_yolo_object_detection_dataset(
+            tmp_path=tmp_path, split_first=True, num_files=2
+        )
+        args = YOLOObjectDetectionDataArgs(
+            path=tmp_path,
+            train="train/images",
+            val="val/images",
+            names={0: "class_0", 1: "class_1"},
+        )
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()

--- a/tests/_data/test_yolo_object_detection_dataset.py
+++ b/tests/_data/test_yolo_object_detection_dataset.py
@@ -84,6 +84,8 @@ class TestYOLOObjectDetectionDatasetArgs:
             assert bboxes == [[0.375, 0.5, 0.25, 0.5]]
             assert class_labels == [1]
 
+
+class TestYOLOObjectDetectionMmapHash:
     def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
         create_yolo_object_detection_dataset(
             tmp_path=tmp_path, split_first=True, num_files=2

--- a/tests/_data/test_yolo_oriented_object_detection_dataset.py
+++ b/tests/_data/test_yolo_oriented_object_detection_dataset.py
@@ -274,3 +274,18 @@ class TestYoloOrientedObjectDetectionDataset:
         assert sample["image"].dtype == torch.float32
         assert sample["bboxes"].shape == (0, 5)
         assert sample["classes"].shape == (0,)
+
+
+class TestYOLOOrientedObjectDetectionMmapHash:
+    def test_mmap_hash_is_deterministic(self, tmp_path: Path) -> None:
+        create_yolo_oriented_object_detection_dataset(
+            tmp_path=tmp_path, split_first=True
+        )
+        args = YOLOOrientedObjectDetectionDataArgs(
+            path=tmp_path,
+            train="train/images",
+            val="val/images",
+            names={0: "class_0", 1: "class_1"},
+        )
+        assert args.train_data_mmap_hash() == args.train_data_mmap_hash()
+        assert args.val_data_mmap_hash() == args.val_data_mmap_hash()


### PR DESCRIPTION

## What has changed and why?

This PR ensures that that the hash function that we compute caching image_info works better by

- Storing the timestamp for COCO image annotation files
- Add more fields for other dataset hash functions
- Ensure correct path resolution when computing the hashes

## How has it been tested?

Added some small tests for the COCO dataset hashes.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
