### PR TITLE
Fix Training Crash Caused by Assertion Failure in `generalized_box_iou`

### DIFF
--- a/src/lightly_train/_task_models/object_detection_components/box_ops.py
+++ b/src/lightly_train/_task_models/object_detection_components/box_ops.py
@@ -49,6 +49,23 @@ def box_iou(boxes1: Tensor, boxes2: Tensor):
     return iou, union
 
 
+def _sanitize_boxes_xyxy(boxes: Tensor) -> Tensor:
+    """Sanitize xyxy boxes so that they are non-degenerate and NaN-free.
+
+    Replaces NaN/inf with 0 and enforces ``x1 >= x0`` and ``y1 >= y0`` so that
+    downstream IoU computations do not produce NaN and the degenerate-box
+    assertion in :func:`generalized_box_iou` cannot trip.
+
+    This is a defensive safety net: the upstream code (decoder) should not
+    produce NaN predictions in the first place. When NaN is encountered here,
+    it indicates numerical instability upstream (e.g. fp16 overflow).
+    """
+    boxes = torch.nan_to_num(boxes, nan=0.0, posinf=0.0, neginf=0.0)
+    left_top = boxes[..., :2]
+    right_bottom = torch.max(boxes[..., 2:], left_top)
+    return torch.cat([left_top, right_bottom], dim=-1)
+
+
 def generalized_box_iou(boxes1, boxes2):
     """
     Generalized IoU from https://giou.stanford.edu/
@@ -58,10 +75,12 @@ def generalized_box_iou(boxes1, boxes2):
     Returns a [N, M] pairwise matrix, where N = len(boxes1)
     and M = len(boxes2)
     """
-    # degenerate boxes gives inf / nan results
-    # so do an early check
-    assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
-    assert (boxes2[:, 2:] >= boxes2[:, :2]).all()
+    # Sanitize degenerate/NaN boxes defensively. This replaces the previous
+    # hard asserts so that transient numerical issues (e.g. fp16 overflow in
+    # predictions) don't crash training. Upstream code should still avoid
+    # producing NaN in the first place — this is a safety net, not a fix.
+    boxes1 = _sanitize_boxes_xyxy(boxes1)
+    boxes2 = _sanitize_boxes_xyxy(boxes2)
     iou, union = box_iou(boxes1, boxes2)
 
     lt = torch.min(boxes1[:, None, :2], boxes2[:, :2])

