### PR TITLE
Decode RLE encoded COCO segmetation datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
                             # 4.46 is last version that supports Python 3.8.
                             # 4.51.3 is the default for EoMT
     "tqdm>=4.0.0",
+    "pycocotools>=2.0.11; python_version>='3.9'",
 ]
 
 [project.optional-dependencies]
@@ -57,6 +58,7 @@ dev = [
     "mypy>=1.10.0",
     "pillow>=10.3.0,<12.0.0",  # helpers.create_image currently fails for newer pillow versions
     "pre-commit>=3.5.0",
+    "types-pycocotools>=0.1.1; python_version>='3.9'",
     "pytest-examples>=0.0.13,<0.0.16", # 0.0.16 and 0.0.17 (latest to date) will cause the following failure when running pytest: "TypeError: 'ABCMeta' object is not subscriptable"
     "pytest-mock>=3.14.0",
     "pytest>=8.0.0",

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -123,16 +123,17 @@ class InstanceSegmentationDataset(TaskDataset):
                 mask_list.append(mask)
             elif isinstance(segment, dict):
                 # RLE format. pycocotools is only available for Python >= 3.9.
-                if sys.version_info < (3, 9):
+                if sys.version_info >= (3, 9):
+                    from pycocotools import mask as coco_mask
+
+                    mask_list.append(
+                        coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
+                    )
+                else:
                     raise RuntimeError(
                         "RLE encoded segmentation requires Python >= 3.9 "
                         "for pycocotools support."
                     )
-                from pycocotools import mask as coco_mask
-
-                mask_list.append(
-                    coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
-                )
         binary_masks_np = (
             np.stack(mask_list) if mask_list else np.zeros((0, h, w), dtype=np.bool_)
         )
@@ -520,37 +521,41 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     elif isinstance(segmentation, dict):
                         # RLE encoded segmentation. pycocotools is only
                         # available for Python >= 3.9.
+                        if sys.version_info >= (3, 9):
+                            from pycocotools import mask as coco_mask
 
-                        if sys.version_info < (3, 9):
+                            # Ensure RLE is in compressed format.
+                            if isinstance(segmentation.get("counts"), list):
+                                rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
+                                    segmentation,
+                                    image_height_pixel,
+                                    image_width_pixel,
+                                )
+                            else:
+                                rle = segmentation  # type: ignore[arg-type]
+
+                            # Extract bbox [x, y, w, h] from RLE and convert
+                            # to normalized [x_center, y_center, w, h].
+                            left_pixel, top_pixel, width_pixel, height_pixel = (
+                                coco_mask.toBbox(rle).flatten().tolist()
+                            )
+                            x_center = (
+                                left_pixel + width_pixel / 2.0
+                            ) / image_width_pixel
+                            y_center = (
+                                top_pixel + height_pixel / 2.0
+                            ) / image_height_pixel
+                            width = width_pixel / image_width_pixel
+                            height = height_pixel / image_height_pixel
+                            # Ensure counts is a string for JSON serialization.
+                            if isinstance(rle["counts"], bytes):
+                                rle["counts"] = rle["counts"].decode("utf-8")
+                            segments.append(rle)  # type: ignore[arg-type]
+                        else:
                             raise RuntimeError(
                                 "RLE encoded segmentation requires Python >= 3.9 "
                                 "for pycocotools support."
                             )
-                        from pycocotools import mask as coco_mask
-
-                        # Ensure RLE is in compressed format.
-                        if isinstance(segmentation.get("counts"), list):
-                            rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
-                                segmentation,
-                                image_height_pixel,
-                                image_width_pixel,
-                            )
-                        else:
-                            rle = segmentation  # type: ignore[arg-type]
-
-                        # Extract bbox [x, y, w, h] from RLE and convert
-                        # to normalized [x_center, y_center, w, h].
-                        left_pixel, top_pixel, width_pixel, height_pixel = (
-                            coco_mask.toBbox(rle).flatten().tolist()
-                        )
-                        x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
-                        y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
-                        width = width_pixel / image_width_pixel
-                        height = height_pixel / image_height_pixel
-                        # Ensure counts is a string for JSON serialization.
-                        if isinstance(rle["counts"], bytes):
-                            rle["counts"] = rle["counts"].decode("utf-8")
-                        segments.append(rle)  # type: ignore[arg-type]
                     else:
                         # TODO this should not be the case
                         continue

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -22,6 +22,7 @@ else:
     coco_mask: Any = None
 
 import numpy as np
+import numpy.typing as npt
 import pydantic
 import torch
 from pydantic import Field
@@ -45,6 +46,97 @@ from lightly_train.types import (
     InstanceSegmentationDatasetItem,
     PathLike,
 )
+
+
+def _filter_valid_polygon_segments(
+    segmentation: list[list[float]],
+) -> list[list[float]]:
+    """Return polygon segments with >= 3 points (>= 6 even-length coords)."""
+    return [
+        segment
+        for segment in segmentation
+        if isinstance(segment, list) and len(segment) >= 6 and len(segment) % 2 == 0
+    ]
+
+
+def _normalize_polygon_segments(
+    segments: list[list[float]],
+    image_width: float,
+    image_height: float,
+) -> list[list[float]]:
+    """Normalize polygon coordinates from pixels to [0, 1]."""
+    return [
+        [
+            coord / image_width if i % 2 == 0 else coord / image_height
+            for i, coord in enumerate(segment)
+        ]
+        for segment in segments
+    ]
+
+
+def _bbox_from_polygon_segments(
+    segments: list[list[float]],
+) -> tuple[float, float, float, float]:
+    """Compute [x, y, w, h] bounding box in pixels from polygon segments."""
+    all_px = [coord for segment in segments for coord in segment]
+    xs = all_px[0::2]
+    ys = all_px[1::2]
+    left = min(xs)
+    top = min(ys)
+    return left, top, max(xs) - left, max(ys) - top
+
+
+def _process_polygon_segmentation(
+    segmentation: list[list[float]],
+    annotation: dict[str, Any],
+    image_width: float,
+    image_height: float,
+) -> tuple[list[list[float]], tuple[float, float, float, float]] | None:
+    """Process a polygon segmentation annotation.
+
+    Returns the normalized polygon group and bbox in [x, y, w, h] pixels,
+    or None if no valid segments exist.
+    """
+    valid_segments = _filter_valid_polygon_segments(segmentation)
+    if not valid_segments:
+        return None
+    polygon_group_norm = _normalize_polygon_segments(
+        valid_segments, image_width, image_height
+    )
+    if "bbox" in annotation:
+        bbox = tuple(annotation["bbox"])
+    else:
+        bbox = _bbox_from_polygon_segments(valid_segments)
+    return polygon_group_norm, bbox  # type: ignore[return-value]
+
+
+def _process_rle_segmentation(
+    segmentation: dict[str, Any],
+    annotation: dict[str, Any],
+    image_width: float,
+    image_height: float,
+) -> tuple[dict[str, Any], tuple[float, float, float, float]]:
+    """Process an RLE segmentation annotation.
+
+    Returns the compressed RLE dict and bbox in [x, y, w, h] pixels.
+    """
+    if coco_mask is None:
+        raise RuntimeError(
+            "RLE encoded segmentation requires Python >= 3.9 for pycocotools support."
+        )
+    if isinstance(segmentation.get("counts"), list):
+        rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
+            segmentation, image_height, image_width
+        )
+    else:
+        rle = segmentation
+    if "bbox" in annotation:
+        bbox = tuple(annotation["bbox"])
+    else:
+        bbox = tuple(coco_mask.toBbox(rle).flatten().tolist())
+    if isinstance(rle["counts"], bytes):
+        rle["counts"] = rle["counts"].decode("utf-8")
+    return rle, bbox  # type: ignore[return-value]
 
 
 class InstanceSegmentationDataset(TaskDataset):
@@ -117,7 +209,7 @@ class InstanceSegmentationDataset(TaskDataset):
         class_labels_np = np.array(class_labels, dtype=np.int64)
 
         h, w = image_np.shape[0], image_np.shape[1]
-        mask_list: list[np.ndarray[Any, Any]] = []
+        mask_list: list[npt.NDArray[np.bool_]] = []
         for segment in segments:
             if isinstance(segment, list):
                 # Polygon format: list of polygon coordinate arrays.
@@ -465,7 +557,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
             image_id = image["id"]
             image_filepath = image_dir / image["file_name"]
 
-            segments: list[Any] = []
+            segments: list[list[list[float]] | dict[str, Any]] = []
             bboxes = []
             class_labels = []
             if image_id in annotations_by_image_id:
@@ -474,85 +566,34 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     if not segmentation:
                         continue
                     if isinstance(segmentation, list):
-                        # Filter to valid polygon segments (list with >= 6
-                        # even-length coordinates, i.e. at least 3 points).
-                        valid_segments = [
-                            segment
-                            for segment in segmentation
-                            if isinstance(segment, list)
-                            and len(segment) >= 6
-                            and len(segment) % 2 == 0
-                        ]
-                        if not valid_segments:
+                        result = _process_polygon_segmentation(
+                            segmentation,
+                            annotation,
+                            image_width_pixel,
+                            image_height_pixel,
+                        )
+                        if result is None:
                             continue
-                        # Normalize each polygon segment to [0, 1].
-                        polygon_group_norm = [
-                            [
-                                coord / image_width_pixel
-                                if i % 2 == 0
-                                else coord / image_height_pixel
-                                for i, coord in enumerate(segment)
-                            ]
-                            for segment in valid_segments
-                        ]
-                        # Get bbox in [x, y, w, h] pixel format.
-                        if "bbox" in annotation:
-                            left_pixel, top_pixel, width_pixel, height_pixel = (
-                                annotation["bbox"]
-                            )
-                        else:
-                            all_px = [
-                                coord for segment in valid_segments for coord in segment
-                            ]
-                            xs = all_px[0::2]
-                            ys = all_px[1::2]
-                            left_pixel = min(xs)
-                            top_pixel = min(ys)
-                            width_pixel = max(xs) - left_pixel
-                            height_pixel = max(ys) - top_pixel
-                        segments.append(polygon_group_norm)
-
+                        segment: list[list[float]] | dict[str, Any] = result[0]
+                        bbox = result[1]
                     elif isinstance(segmentation, dict):
-                        # RLE encoded segmentation. pycocotools is only
-                        # available for Python >= 3.9.
-                        if coco_mask is None:
-                            raise RuntimeError(
-                                "RLE encoded segmentation requires Python >= 3.9 "
-                                "for pycocotools support."
-                            )
-
-                        # Ensure RLE is in compressed format.
-                        if isinstance(segmentation.get("counts"), list):
-                            rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
-                                segmentation,
-                                image_height_pixel,
-                                image_width_pixel,
-                            )
-                        else:
-                            rle = segmentation
-
-                        # Get bbox in [x, y, w, h] pixel format.
-                        if "bbox" in annotation:
-                            left_pixel, top_pixel, width_pixel, height_pixel = (
-                                annotation["bbox"]
-                            )
-                        else:
-                            left_pixel, top_pixel, width_pixel, height_pixel = (
-                                coco_mask.toBbox(rle).flatten().tolist()
-                            )
-
-                        # Ensure counts is a string for JSON serialization.
-                        if isinstance(rle["counts"], bytes):
-                            rle["counts"] = rle["counts"].decode("utf-8")
-                        segments.append(rle)
+                        segment, bbox = _process_rle_segmentation(
+                            segmentation,
+                            annotation,
+                            image_width_pixel,
+                            image_height_pixel,
+                        )
                     else:
                         raise ValueError(
                             f"Unsupported segmentation format: {type(segmentation)}. "
                             "Expected a list of polygons or an RLE dict."
                         )
 
+                    segments.append(segment)
+
                     # Convert bbox from [x, y, w, h] pixels to normalized
                     # [x_center, y_center, w, h].
+                    left_pixel, top_pixel, width_pixel, height_pixel = bbox
                     x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
                     y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
                     width = width_pixel / image_width_pixel

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -527,14 +527,12 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     # Get bbox in [x, y, w, h] pixel format. Use annotation
                     # bbox if available, otherwise derive from segmentation.
                     if "bbox" in annotation:
-                        left_pixel, top_pixel, width_pixel, height_pixel = (
-                            annotation["bbox"]
-                        )
+                        left_pixel, top_pixel, width_pixel, height_pixel = annotation[
+                            "bbox"
+                        ]
                     elif isinstance(segmentation, list):
                         all_px = [
-                            coord
-                            for segment in valid_segments
-                            for coord in segment
+                            coord for segment in valid_segments for coord in segment
                         ]
                         xs = all_px[0::2]
                         ys = all_px[1::2]

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -14,7 +14,10 @@ import sys
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, ClassVar, Literal, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
+
+if TYPE_CHECKING and sys.version_info >= (3, 9):
+    from pycocotools import _EncodedRLE
 
 import numpy as np
 import pydantic
@@ -518,13 +521,13 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
 
                             # Ensure RLE is in compressed format.
                             if isinstance(segmentation.get("counts"), list):
-                                rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
-                                    segmentation,
+                                rle = coco_mask.frPyObjects(
+                                    cast("_EncodedRLE", segmentation),
                                     image_height_pixel,
                                     image_width_pixel,
                                 )
                             else:
-                                rle = segmentation
+                                rle = cast("_EncodedRLE", segmentation)
 
                             # Get bbox in [x, y, w, h] pixel format.
                             if "bbox" in annotation:

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -493,6 +493,21 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             ]
                             for segment in valid_segments
                         ]
+                        # Get bbox in [x, y, w, h] pixel format.
+                        if "bbox" in annotation:
+                            left_pixel, top_pixel, width_pixel, height_pixel = (
+                                annotation["bbox"]
+                            )
+                        else:
+                            all_px = [
+                                coord for segment in valid_segments for coord in segment
+                            ]
+                            xs = all_px[0::2]
+                            ys = all_px[1::2]
+                            left_pixel = min(xs)
+                            top_pixel = min(ys)
+                            width_pixel = max(xs) - left_pixel
+                            height_pixel = max(ys) - top_pixel
                         segments.append(polygon_group_norm)
 
                     elif isinstance(segmentation, dict):
@@ -511,6 +526,16 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             else:
                                 rle = segmentation  # type: ignore[arg-type]
 
+                            # Get bbox in [x, y, w, h] pixel format.
+                            if "bbox" in annotation:
+                                left_pixel, top_pixel, width_pixel, height_pixel = (
+                                    annotation["bbox"]
+                                )
+                            else:
+                                left_pixel, top_pixel, width_pixel, height_pixel = (
+                                    coco_mask.toBbox(rle).flatten().tolist()
+                                )
+
                             # Ensure counts is a string for JSON serialization.
                             if isinstance(rle["counts"], bytes):
                                 rle["counts"] = rle["counts"].decode("utf-8")
@@ -523,28 +548,6 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     else:
                         # TODO this should not be the case
                         continue
-
-                    # Get bbox in [x, y, w, h] pixel format. Use annotation
-                    # bbox if available, otherwise derive from segmentation.
-                    if "bbox" in annotation:
-                        left_pixel, top_pixel, width_pixel, height_pixel = annotation[
-                            "bbox"
-                        ]
-                    elif isinstance(segmentation, list):
-                        all_px = [
-                            coord for segment in valid_segments for coord in segment
-                        ]
-                        xs = all_px[0::2]
-                        ys = all_px[1::2]
-                        left_pixel = min(xs)
-                        top_pixel = min(ys)
-                        width_pixel = max(xs) - left_pixel
-                        height_pixel = max(ys) - top_pixel
-                    else:
-                        # RLE without bbox: derive from mask.
-                        left_pixel, top_pixel, width_pixel, height_pixel = (
-                            coco_mask.toBbox(rle).flatten().tolist()
-                        )
 
                     # Convert bbox from [x, y, w, h] pixels to normalized
                     # [x_center, y_center, w, h].

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import functools
 import itertools
 import json
+import sys
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
@@ -121,7 +122,12 @@ class InstanceSegmentationDataset(TaskDataset):
                 )
                 mask_list.append(mask)
             elif isinstance(segment, dict):
-                # RLE format.
+                # RLE format. pycocotools is only available for Python >= 3.9.
+                if sys.version_info < (3, 9):
+                    raise RuntimeError(
+                        "RLE encoded segmentation requires Python >= 3.9 "
+                        "for pycocotools support."
+                    )
                 from pycocotools import mask as coco_mask
 
                 mask_list.append(
@@ -514,7 +520,6 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     elif isinstance(segmentation, dict):
                         # RLE encoded segmentation. pycocotools is only
                         # available for Python >= 3.9.
-                        import sys
 
                         if sys.version_info < (3, 9):
                             raise RuntimeError(

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -120,20 +120,18 @@ class InstanceSegmentationDataset(TaskDataset):
                 mask = yolo_helpers.binary_mask_from_polygon(
                     polygons_np, height=h, width=w
                 )
-                mask_list.append(mask)
             elif isinstance(segment, dict):
-                # RLE format. pycocotools is only available for Python >= 3.9.
+                # Compressed RLE format.
                 if sys.version_info >= (3, 9):
                     from pycocotools import mask as coco_mask
 
-                    mask_list.append(
-                        coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
-                    )
+                    mask = coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
                 else:
                     raise RuntimeError(
                         "RLE encoded segmentation requires Python >= 3.9 "
                         "for pycocotools support."
                     )
+            mask_list.append(mask)
         binary_masks_np = (
             np.stack(mask_list) if mask_list else np.zeros((0, h, w), dtype=np.bool_)
         )
@@ -495,27 +493,6 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             ]
                             for segment in valid_segments
                         ]