--- a/src/lightly_train/_task_models/object_detection_components/box_ops.py
+++ b/src/lightly_train/_task_models/object_detection_components/box_ops.py
@@ -15,9 +15,14 @@
 https://github.com/facebookresearch/detr/blob/main/util/box_ops.py
 """
 
+import logging
+
 import torch
 from torch import Tensor
 from torchvision.ops.boxes import box_area
+
+_logger = logging.getLogger(__name__)
+_invalid_bbox_warning_emitted = False
 
 
 def box_cxcywh_to_xyxy(x: Tensor) -> Tensor:
@@ -30,6 +35,30 @@ def box_xyxy_to_cxcywh(x: Tensor) -> Tensor:
     x0, y0, x1, y1 = x.unbind(-1)
     b = [(x0 + x1) / 2, (y0 + y1) / 2, (x1 - x0), (y1 - y0)]
     return torch.stack(b, dim=-1)
+
+
+def sanitize_boxes_cxcywh_normalized(boxes: Tensor) -> Tensor:
+    """Sanitize normalized ``cxcywh`` boxes predicted by the decoder.
+
+    The RT-DETR matcher and criterion operate on boxes normalized by image
+    size. We therefore map NaN to ``0``, ``-inf`` to ``0``, ``+inf`` to ``1``,
+    and clamp all coordinates to ``[0, 1]`` before downstream L1/IoU/GIoU
+    computations.
+    """
+    global _invalid_bbox_warning_emitted
+
+    if not _invalid_bbox_warning_emitted:
+        invalid_mask = ~torch.isfinite(boxes)
+        if invalid_mask.any():
+            _logger.warning(
+                "Found invalid predicted bbox values (NaN/inf) before "
+                "sanitization. This usually indicates numerical instability "
+                "upstream."
+            )
+            _invalid_bbox_warning_emitted = True
+
+    boxes = torch.nan_to_num(boxes, nan=0.0, posinf=1.0, neginf=0.0)
+    return boxes.clamp(min=0.0, max=1.0)
 
 
 # modified from torchvision to also return the union
@@ -49,23 +78,6 @@ def box_iou(boxes1: Tensor, boxes2: Tensor):
     return iou, union
 
 
-def _sanitize_boxes_xyxy(boxes: Tensor) -> Tensor:
-    """Sanitize xyxy boxes so that they are non-degenerate and NaN-free.
-
-    Replaces NaN/inf with 0 and enforces ``x1 >= x0`` and ``y1 >= y0`` so that
-    downstream IoU computations do not produce NaN and the degenerate-box
-    assertion in :func:`generalized_box_iou` cannot trip.
-
-    This is a defensive safety net: the upstream code (decoder) should not
-    produce NaN predictions in the first place. When NaN is encountered here,
-    it indicates numerical instability upstream (e.g. fp16 overflow).
-    """
-    boxes = torch.nan_to_num(boxes, nan=0.0, posinf=0.0, neginf=0.0)
-    left_top = boxes[..., :2]
-    right_bottom = torch.max(boxes[..., 2:], left_top)
-    return torch.cat([left_top, right_bottom], dim=-1)
-
-
 def generalized_box_iou(boxes1, boxes2):
     """
     Generalized IoU from https://giou.stanford.edu/
@@ -75,12 +87,6 @@ def generalized_box_iou(boxes1, boxes2):
     Returns a [N, M] pairwise matrix, where N = len(boxes1)
     and M = len(boxes2)
     """
-    # Sanitize degenerate/NaN boxes defensively. This replaces the previous
-    # hard asserts so that transient numerical issues (e.g. fp16 overflow in
-    # predictions) don't crash training. Upstream code should still avoid
-    # producing NaN in the first place — this is a safety net, not a fix.
-    boxes1 = _sanitize_boxes_xyxy(boxes1)
-    boxes2 = _sanitize_boxes_xyxy(boxes2)
     iou, union = box_iou(boxes1, boxes2)
 
     lt = torch.min(boxes1[:, None, :2], boxes2[:, :2])

--- a/src/lightly_train/_task_models/object_detection_components/matcher.py
+++ b/src/lightly_train/_task_models/object_detection_components/matcher.py
@@ -27,6 +27,7 @@ from scipy.optimize import linear_sum_assignment
 from lightly_train._task_models.object_detection_components.box_ops import (
     box_cxcywh_to_xyxy,
     generalized_box_iou,
+    sanitize_boxes_cxcywh_normalized,
 )
 
 
@@ -91,6 +92,7 @@ class HungarianMatcher(nn.Module):
             )  # [batch_size * num_queries, num_classes]
 
         out_bbox = outputs["pred_boxes"].flatten(0, 1)  # [batch_size * num_queries, 4]
+        out_bbox = sanitize_boxes_cxcywh_normalized(out_bbox)
 
         # Also concat the target labels and boxes
         tgt_ids = torch.cat([v["labels"] for v in targets])

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_criterion.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_criterion.py
@@ -24,6 +24,7 @@ from lightly_train._task_models.object_detection_components.box_ops import (
     box_cxcywh_to_xyxy,
     box_iou,
     generalized_box_iou,
+    sanitize_boxes_cxcywh_normalized,
 )
 
 
@@ -99,6 +100,7 @@ class RTDETRCriterionv2(nn.Module):
         idx = self._get_src_permutation_idx(indices)
         if values is None:
             src_boxes = outputs["pred_boxes"][idx]
+            src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
             target_boxes = torch.cat(
                 [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
             )
@@ -143,6 +145,7 @@ class RTDETRCriterionv2(nn.Module):
         assert "pred_boxes" in outputs
         idx = self._get_src_permutation_idx(indices)
         src_boxes = outputs["pred_boxes"][idx]
+        src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
         target_boxes = torch.cat(
             [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
         )
@@ -299,6 +302,7 @@ class RTDETRCriterionv2(nn.Module):
             return {}
 
         src_boxes = outputs["pred_boxes"][self._get_src_permutation_idx(indices)]
+        src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
         target_boxes = torch.cat(
             [t["boxes"][j] for t, (_, j) in zip(targets, indices)], dim=0
         )

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
@@ -354,10 +354,11 @@ class TransformerDecoder(nn.Module):
             # hotspot in RTDETR-style decoders, especially with EMA weights
             # that can drift into regions where the MLP output exceeds fp16's
             # ~65K range.
-            with torch.amp.autocast(device_type="cuda", enabled=False):
+            with torch.amp.autocast(device_type=output.device.type, enabled=False):
+                output_fp32 = output.float()
+                bbox_delta = bbox_head[i](output_fp32)
                 inter_ref_bbox = F.sigmoid(
-                    bbox_head[i](output.float())
-                    + inverse_sigmoid(ref_points_detach.float())
+                    bbox_delta + inverse_sigmoid(ref_points_detach.float())
                 )
 
             ref_points = inter_ref_bbox
@@ -367,12 +368,11 @@ class TransformerDecoder(nn.Module):
                 if i == 0:
                     dec_out_bboxes.append(inter_ref_bbox)
                 else:
-                    with torch.amp.autocast(device_type="cuda", enabled=False):
+                    with torch.amp.autocast(
+                        device_type=output.device.type, enabled=False
+                    ):
                         dec_out_bboxes.append(
-                            F.sigmoid(
-                                bbox_head[i](output.float())
-                                + inverse_sigmoid(ref_points.float())
-                            )
+                            F.sigmoid(bbox_delta + inverse_sigmoid(ref_points.float()))
                         )
 
             elif i == self.eval_idx:

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
@@ -348,9 +348,17 @@ class TransformerDecoder(nn.Module):
                 query_pos_embed,
             )
 
-            inter_ref_bbox = F.sigmoid(
-                bbox_head[i](output) + inverse_sigmoid(ref_points_detach)
-            )
+            # Run the bbox refinement in fp32 to avoid fp16 overflow in the
+            # bbox_head MLP output. The addition of bbox_head(output) and
+            # inverse_sigmoid(ref_points) before sigmoid is a known overflow
+            # hotspot in RTDETR-style decoders, especially with EMA weights
+            # that can drift into regions where the MLP output exceeds fp16's
+            # ~65K range.
+            with torch.amp.autocast(device_type="cuda", enabled=False):
+                inter_ref_bbox = F.sigmoid(
+                    bbox_head[i](output.float())
+                    + inverse_sigmoid(ref_points_detach.float())
+                )
 
             ref_points = inter_ref_bbox
 
@@ -359,9 +367,13 @@ class TransformerDecoder(nn.Module):
                 if i == 0:
                     dec_out_bboxes.append(inter_ref_bbox)
                 else:
-                    dec_out_bboxes.append(
-                        F.sigmoid(bbox_head[i](output) + inverse_sigmoid(ref_points))
-                    )
+                    with torch.amp.autocast(device_type="cuda", enabled=False):
+                        dec_out_bboxes.append(
+                            F.sigmoid(
+                                bbox_head[i](output.float())
+                                + inverse_sigmoid(ref_points.float())
+                            )
+                        )
 
             elif i == self.eval_idx:
                 dec_out_logits.append(score_head[i](output))

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
@@ -356,31 +356,35 @@ class TransformerDecoder(nn.Module):
             # ~65K range.
             with torch.amp.autocast(device_type=output.device.type, enabled=False):
                 output_fp32 = output.float()
-                bbox_delta = bbox_head[i](output_fp32)
-                inter_ref_bbox = F.sigmoid(
-                    bbox_delta + inverse_sigmoid(ref_points_detach.float())
+                ref_points_detach_fp32 = ref_points_detach.float()
+                bbox_delta_fp32 = bbox_head[i](output_fp32)
+
+                inter_ref_bbox_fp32 = F.sigmoid(
+                    bbox_delta_fp32 + inverse_sigmoid(ref_points_detach_fp32)
                 )
 
-            ref_points = inter_ref_bbox
+            ref_points = inter_ref_bbox_fp32.to(dtype=output.dtype)
 
             if self.training:
                 dec_out_logits.append(score_head[i](output))
                 if i == 0:
-                    dec_out_bboxes.append(inter_ref_bbox)
+                    dec_out_bboxes.append(inter_ref_bbox_fp32)
                 else:
                     with torch.amp.autocast(
                         device_type=output.device.type, enabled=False
                     ):
                         dec_out_bboxes.append(
-                            F.sigmoid(bbox_delta + inverse_sigmoid(ref_points.float()))
-                        )
+                            F.sigmoid(
+                                bbox_delta_fp32 + inverse_sigmoid(inter_ref_bbox_fp32)
+                            )
+                        )  # use FP32 for training
 
             elif i == self.eval_idx:
                 dec_out_logits.append(score_head[i](output))
-                dec_out_bboxes.append(inter_ref_bbox)
+                dec_out_bboxes.append(ref_points)  # use FP16 for evaluation
                 break
 
-            ref_points_detach = inter_ref_bbox.detach()
+            ref_points_detach = ref_points.detach()
 
         return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits)
 

--- a/tests/_task_models/object_detection_components/test_box_ops.py
+++ b/tests/_task_models/object_detection_components/test_box_ops.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import logging
+
+import torch
+from _pytest.logging import LogCaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
+
+from lightly_train._task_models.object_detection_components import box_ops
+from lightly_train._task_models.object_detection_components.box_ops import (
+    sanitize_boxes_cxcywh_normalized,
+)
+
+
+def test_sanitize_boxes_cxcywh_normalized_clamps_without_warning(
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(box_ops, "_invalid_bbox_warning_emitted", False)
+    boxes = torch.tensor(
+        [[-0.5, 0.25, 1.5, 0.75], [0.2, 1.2, 0.0, -0.1]],
+        dtype=torch.float32,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=box_ops.__name__):
+        sanitized = sanitize_boxes_cxcywh_normalized(boxes)
+
+    expected = torch.tensor(
+        [[0.0, 0.25, 1.0, 0.75], [0.2, 1.0, 0.0, 0.0]],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(sanitized, expected)
+    assert caplog.records == []
+
+
+def test_sanitize_boxes_cxcywh_normalized_replaces_invalid_values(
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(box_ops, "_invalid_bbox_warning_emitted", False)
+    boxes = torch.tensor(
+        [[torch.nan, torch.inf, -torch.inf, 0.5]],
+        dtype=torch.float32,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=box_ops.__name__):
+        sanitized = sanitize_boxes_cxcywh_normalized(boxes)
+
+    expected = torch.tensor([[0.0, 1.0, 0.0, 0.5]], dtype=torch.float32)
+    torch.testing.assert_close(sanitized, expected)
+    assert len(caplog.records) == 1
+    assert "Found invalid predicted bbox values" in caplog.records[0].message
+
+
+def test_sanitize_boxes_cxcywh_normalized_warns_only_once(
+    caplog: LogCaptureFixture,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(box_ops, "_invalid_bbox_warning_emitted", False)
+    boxes = torch.tensor([[torch.nan, 0.2, 0.3, 0.4]], dtype=torch.float32)
+
+    with caplog.at_level(logging.WARNING, logger=box_ops.__name__):
+        sanitize_boxes_cxcywh_normalized(boxes)
+        sanitize_boxes_cxcywh_normalized(boxes)
+
+    assert len(caplog.records) == 1


### PR DESCRIPTION
## What has changed and why?

Fix Training Crash Caused by Assertion Failure in `generalized_box_iou` by

- Upcasting relevant decoder path
- Sanitizing the bboxes

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