-                        # Convert bbox from [x, y, w, h] pixels to normalized
-                        # [x_center, y_center, w, h]. If bbox is missing, derive it
-                        # from the axis-aligned bounding box of all segments.
-                        if "bbox" in annotation:
-                            left_pixel, top_pixel, width_pixel, height_pixel = (
-                                annotation["bbox"]
-                            )
-                        else:
-                            all_px = [
-                                coord for segment in valid_segments for coord in segment
-                            ]
-                            xs = all_px[0::2]
-                            ys = all_px[1::2]
-                            left_pixel = min(xs)
-                            top_pixel = min(ys)
-                            width_pixel = max(xs) - left_pixel
-                            height_pixel = max(ys) - top_pixel
-                        x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
-                        y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
-                        width = width_pixel / image_width_pixel
-                        height = height_pixel / image_height_pixel
                         segments.append(polygon_group_norm)
 
                     elif isinstance(segmentation, dict):
@@ -534,19 +511,6 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             else:
                                 rle = segmentation  # type: ignore[arg-type]
 
-                            # Extract bbox [x, y, w, h] from RLE and convert
-                            # to normalized [x_center, y_center, w, h].
-                            left_pixel, top_pixel, width_pixel, height_pixel = (
-                                coco_mask.toBbox(rle).flatten().tolist()
-                            )
-                            x_center = (
-                                left_pixel + width_pixel / 2.0
-                            ) / image_width_pixel
-                            y_center = (
-                                top_pixel + height_pixel / 2.0
-                            ) / image_height_pixel
-                            width = width_pixel / image_width_pixel
-                            height = height_pixel / image_height_pixel
                             # Ensure counts is a string for JSON serialization.
                             if isinstance(rle["counts"], bytes):
                                 rle["counts"] = rle["counts"].decode("utf-8")
@@ -559,6 +523,37 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     else:
                         # TODO this should not be the case
                         continue
+
+                    # Get bbox in [x, y, w, h] pixel format. Use annotation
+                    # bbox if available, otherwise derive from segmentation.
+                    if "bbox" in annotation:
+                        left_pixel, top_pixel, width_pixel, height_pixel = (
+                            annotation["bbox"]
+                        )
+                    elif isinstance(segmentation, list):
+                        all_px = [
+                            coord
+                            for segment in valid_segments
+                            for coord in segment
+                        ]
+                        xs = all_px[0::2]
+                        ys = all_px[1::2]
+                        left_pixel = min(xs)
+                        top_pixel = min(ys)
+                        width_pixel = max(xs) - left_pixel
+                        height_pixel = max(ys) - top_pixel
+                    else:
+                        # RLE without bbox: derive from mask.
+                        left_pixel, top_pixel, width_pixel, height_pixel = (
+                            coco_mask.toBbox(rle).flatten().tolist()
+                        )
+
+                    # Convert bbox from [x, y, w, h] pixels to normalized
+                    # [x_center, y_center, w, h].
+                    x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
+                    y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
+                    width = width_pixel / image_width_pixel
+                    height = height_pixel / image_height_pixel
                     bboxes.append([x_center, y_center, width, height])
                     class_labels.append(annotation["category_id"])
             else:

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -14,11 +14,7 @@ import sys
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
-
-if TYPE_CHECKING:
-    if sys.version_info >= (3, 9):
-        from pycocotools import _EncodedRLE
+from typing import Any, ClassVar, Literal, Sequence
 
 if sys.version_info >= (3, 9):
     from pycocotools import mask as coco_mask
@@ -526,15 +522,14 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             )
 
                         # Ensure RLE is in compressed format.
-                        rle_input = cast("_EncodedRLE", segmentation)
                         if isinstance(segmentation.get("counts"), list):
-                            rle = coco_mask.frPyObjects(
-                                rle_input,
+                            rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
+                                segmentation,
                                 image_height_pixel,
                                 image_width_pixel,
                             )
                         else:
-                            rle = rle_input
+                            rle = segmentation
 
                         # Get bbox in [x, y, w, h] pixel format.
                         if "bbox" in annotation:

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -524,12 +524,13 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
     def list_image_info(self) -> Iterable[dict[str, str]]:
         """Yields image info dicts for each image in the COCO annotation file.
 
-        Polygons are converted from COCO format (pixel coordinates) to normalized
-        [0, 1] coordinates. Each annotation's polygon segments are stored as a list
-        of polygons. Bounding boxes are converted from COCO format
-        (x, y, width, height in pixels) to normalized (x_center, y_center, width,
-        height) format. Images with no annotations are included unless
-        ``skip_if_annotations_missing`` is True.
+        Each annotation's segmentation is either a polygon group or an RLE dict.
+        Polygon segmentations are normalized from pixel coordinates to [0, 1] and
+        stored as ``list[list[float]]``. RLE segmentations are stored as compressed
+        RLE dicts (``{"counts": str, "size": [h, w]}``). Bounding boxes are
+        converted from COCO format (x, y, width, height in pixels) to normalized
+        (x_center, y_center, width, height) format. Images with no annotations are
+        included unless ``skip_if_annotations_missing`` is True.
         """
         class_id_to_internal_class_id = (
             label_helpers.get_class_id_to_internal_class_id_mapping(
@@ -567,10 +568,10 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                         continue
                     if isinstance(segmentation, list):
                         result = _process_polygon_segmentation(
-                            segmentation,
-                            annotation,
-                            image_width_pixel,
-                            image_height_pixel,
+                            segmentation=segmentation,
+                            annotation=annotation,
+                            image_width=image_width_pixel,
+                            image_height=image_height_pixel,
                         )
                         if result is None:
                             continue
@@ -578,10 +579,10 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                         bbox = result[1]
                     elif isinstance(segmentation, dict):
                         segment, bbox = _process_rle_segmentation(
-                            segmentation,
-                            annotation,
-                            image_width_pixel,
-                            image_height_pixel,
+                            segmentation=segmentation,
+                            annotation=annotation,
+                            image_width=image_width_pixel,
+                            image_height=image_height_pixel,
                         )
                     else:
                         raise ValueError(

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -115,6 +115,15 @@ class InstanceSegmentationDataset(TaskDataset):
         class_labels_np = np.array(class_labels, dtype=np.int64)
 
         h, w = image_np.shape[0], image_np.shape[1]
+        coco_mask_mod = None
+        if any(isinstance(s, dict) for s in segments):
+            if sys.version_info >= (3, 9):
+                from pycocotools import mask as coco_mask_mod
+            else:
+                raise RuntimeError(
+                    "RLE encoded segmentation requires Python >= 3.9 "
+                    "for pycocotools support."
+                )
         mask_list: list[np.ndarray[Any, Any]] = []
         for segment in segments:
             if isinstance(segment, list):
@@ -125,15 +134,8 @@ class InstanceSegmentationDataset(TaskDataset):
                 )
             elif isinstance(segment, dict):
                 # Compressed RLE format.
-                if sys.version_info >= (3, 9):
-                    from pycocotools import mask as coco_mask
-
-                    mask = coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
-                else:
-                    raise RuntimeError(
-                        "RLE encoded segmentation requires Python >= 3.9 "
-                        "for pycocotools support."
-                    )
+                assert coco_mask_mod is not None
+                mask = coco_mask_mod.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
             mask_list.append(mask)
         binary_masks_np = (
             np.stack(mask_list) if mask_list else np.zeros((0, h, w), dtype=np.bool_)
@@ -440,6 +442,10 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
         height) format. Images with no annotations are included unless
         ``skip_if_annotations_missing`` is True.
         """
+        coco_mask: Any = None
+        if sys.version_info >= (3, 9):
+            from pycocotools import mask as coco_mask
+
         class_id_to_internal_class_id = (
             label_helpers.get_class_id_to_internal_class_id_mapping(
                 class_ids=self.classes.keys(),
@@ -516,38 +522,36 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                     elif isinstance(segmentation, dict):
                         # RLE encoded segmentation. pycocotools is only
                         # available for Python >= 3.9.
-                        if sys.version_info >= (3, 9):
-                            from pycocotools import mask as coco_mask
-
-                            # Ensure RLE is in compressed format.
-                            if isinstance(segmentation.get("counts"), list):
-                                rle = coco_mask.frPyObjects(
-                                    cast("_EncodedRLE", segmentation),
-                                    image_height_pixel,
-                                    image_width_pixel,
-                                )
-                            else:
-                                rle = cast("_EncodedRLE", segmentation)
-
-                            # Get bbox in [x, y, w, h] pixel format.
-                            if "bbox" in annotation:
-                                left_pixel, top_pixel, width_pixel, height_pixel = (
-                                    annotation["bbox"]
-                                )
-                            else:
-                                left_pixel, top_pixel, width_pixel, height_pixel = (
-                                    coco_mask.toBbox(rle).flatten().tolist()
-                                )
-
-                            # Ensure counts is a string for JSON serialization.
-                            if isinstance(rle["counts"], bytes):
-                                rle["counts"] = rle["counts"].decode("utf-8")
-                            segments.append(rle)
-                        else:
+                        if coco_mask is None:
                             raise RuntimeError(
                                 "RLE encoded segmentation requires Python >= 3.9 "
                                 "for pycocotools support."
                             )
+
+                        # Ensure RLE is in compressed format.
+                        if isinstance(segmentation.get("counts"), list):
+                            rle = coco_mask.frPyObjects(
+                                cast("_EncodedRLE", segmentation),
+                                image_height_pixel,
+                                image_width_pixel,
+                            )
+                        else:
+                            rle = cast("_EncodedRLE", segmentation)
+
+                        # Get bbox in [x, y, w, h] pixel format.
+                        if "bbox" in annotation:
+                            left_pixel, top_pixel, width_pixel, height_pixel = (
+                                annotation["bbox"]
+                            )
+                        else:
+                            left_pixel, top_pixel, width_pixel, height_pixel = (
+                                coco_mask.toBbox(rle).flatten().tolist()
+                            )
+
+                        # Ensure counts is a string for JSON serialization.
+                        if isinstance(rle["counts"], bytes):
+                            rle["counts"] = rle["counts"].decode("utf-8")
+                        segments.append(rle)
                     else:
                         raise ValueError(
                             f"Unsupported segmentation format: {type(segmentation)}. "

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -96,7 +96,7 @@ class InstanceSegmentationDataset(TaskDataset):
         # Load the image.
         image_info = self.image_info[index]
         image_path = Path(image_info["image_path"])
-        polygons = json.loads(image_info["polygons"])
+        segments = json.loads(image_info["segments"])
         bboxes = json.loads(image_info["bboxes"])
         class_labels = json.loads(image_info["class_labels"])
 
@@ -106,15 +106,29 @@ class InstanceSegmentationDataset(TaskDataset):
         image_np = file_helpers.open_image_numpy(
             image_path=image_path, mode=self.image_mode
         )
-        polygons_np = [
-            [np.array(segment, dtype=np.float64) for segment in polygon_group]
-            for polygon_group in polygons
-        ]
+
         bboxes_np = np.array(bboxes, dtype=np.float64).reshape(len(bboxes), 4)
         class_labels_np = np.array(class_labels, dtype=np.int64)
 
-        binary_masks_np = yolo_helpers.binary_masks_from_polygons(
-            polygons=polygons_np, height=image_np.shape[0], width=image_np.shape[1]
+        h, w = image_np.shape[0], image_np.shape[1]
+        mask_list: list[np.ndarray[Any, Any]] = []
+        for segment in segments:
+            if isinstance(segment, list):
+                # Polygon format: list of polygon coordinate arrays.
+                polygons_np = [np.array(poly, dtype=np.float64) for poly in segment]
+                mask = yolo_helpers.binary_mask_from_polygon(
+                    polygons_np, height=h, width=w
+                )
+                mask_list.append(mask)
+            elif isinstance(segment, dict):
+                # RLE format.
+                from pycocotools import mask as coco_mask
+
+                mask_list.append(
+                    coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
+                )
+        binary_masks_np = (
+            np.stack(mask_list) if mask_list else np.zeros((0, h, w), dtype=np.bool_)
         )
 
         transform_input: InstanceSegmentationTransformInput = {
@@ -269,7 +283,7 @@ class YOLOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
             label_filepath = self.label_dir / Path(image_filename).with_suffix(".txt")
 
             if label_filepath.exists():
-                polygons, bboxes, class_labels = (
+                segments, bboxes, class_labels = (
                     file_helpers.open_yolo_instance_segmentation_label(
                         label_path=label_filepath
                     )
@@ -279,13 +293,13 @@ class YOLOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                 #   And keep track of how many files are missing labels.
                 if self.skip_if_label_file_missing:
                     continue
-                polygons = []
+                segments = []
                 bboxes = []
                 class_labels = []
 
             # Remove instances with class IDs that are not in the included classes
             keep = [label in class_id_to_internal_class_id for label in class_labels]
-            polygons = list(itertools.compress(polygons, keep))
+            segments = list(itertools.compress(segments, keep))
             bboxes = list(itertools.compress(bboxes, keep))
             class_labels = list(itertools.compress(class_labels, keep))
 
@@ -296,7 +310,7 @@ class YOLOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
 
             yield {
                 "image_path": str(image_filepath),
-                "polygons": json.dumps(polygons),
+                "segments": json.dumps(segments),
                 "bboxes": json.dumps(bboxes),
                 "class_labels": json.dumps(class_labels),
             }
@@ -444,58 +458,97 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
             image_id = image["id"]
             image_filepath = image_dir / image["file_name"]
 
-            polygons = []
+            segments = []
             bboxes = []
             class_labels = []
             if image_id in annotations_by_image_id:
                 for annotation in annotations_by_image_id[image_id]:
                     segmentation = annotation.get("segmentation", [])
-                    if not segmentation or not isinstance(segmentation, list):
+                    if not segmentation:
                         continue
-                    # Filter to valid polygon segments (list with >= 6
-                    # even-length coordinates, i.e. at least 3 points).
-                    valid_segments = [
-                        segment
-                        for segment in segmentation
-                        if isinstance(segment, list)
-                        and len(segment) >= 6
-                        and len(segment) % 2 == 0
-                    ]
-                    if not valid_segments:
-                        continue
-                    # Normalize each polygon segment to [0, 1].
-                    polygon_group_norm = [
-                        [
-                            coord / image_width_pixel
-                            if i % 2 == 0
-                            else coord / image_height_pixel
-                            for i, coord in enumerate(segment)
+                    if isinstance(segmentation, list):
+                        # Filter to valid polygon segments (list with >= 6
+                        # even-length coordinates, i.e. at least 3 points).
+                        valid_segments = [
+                            segment
+                            for segment in segmentation
+                            if isinstance(segment, list)
+                            and len(segment) >= 6
+                            and len(segment) % 2 == 0
                         ]
-                        for segment in valid_segments
-                    ]
-                    # Convert bbox from [x, y, w, h] pixels to normalized
-                    # [x_center, y_center, w, h]. If bbox is missing, derive it
-                    # from the axis-aligned bounding box of all segments.
-                    if "bbox" in annotation:
-                        left_pixel, top_pixel, width_pixel, height_pixel = annotation[
-                            "bbox"
+                        if not valid_segments:
+                            continue
+                        # Normalize each polygon segment to [0, 1].
+                        polygon_group_norm = [
+                            [
+                                coord / image_width_pixel
+                                if i % 2 == 0
+                                else coord / image_height_pixel
+                                for i, coord in enumerate(segment)
+                            ]
+                            for segment in valid_segments
                         ]
-                    else:
-                        all_px = [
-                            coord for segment in valid_segments for coord in segment
-                        ]
-                        xs = all_px[0::2]
-                        ys = all_px[1::2]
-                        left_pixel = min(xs)
-                        top_pixel = min(ys)
-                        width_pixel = max(xs) - left_pixel
-                        height_pixel = max(ys) - top_pixel
-                    x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
-                    y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
-                    width = width_pixel / image_width_pixel
-                    height = height_pixel / image_height_pixel
+                        # Convert bbox from [x, y, w, h] pixels to normalized
+                        # [x_center, y_center, w, h]. If bbox is missing, derive it
+                        # from the axis-aligned bounding box of all segments.
+                        if "bbox" in annotation:
+                            left_pixel, top_pixel, width_pixel, height_pixel = (
+                                annotation["bbox"]
+                            )
+                        else:
+                            all_px = [
+                                coord for segment in valid_segments for coord in segment
+                            ]
+                            xs = all_px[0::2]
+                            ys = all_px[1::2]
+                            left_pixel = min(xs)
+                            top_pixel = min(ys)
+                            width_pixel = max(xs) - left_pixel
+                            height_pixel = max(ys) - top_pixel
+                        x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
+                        y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
+                        width = width_pixel / image_width_pixel
+                        height = height_pixel / image_height_pixel
+                        segments.append(polygon_group_norm)
 
-                    polygons.append(polygon_group_norm)
+                    elif isinstance(segmentation, dict):
+                        # RLE encoded segmentation. pycocotools is only
+                        # available for Python >= 3.9.
+                        import sys
+
+                        if sys.version_info < (3, 9):
+                            raise RuntimeError(
+                                "RLE encoded segmentation requires Python >= 3.9 "
+                                "for pycocotools support."
+                            )
+                        from pycocotools import mask as coco_mask
+
+                        # Ensure RLE is in compressed format.
+                        if isinstance(segmentation.get("counts"), list):
+                            rle = coco_mask.frPyObjects(  # type: ignore[call-overload]
+                                segmentation,
+                                image_height_pixel,
+                                image_width_pixel,
+                            )
+                        else:
+                            rle = segmentation  # type: ignore[arg-type]
+
+                        # Extract bbox [x, y, w, h] from RLE and convert
+                        # to normalized [x_center, y_center, w, h].
+                        left_pixel, top_pixel, width_pixel, height_pixel = (
+                            coco_mask.toBbox(rle).flatten().tolist()
+                        )
+                        x_center = (left_pixel + width_pixel / 2.0) / image_width_pixel
+                        y_center = (top_pixel + height_pixel / 2.0) / image_height_pixel
+                        width = width_pixel / image_width_pixel
+                        height = height_pixel / image_height_pixel
+                        # Ensure counts is a string for JSON serialization.
+                        if isinstance(rle["counts"], bytes):
+                            rle["counts"] = rle["counts"].decode("utf-8")
+                        segments.append(rle)  # type: ignore[arg-type]
+                    else:
+                        # TODO this should not be the case
+                        continue
                     bboxes.append([x_center, y_center, width, height])
                     class_labels.append(annotation["category_id"])
             else:
@@ -506,7 +559,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
 
             # Remove instances with class IDs that are not in the included classes.
             keep = [label in class_id_to_internal_class_id for label in class_labels]
-            polygons = list(itertools.compress(polygons, keep))
+            segments = list(itertools.compress(segments, keep))
             bboxes = list(itertools.compress(bboxes, keep))
             class_labels = list(itertools.compress(class_labels, keep))
 
@@ -517,7 +570,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
 
             yield {
                 "image_path": str(image_filepath),
-                "polygons": json.dumps(polygons),
+                "segments": json.dumps(segments),
                 "bboxes": json.dumps(bboxes),
                 "class_labels": json.dumps(class_labels),
             }

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -524,7 +524,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                                     image_width_pixel,
                                 )
                             else:
-                                rle = segmentation  # type: ignore[arg-type]
+                                rle = segmentation
 
                             # Get bbox in [x, y, w, h] pixel format.
                             if "bbox" in annotation:
@@ -539,15 +539,17 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             # Ensure counts is a string for JSON serialization.
                             if isinstance(rle["counts"], bytes):
                                 rle["counts"] = rle["counts"].decode("utf-8")
-                            segments.append(rle)  # type: ignore[arg-type]
+                            segments.append(rle)
                         else:
                             raise RuntimeError(
                                 "RLE encoded segmentation requires Python >= 3.9 "
                                 "for pycocotools support."
                             )
                     else:
-                        # TODO this should not be the case
-                        continue
+                        raise ValueError(
+                            f"Unsupported segmentation format: {type(segmentation)}. "
+                            "Expected a list of polygons or an RLE dict."
+                        )
 
                     # Convert bbox from [x, y, w, h] pixels to normalized
                     # [x_center, y_center, w, h].

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -466,7 +466,7 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
             image_id = image["id"]
             image_filepath = image_dir / image["file_name"]
 
-            segments = []
+            segments: list[Any] = []
             bboxes = []
             class_labels = []
             if image_id in annotations_by_image_id:

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -19,6 +19,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
 if TYPE_CHECKING and sys.version_info >= (3, 9):
     from pycocotools import _EncodedRLE
 
+if sys.version_info >= (3, 9):
+    from pycocotools import mask as coco_mask
+else:
+    coco_mask: Any = None
+
 import numpy as np
 import pydantic
 import torch
@@ -115,15 +120,6 @@ class InstanceSegmentationDataset(TaskDataset):
         class_labels_np = np.array(class_labels, dtype=np.int64)
 
         h, w = image_np.shape[0], image_np.shape[1]
-        coco_mask_mod = None
-        if any(isinstance(s, dict) for s in segments):
-            if sys.version_info >= (3, 9):
-                from pycocotools import mask as coco_mask_mod
-            else:
-                raise RuntimeError(
-                    "RLE encoded segmentation requires Python >= 3.9 "
-                    "for pycocotools support."
-                )
         mask_list: list[np.ndarray[Any, Any]] = []
         for segment in segments:
             if isinstance(segment, list):
@@ -134,8 +130,12 @@ class InstanceSegmentationDataset(TaskDataset):
                 )
             elif isinstance(segment, dict):
                 # Compressed RLE format.
-                assert coco_mask_mod is not None
-                mask = coco_mask_mod.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
+                if coco_mask is None:
+                    raise RuntimeError(
+                        "RLE encoded segmentation requires Python >= 3.9 "
+                        "for pycocotools support."
+                    )
+                mask = coco_mask.decode(segment).astype(np.bool_)  # type: ignore[arg-type]
             mask_list.append(mask)
         binary_masks_np = (
             np.stack(mask_list) if mask_list else np.zeros((0, h, w), dtype=np.bool_)
@@ -442,10 +442,6 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
         height) format. Images with no annotations are included unless
         ``skip_if_annotations_missing`` is True.
         """
-        coco_mask: Any = None
-        if sys.version_info >= (3, 9):
-            from pycocotools import mask as coco_mask
-
         class_id_to_internal_class_id = (
             label_helpers.get_class_id_to_internal_class_id_mapping(
                 class_ids=self.classes.keys(),

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -16,8 +16,9 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
 
-if TYPE_CHECKING and sys.version_info >= (3, 9):
-    from pycocotools import _EncodedRLE
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 9):
+        from pycocotools import _EncodedRLE
 
 if sys.version_info >= (3, 9):
     from pycocotools import mask as coco_mask
@@ -525,14 +526,15 @@ class COCOInstanceSegmentationDatasetArgs(TaskDatasetArgs):
                             )
 
                         # Ensure RLE is in compressed format.
+                        rle_input = cast("_EncodedRLE", segmentation)
                         if isinstance(segmentation.get("counts"), list):
                             rle = coco_mask.frPyObjects(
-                                cast("_EncodedRLE", segmentation),
+                                rle_input,
                                 image_height_pixel,
                                 image_width_pixel,
                             )
                         else:
-                            rle = cast("_EncodedRLE", segmentation)
+                            rle = rle_input
 
                         # Get bbox in [x, y, w, h] pixel format.
                         if "bbox" in annotation:

--- a/src/lightly_train/_data/yolo_helpers.py
+++ b/src/lightly_train/_data/yolo_helpers.py
@@ -123,33 +123,6 @@ def binary_mask_from_polygon(
     return np.array(mask, dtype=np.bool_)
 
 
-def binary_masks_from_polygons(
-    polygons: list[list[NDArrayPolygon]], height: int, width: int
-) -> NDArrayBinaryMasks:
-    """Convert a list of per-instance polygon groups to a stack of binary masks.
-
-    Args:
-        polygons:
-            List of polygon groups, one per instance. Each group is a list of
-            numpy arrays of shape (n_points*2,) in normalized coordinates [0, 1].
-        height:
-            Height of the image.
-        width:
-            Width of the image.
-
-    Returns:
-        Stack of binary masks with shape (n_instances, H, W).
-    """
-    binary_masks = [
-        binary_mask_from_polygon(polygon_group, height, width)
-        for polygon_group in polygons
-    ]
-    if binary_masks:
-        return np.stack(binary_masks)
-    else:
-        return np.zeros((0, height, width), dtype=np.bool_)
-
-
 def oriented_bbox_from_corners(corners: NDArray4Corners) -> NDArrayOBBoxes:
     """Convert 4-corner format to (cx, cy, w, h, angle) format.
 

--- a/src/lightly_train/_data/yolo_helpers.py
+++ b/src/lightly_train/_data/yolo_helpers.py
@@ -16,7 +16,6 @@ from typing_extensions import Literal
 from lightly_train.types import (
     NDArray4Corners,
     NDArrayBinaryMask,
-    NDArrayBinaryMasks,
     NDArrayOBBoxes,
     NDArrayPolygon,
 )

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,6 +21,10 @@ from lightly_train._data.instance_segmentation_dataset import (
     COCOSplitArgs,
     YOLOInstanceSegmentationDataArgs,
     YOLOInstanceSegmentationDatasetArgs,
+    _bbox_from_polygon_segments,
+    _filter_valid_polygon_segments,
+    _normalize_polygon_segments,
+    _process_polygon_segmentation,
 )
 
 from .. import helpers
@@ -148,6 +153,48 @@ _COCO_POLYGON_NORM = [v / 128 for v in _COCO_POLYGON_PX]
 _COCO_BBOX = [25 / 128, 30 / 128, 30 / 128, 40 / 128]
 # Bbox derived from polygon (same rectangle, so same result).
 _COCO_BBOX_FROM_POLYGON = [25 / 128, 30 / 128, 30 / 128, 40 / 128]
+
+
+def _create_rle_annotations_from_polygon(
+    polygon_px: list[float], height: int, width: int
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if sys.version_info >= (3, 9):  # Needed for Mypy
+        from pycocotools import mask as coco_mask
+
+        # Create a compressed RLE from a polygon using pycocotools.
+        rle_list = coco_mask.frPyObjects([[int(v) for v in polygon_px]], height, width)
+        compressed_rle = coco_mask.merge(rle_list)
+        # counts is bytes, convert to str for JSON.
+        counts_raw = compressed_rle["counts"]
+        counts_str = (
+            counts_raw.decode("utf-8") if isinstance(counts_raw, bytes) else counts_raw
+        )
+        compressed_rle_annotation = {
+            "counts": counts_str,
+            "size": compressed_rle["size"],
+        }
+
+        # Create an uncompressed RLE (counts as a list of ints).
+        binary_mask = coco_mask.decode(compressed_rle)
+        flat = binary_mask.flatten(order="F")
+        counts: list[int] = []
+        current: int = 0
+        count: int = 0
+        for val in flat:
+            if val == current:
+                count += 1
+            else:
+                counts.append(count)
+                current = int(val)
+                count = 1
+        counts.append(count)
+        uncompressed_rle_annotation = {
+            "counts": counts,
+            "size": [height, width],
+        }
+
+        return compressed_rle_annotation, uncompressed_rle_annotation
+    raise RuntimeError("pycocotools requires Python >= 3.9")
 
 
 class TestCOCOInstanceSegmentationDataArgs:
@@ -366,45 +413,12 @@ class TestCOCOInstanceSegmentationMmapHash:
     def test_list_image_info__mixed_polygon_and_rle(self, tmp_path: Path) -> None:
         """Test a single image with polygon, compressed RLE, and uncompressed RLE annotations."""
         if sys.version_info >= (3, 9):  # Needed for Mypy
-            from pycocotools import mask as coco_mask
-
             height, width = 128, 128
 
-            # Create a compressed RLE from a polygon using pycocotools.
-            rle_list = coco_mask.frPyObjects(
-                [[int(v) for v in _COCO_POLYGON_PX]], height, width
-            )
-            compressed_rle = coco_mask.merge(rle_list)
-            # counts is bytes, convert to str for JSON.
-            counts_raw = compressed_rle["counts"]
-            counts_str = (
-                counts_raw.decode("utf-8")
-                if isinstance(counts_raw, bytes)
-                else counts_raw
-            )
-            compressed_rle_annotation = {
-                "counts": counts_str,
-                "size": compressed_rle["size"],
-            }
-
-            # Create an uncompressed RLE (counts as a list of ints).
-            binary_mask = coco_mask.decode(compressed_rle)
-            flat = binary_mask.flatten(order="F")
-            counts: list[int] = []
-            current: int = 0
-            count: int = 0
-            for val in flat:
-                if val == current:
-                    count += 1
-                else:
-                    counts.append(count)
-                    current = int(val)
-                    count = 1
-            counts.append(count)
-            uncompressed_rle_annotation = {
-                "counts": counts,
-                "size": [height, width],
-            }
+            (
+                compressed_rle_annotation,
+                uncompressed_rle_annotation,
+            ) = _create_rle_annotations_from_polygon(_COCO_POLYGON_PX, height, width)
 
             annotations_per_image = [
                 [
@@ -498,3 +512,172 @@ class TestCOCOInstanceSegmentationMmapHash:
 
         with pytest.raises(RuntimeError, match="Python >= 3.9"):
             list(args.list_image_info())
+
+
+class TestFilterValidPolygonSegments:
+    def test_valid_segments_kept(self) -> None:
+        # Arrange
+        segments = [
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0],
+        ]
+
+        # Act
+        result = _filter_valid_polygon_segments(segments)
+
+        # Assert
+        assert result == segments
+
+    def test_too_few_coords_removed(self) -> None:
+        # Arrange
+        segments = [[1.0, 2.0, 3.0, 4.0]]
+
+        # Act
+        result = _filter_valid_polygon_segments(segments)
+
+        # Assert
+        assert result == []
+
+    def test_odd_length_removed(self) -> None:
+        # Arrange
+        segments = [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]]
+
+        # Act
+        result = _filter_valid_polygon_segments(segments)
+
+        # Assert
+        assert result == []
+
+    def test_non_list_entries_removed(self) -> None:
+        # Arrange
+        segments: list[Any] = ["not_a_list", [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]
+
+        # Act
+        result = _filter_valid_polygon_segments(segments)
+
+        # Assert
+        assert result == [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]
+
+    def test_empty_input(self) -> None:
+        # Arrange
+        segments: list[list[float]] = []
+
+        # Act
+        result = _filter_valid_polygon_segments(segments)
+
+        # Assert
+        assert result == []
+
+
+class TestNormalizePolygonSegments:
+    def test_normalize(self) -> None:
+        # Arrange
+        segments = [[10.0, 20.0, 30.0, 40.0, 50.0, 60.0]]
+
+        # Act
+        result = _normalize_polygon_segments(
+            segments, image_width=100, image_height=200
+        )
+
+        # Assert
+        assert result == [[0.1, 0.1, 0.3, 0.2, 0.5, 0.3]]
+
+    def test_multiple_segments(self) -> None:
+        # Arrange
+        segments = [
+            [100.0, 200.0, 300.0, 400.0, 500.0, 600.0],
+            [50.0, 50.0, 150.0, 150.0, 250.0, 250.0],
+        ]
+
+        # Act
+        result = _normalize_polygon_segments(
+            segments, image_width=500, image_height=1000
+        )
+
+        # Assert
+        assert result == [
+            [0.2, 0.2, 0.6, 0.4, 1.0, 0.6],
+            [0.1, 0.05, 0.3, 0.15, 0.5, 0.25],
+        ]
+
+
+class TestBboxFromPolygonSegments:
+    def test_single_segment(self) -> None:
+        # Arrange
+        segments = [[10.0, 10.0, 40.0, 10.0, 40.0, 50.0, 10.0, 50.0]]
+
+        # Act
+        result = _bbox_from_polygon_segments(segments)
+
+        # Assert
+        assert result == (10.0, 10.0, 30.0, 40.0)
+
+    def test_multiple_segments(self) -> None:
+        # Arrange
+        segments = [
+            [0.0, 0.0, 10.0, 10.0, 20.0, 20.0],
+            [5.0, 5.0, 30.0, 25.0, 15.0, 15.0],
+        ]
+
+        # Act
+        left, top, w, h = _bbox_from_polygon_segments(segments)
+
+        # Assert
+        assert (left, top) == (0.0, 0.0)
+        assert w == 30.0
+        assert h == 25.0
+
+
+class TestProcessPolygonSegmentation:
+    def test_returns_none_for_invalid_segments(self) -> None:
+        # Arrange
+        segmentation = [[1.0, 2.0]]
+        annotation: dict[str, Any] = {"bbox": [0, 0, 10, 10]}
+
+        # Act
+        result = _process_polygon_segmentation(
+            segmentation=segmentation,
+            annotation=annotation,
+            image_width=100,
+            image_height=100,
+        )
+
+        # Assert
+        assert result is None
+
+    def test_uses_annotation_bbox(self) -> None:
+        # Arrange
+        segmentation = [[10.0, 10.0, 40.0, 10.0, 40.0, 50.0, 10.0, 50.0]]
+        annotation = {"bbox": [5, 5, 50, 60]}
+
+        # Act
+        result = _process_polygon_segmentation(
+            segmentation=segmentation,
+            annotation=annotation,
+            image_width=128,
+            image_height=128,
+        )
+
+        # Assert
+        assert result is not None
+        _, bbox = result
+        assert bbox == (5, 5, 50, 60)
+
+    def test_derives_bbox_from_polygon(self) -> None:
+        # Arrange
+        polygon = [10.0, 10.0, 40.0, 10.0, 40.0, 50.0, 10.0, 50.0]
+        annotation: dict[str, Any] = {}
+
+        # Act
+        result = _process_polygon_segmentation(
+            segmentation=[polygon],
+            annotation=annotation,
+            image_width=128,
+            image_height=128,
+        )
+
+        # Assert
+        assert result is not None
+        segments, bbox = result
+        assert bbox == (10.0, 10.0, 30.0, 40.0)
+        assert segments == [[v / 128 for v in polygon]]

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -111,7 +112,7 @@ class TestYOLOInstanceSegmentationDatasetArgs:
         assert len(image_info) == 2
         for info in image_info:
             assert Path(info["image_path"]).exists()
-            assert json.loads(info["polygons"]) == [[_POLYGON]]
+            assert json.loads(info["segments"]) == [[_POLYGON]]
             assert json.loads(info["bboxes"]) == [_BBOX]
             assert json.loads(info["class_labels"]) == [0]
 
@@ -135,7 +136,7 @@ class TestYOLOInstanceSegmentationDatasetArgs:
         assert len(image_info) == 3
         for info in image_info:
             assert Path(info["image_path"]).exists()
-            assert json.loads(info["polygons"]) == [[_POLYGON]]
+            assert json.loads(info["segments"]) == [[_POLYGON]]
             assert json.loads(info["bboxes"]) == [_BBOX]
             assert json.loads(info["class_labels"]) == [0]
 
@@ -212,7 +213,7 @@ class TestCOCOInstanceSegmentationDatasetArgs:
         assert len(image_info) == 3
         for info in image_info:
             assert Path(info["image_path"]).exists()
-            assert json.loads(info["polygons"]) == [[_COCO_POLYGON_NORM]]
+            assert json.loads(info["segments"]) == [[_COCO_POLYGON_NORM]]
             assert json.loads(info["bboxes"]) == [_COCO_BBOX]
             assert json.loads(info["class_labels"]) == [0]
 
@@ -358,3 +359,139 @@ class TestCOCOInstanceSegmentationMmapHash:
         st = annotations_path.stat()
         os.utime(annotations_path, (st.st_atime, st.st_mtime + 1))
         assert args.train_data_mmap_hash() != hash_before
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9), reason="pycocotools requires Python >= 3.9"
+    )
+    def test_list_image_info__mixed_polygon_and_rle(self, tmp_path: Path) -> None:
+        """Test a single image with polygon, compressed RLE, and uncompressed RLE annotations."""
+        from pycocotools import mask as coco_mask
+
+        height, width = 128, 128
+
+        # Create a compressed RLE from a polygon using pycocotools.
+        rle_list = coco_mask.frPyObjects(
+            [[int(v) for v in _COCO_POLYGON_PX]], height, width
+        )
+        compressed_rle = coco_mask.merge(rle_list)
+        # counts is bytes, convert to str for JSON.
+        counts_raw = compressed_rle["counts"]
+        counts_str = (
+            counts_raw.decode("utf-8") if isinstance(counts_raw, bytes) else counts_raw
+        )
+        compressed_rle_annotation = {
+            "counts": counts_str,
+            "size": compressed_rle["size"],
+        }
+
+        # Create an uncompressed RLE (counts as a list of ints).
+        binary_mask = coco_mask.decode(compressed_rle)
+        flat = binary_mask.flatten(order="F")
+        counts: list[int] = []
+        current: int = 0
+        count: int = 0
+        for val in flat:
+            if val == current:
+                count += 1
+            else:
+                counts.append(count)
+                current = int(val)
+                count = 1
+        counts.append(count)
+        uncompressed_rle_annotation = {
+            "counts": counts,
+            "size": [height, width],
+        }
+
+        annotations_per_image = [
+            [
+                {
+                    "category_id": 0,
+                    "bbox": [10, 10, 30, 40],
+                    "segmentation": [_COCO_POLYGON_PX],
+                },
+                {
+                    "category_id": 0,
+                    "segmentation": compressed_rle_annotation,
+                },
+                {
+                    "category_id": 0,
+                    "segmentation": uncompressed_rle_annotation,
+                },
+            ]
+        ]
+
+        create_coco_instance_segmentation_dataset(
+            tmp_path=tmp_path,
+            num_files=1,
+            height=height,
+            width=width,
+            num_classes=1,
+            annotations_per_image=annotations_per_image,
+        )
+        args = COCOInstanceSegmentationDatasetArgs(
+            labels=tmp_path / "train.json",
+            data_dir=Path("train"),
+            classes={0: "class_0"},
+            ignore_classes=None,
+            skip_if_annotations_missing=False,
+        )
+
+        image_info = list(args.list_image_info())
+
+        assert len(image_info) == 1
+        info = image_info[0]
+        segments = json.loads(info["segments"])
+        bboxes = json.loads(info["bboxes"])
+        class_labels = json.loads(info["class_labels"])
+
+        # Three annotations: one polygon, two RLE.
+        assert len(segments) == 3
+        assert len(bboxes) == 3
+        assert len(class_labels) == 3
+
+        # First segment is a polygon (list of lists).
+        assert isinstance(segments[0], list)
+        # Second and third segments are RLE dicts (compressed).
+        assert isinstance(segments[1], dict)
+        assert isinstance(segments[1]["counts"], str)
+        assert isinstance(segments[2], dict)
+        assert isinstance(segments[2]["counts"], str)
+
+        # All bboxes should be close (they represent the same shape).
+        for bbox in bboxes:
+            assert len(bbox) == 4
+
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9), reason="Test only applies to Python 3.8"
+    )
+    def test_list_image_info__rle_fails_on_python38(self, tmp_path: Path) -> None:
+        """RLE annotations should raise RuntimeError on Python < 3.9."""
+        create_coco_instance_segmentation_dataset(
+            tmp_path=tmp_path,
+            num_files=1,
+            height=128,
+            width=128,
+            num_classes=1,
+            annotations_per_image=[
+                [
+                    {
+                        "category_id": 0,
+                        "segmentation": {
+                            "counts": [0, 5, 3],
+                            "size": [128, 128],
+                        },
+                    }
+                ]
+            ],
+        )
+        args = COCOInstanceSegmentationDatasetArgs(
+            labels=tmp_path / "train.json",
+            data_dir=Path("train"),
+            classes={0: "class_0"},
+            ignore_classes=None,
+            skip_if_annotations_missing=False,
+        )
+
+        with pytest.raises(RuntimeError, match="Python >= 3.9"):
+            list(args.list_image_info())

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -365,11 +365,7 @@ class TestCOCOInstanceSegmentationMmapHash:
     )
     def test_list_image_info__mixed_polygon_and_rle(self, tmp_path: Path) -> None:
         """Test a single image with polygon, compressed RLE, and uncompressed RLE annotations."""
-        if sys.version_info < (3, 9):
-            pytest.skip("pycocotools requires Python >= 3.9")
-            return
-
-        if sys.version_info >= (3, 9):
+        if sys.version_info >= (3, 9):  # Needed for Mypy
             from pycocotools import mask as coco_mask
 
             height, width = 128, 128

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import torch
 
 from lightly_train._data.instance_segmentation_dataset import (
     COCOInstanceSegmentationDataArgs,
@@ -512,6 +513,97 @@ class TestCOCOInstanceSegmentationMmapHash:
 
         with pytest.raises(RuntimeError, match="Python >= 3.9"):
             list(args.list_image_info())
+
+
+class TestInstanceSegmentationDatasetGetitem:
+    @pytest.mark.skipif(
+        sys.version_info < (3, 9), reason="pycocotools requires Python >= 3.9"
+    )
+    def test_getitem__rle_segment(self, tmp_path: Path) -> None:
+        """RLE segments are decoded to binary masks in __getitem__."""
+        if sys.version_info >= (3, 9):  # Needed for Mypy
+            from albumentations import BboxParams
+            from lightning_utilities.core.imports import RequirementCache
+
+            from lightly_train._data.instance_segmentation_dataset import (
+                InstanceSegmentationDataset,
+            )
+            from lightly_train._transforms.instance_segmentation_transform import (
+                InstanceSegmentationTransform,
+                InstanceSegmentationTransformArgs,
+            )
+            from lightly_train._transforms.transform import NormalizeArgs
+
+            ALBUMENTATIONS_GE_1_4_5 = RequirementCache("albumentations>=1.4.5")
+            ALBUMENTATIONS_GE_2_0_1 = RequirementCache("albumentations>=2.0.1")
+
+            # Arrange
+            height, width = 128, 128
+            compressed_rle, _ = _create_rle_annotations_from_polygon(
+                _COCO_POLYGON_PX, height, width
+            )
+
+            create_coco_instance_segmentation_dataset(
+                tmp_path=tmp_path,
+                num_files=1,
+                height=height,
+                width=width,
+                num_classes=1,
+                annotations_per_image=[
+                    [
+                        {
+                            "category_id": 0,
+                            "bbox": [10, 10, 30, 40],
+                            "segmentation": compressed_rle,
+                        }
+                    ]
+                ],
+            )
+            dataset_args = COCOInstanceSegmentationDatasetArgs(
+                labels=tmp_path / "train.json",
+                data_dir=Path("train"),
+                classes={0: "class_0"},
+                ignore_classes=None,
+                skip_if_annotations_missing=False,
+            )
+            image_info = list(dataset_args.list_image_info())
+            transform_args = InstanceSegmentationTransformArgs(
+                image_size=None,
+                channel_drop=None,
+                num_channels=3,
+                normalize=NormalizeArgs(),
+                random_flip=None,
+                random_rotate_90=None,
+                random_rotate=None,
+                color_jitter=None,
+                scale_jitter=None,
+                smallest_max_size=None,
+                random_crop=None,
+                bbox_params=BboxParams(
+                    format="yolo",
+                    label_fields=["class_labels", "indices"],
+                    **(
+                        dict(filter_invalid_bboxes=True)
+                        if ALBUMENTATIONS_GE_2_0_1
+                        else {}
+                    ),
+                    **(dict(clip=True) if ALBUMENTATIONS_GE_1_4_5 else {}),
+                ),
+            )
+            transform = InstanceSegmentationTransform(transform_args)
+            dataset = InstanceSegmentationDataset(
+                dataset_args=dataset_args,
+                image_info=image_info,
+                transform=transform,
+            )
+
+            # Act
+            item = dataset[0]
+
+            # Assert
+            assert item["binary_masks"]["masks"].shape == (1, height, width)
+            assert item["binary_masks"]["masks"].dtype == torch.bool
+            assert item["binary_masks"]["masks"].any()
 
 
 class TestFilterValidPolygonSegments:

--- a/tests/_data/test_instance_segmentation_dataset.py
+++ b/tests/_data/test_instance_segmentation_dataset.py
@@ -365,102 +365,109 @@ class TestCOCOInstanceSegmentationMmapHash:
     )
     def test_list_image_info__mixed_polygon_and_rle(self, tmp_path: Path) -> None:
         """Test a single image with polygon, compressed RLE, and uncompressed RLE annotations."""
-        from pycocotools import mask as coco_mask
+        if sys.version_info < (3, 9):
+            pytest.skip("pycocotools requires Python >= 3.9")
+            return
 
-        height, width = 128, 128
+        if sys.version_info >= (3, 9):
+            from pycocotools import mask as coco_mask
 
-        # Create a compressed RLE from a polygon using pycocotools.
-        rle_list = coco_mask.frPyObjects(
-            [[int(v) for v in _COCO_POLYGON_PX]], height, width
-        )
-        compressed_rle = coco_mask.merge(rle_list)
-        # counts is bytes, convert to str for JSON.
-        counts_raw = compressed_rle["counts"]
-        counts_str = (
-            counts_raw.decode("utf-8") if isinstance(counts_raw, bytes) else counts_raw
-        )
-        compressed_rle_annotation = {
-            "counts": counts_str,
-            "size": compressed_rle["size"],
-        }
+            height, width = 128, 128
 
-        # Create an uncompressed RLE (counts as a list of ints).
-        binary_mask = coco_mask.decode(compressed_rle)
-        flat = binary_mask.flatten(order="F")
-        counts: list[int] = []
-        current: int = 0
-        count: int = 0
-        for val in flat:
-            if val == current:
-                count += 1
-            else:
-                counts.append(count)
-                current = int(val)
-                count = 1
-        counts.append(count)
-        uncompressed_rle_annotation = {
-            "counts": counts,
-            "size": [height, width],
-        }
+            # Create a compressed RLE from a polygon using pycocotools.
+            rle_list = coco_mask.frPyObjects(
+                [[int(v) for v in _COCO_POLYGON_PX]], height, width
+            )
+            compressed_rle = coco_mask.merge(rle_list)
+            # counts is bytes, convert to str for JSON.
+            counts_raw = compressed_rle["counts"]
+            counts_str = (
+                counts_raw.decode("utf-8")
+                if isinstance(counts_raw, bytes)
+                else counts_raw
+            )
+            compressed_rle_annotation = {
+                "counts": counts_str,
+                "size": compressed_rle["size"],
+            }
 
-        annotations_per_image = [
-            [
-                {
-                    "category_id": 0,
-                    "bbox": [10, 10, 30, 40],
-                    "segmentation": [_COCO_POLYGON_PX],
-                },
-                {
-                    "category_id": 0,
-                    "segmentation": compressed_rle_annotation,
-                },
-                {
-                    "category_id": 0,
-                    "segmentation": uncompressed_rle_annotation,
-                },
+            # Create an uncompressed RLE (counts as a list of ints).
+            binary_mask = coco_mask.decode(compressed_rle)
+            flat = binary_mask.flatten(order="F")
+            counts: list[int] = []
+            current: int = 0
+            count: int = 0
+            for val in flat:
+                if val == current:
+                    count += 1
+                else:
+                    counts.append(count)
+                    current = int(val)
+                    count = 1
+            counts.append(count)
+            uncompressed_rle_annotation = {
+                "counts": counts,
+                "size": [height, width],
+            }
+
+            annotations_per_image = [
+                [
+                    {
+                        "category_id": 0,
+                        "bbox": [10, 10, 30, 40],
+                        "segmentation": [_COCO_POLYGON_PX],
+                    },
+                    {
+                        "category_id": 0,
+                        "segmentation": compressed_rle_annotation,
+                    },
+                    {
+                        "category_id": 0,
+                        "segmentation": uncompressed_rle_annotation,
+                    },
+                ]
             ]
-        ]
 
-        create_coco_instance_segmentation_dataset(
-            tmp_path=tmp_path,
-            num_files=1,
-            height=height,
-            width=width,
-            num_classes=1,
-            annotations_per_image=annotations_per_image,
-        )
-        args = COCOInstanceSegmentationDatasetArgs(
-            labels=tmp_path / "train.json",
-            data_dir=Path("train"),
-            classes={0: "class_0"},
-            ignore_classes=None,
-            skip_if_annotations_missing=False,
-        )
+            create_coco_instance_segmentation_dataset(
+                tmp_path=tmp_path,
+                num_files=1,
+                height=height,
+                width=width,
+                num_classes=1,
+                annotations_per_image=annotations_per_image,
+            )
+            args = COCOInstanceSegmentationDatasetArgs(
+                labels=tmp_path / "train.json",
+                data_dir=Path("train"),
+                classes={0: "class_0"},
+                ignore_classes=None,
+                skip_if_annotations_missing=False,
+            )
 
-        image_info = list(args.list_image_info())
+            image_info = list(args.list_image_info())
 
-        assert len(image_info) == 1
-        info = image_info[0]
-        segments = json.loads(info["segments"])
-        bboxes = json.loads(info["bboxes"])
-        class_labels = json.loads(info["class_labels"])
+            assert len(image_info) == 1
+            info = image_info[0]
+            segments = json.loads(info["segments"])
+            bboxes = json.loads(info["bboxes"])
+            class_labels = json.loads(info["class_labels"])
 
-        # Three annotations: one polygon, two RLE.
-        assert len(segments) == 3
-        assert len(bboxes) == 3
-        assert len(class_labels) == 3
+            # Three annotations: one polygon, two RLE.
+            assert len(segments) == 3
+            assert len(bboxes) == 3
+            assert len(class_labels) == 3
 
-        # First segment is a polygon (list of lists).
-        assert isinstance(segments[0], list)
-        # Second and third segments are RLE dicts (compressed).
-        assert isinstance(segments[1], dict)
-        assert isinstance(segments[1]["counts"], str)
-        assert isinstance(segments[2], dict)
-        assert isinstance(segments[2]["counts"], str)
+            # First segment is a polygon (list of lists).
+            assert isinstance(segments[0], list)
+            # Second and third segments are RLE dicts (compressed).
+            assert isinstance(segments[1], dict)
+            assert isinstance(segments[1]["counts"], str)
+            assert isinstance(segments[2], dict)
+            assert isinstance(segments[2]["counts"], str)
 
-        # All bboxes should be close (they represent the same shape).
-        for bbox in bboxes:
-            assert len(bbox) == 4
+            # All bboxes should be close (they represent the same shape).
+            for bbox in bboxes:
+                assert len(bbox) == 4
 
     @pytest.mark.skipif(
         sys.version_info >= (3, 9), reason="Test only applies to Python 3.8"


### PR DESCRIPTION
## What has changed and why?

This PR adds support for RLE encoded masks for COCO instance segmentation datasets.

As we use pycocotools to decode these masks and pycocotools only works on Python >= 3.9, we throw an exception if such a mask is encountered on Python 3.8.

## How has it been tested?

Added a test that ensures that COCO datasets with compresses and uncompressed RLE masks work.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
