### PR TITLE
Add D-FINE Decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added decoder and losses from [D-FINE](https://github.com/Peterande/D-FINE).
 - Add support for choosing LR scheduler for LTDETR object detection. You can specify the
   scheduler with `model_args.scheduler_name`, choosing either `linear` or `flat-cosine`.
 

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,19 @@ add-header:
 	licenseheaders -t dev_tools/rtdetr_licenseheader.tmpl \
 		-d src/lightly_train/_task_models/object_detection_components/ \
 		-x src/lightly_train/_task_models/object_detection_components/tiling_utils.py \
+		   src/lightly_train/_task_models/object_detection_components/dfine_decoder.py \
+		   src/lightly_train/_task_models/object_detection_components/dfine_utils.py \
 		-E py
-	
+
 	# Apply Lightly's header to tiling_utils.py
 	licenseheaders -t dev_tools/licenseheader.tmpl \
 		-f src/lightly_train/_task_models/object_detection_components/tiling_utils.py \
+		-E py
+
+	# Apply the Apache 2.0 license header to D-FINE derived files
+	licenseheaders -t dev_tools/dfine_licenseheader.tmpl \
+		-f src/lightly_train/_task_models/object_detection_components/dfine_decoder.py \
+		src/lightly_train/_task_models/object_detection_components/dfine_utils.py \
 		-E py
 
 	# Apply the PicoDet license header to PicoDet-derived files

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ add-header:
 		-x src/lightly_train/_task_models/object_detection_components/tiling_utils.py \
 		   src/lightly_train/_task_models/object_detection_components/dfine_decoder.py \
 		   src/lightly_train/_task_models/object_detection_components/dfine_utils.py \
+		   src/lightly_train/_task_models/object_detection_components/dfine_criterion.py \
 		-E py
 
 	# Apply Lightly's header to tiling_utils.py
@@ -139,6 +140,7 @@ add-header:
 	licenseheaders -t dev_tools/dfine_licenseheader.tmpl \
 		-f src/lightly_train/_task_models/object_detection_components/dfine_decoder.py \
 		src/lightly_train/_task_models/object_detection_components/dfine_utils.py \
+		src/lightly_train/_task_models/object_detection_components/dfine_criterion.py \
 		-E py
 
 	# Apply the PicoDet license header to PicoDet-derived files

--- a/NOTICE
+++ b/NOTICE
@@ -65,6 +65,7 @@ This project incorporates the following third-party components:
   - ``value_op`` returns the flat ``[bs, L, n_head, c]`` tensor to reuse existing ``deformable_attention_core_func_v2`` in ``utils.py``. Affected file: .../dfine_decoder.py
   - Added FP32 guards around bbox refinement for stability in mixed precision. Affected file: .../dfine_decoder.py
   - Added type annotations. Affected file: .../dfine_utils.py
+  - Adapted criterion for LightlyTrain: removed upstream registry hooks, added explicit ``world_size`` forwarding for the Fabric training loop, supports validation-time loss computation when auxiliary outputs are absent, and added FP32 guards around bbox refinement for stability in mixed precision. Affected file: .../dfine_criterion.py
 
 **PicoDet (Picodet_Pytorch)**
 - Source: https://github.com/Bo396543018/Picodet_Pytorch

--- a/NOTICE
+++ b/NOTICE
@@ -43,6 +43,20 @@ This project incorporates the following third-party components:
   - Remove `de_parallel` usage and `ExponentialMovingAverage` class in `ema.py`.
   - Let `ModelEMA` inherit from `torch.nn.Module` in `ema.py`.
   - Remove `to`, `state_dict`, and `load_state_dict` methods from `ModelEMA` in `ema.py`.
+  - Registered `score_head_reuse_or_reinit_hook` and (when denoising is enabled) `denoising_class_embed_reuse_or_reinit_hook` as load-state-dict pre-hooks in `rtdetrv2_decoder.py`, so pretrained RT-DETR checkpoints can be adapted to a new `num_classes` at load time. The hook implementations have been extracted into a shared `hooks.py` module so they can be reused by D-FINE.
+  - Added FP32 guards around bbox refinement in `rtdetrv2_decoder.py` for stability in mixed precision.
+
+**D-FINE**
+- Source: https://github.com/Peterande/D-FINE
+- License: Apache License 2.0
+- License file: licences/DFINE_LICENSE.txt
+- Modifications:
+  - Removed upstream registry hooks and adapted imports for LightlyTrain. Affected file: .../dfine_decoder.py
+  - Registered ``score_head_reuse_or_reinit_hook`` and (when denoising is enabled) ``denoising_class_embed_reuse_or_reinit_hook`` as load-state-dict pre-hooks, so pretrained D-FINE checkpoints can be adapted to a new ``num_classes`` at load time. Affected file: .../dfine_decoder.py
+  - Registered ``anchors`` / ``valid_mask`` for evaluation as non-persistent buffers so they are not written into checkpoints. Affected file: .../dfine_decoder.py
+  - ``value_op`` returns the flat ``[bs, L, n_head, c]`` tensor to reuse existing ``deformable_attention_core_func_v2`` in ``utils.py``. Affected file: .../dfine_decoder.py
+  - Added FP32 guards around bbox refinement for stability in mixed precision. Affected file: .../dfine_decoder.py
+  - Added type annotations. Affected file: .../dfine_utils.py
 
 **PicoDet (Picodet_Pytorch)**
 - Source: https://github.com/Bo396543018/Picodet_Pytorch

--- a/dev_tools/dfine_licenseheader.tmpl
+++ b/dev_tools/dfine_licenseheader.tmpl
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/licences/DFINE_LICENSE.txt
+++ b/licences/DFINE_LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import torch
 from PIL.Image import Image as PILImage
@@ -27,6 +27,9 @@ from lightly_train._task_models.dinov2_ltdetr_object_detection.dinov2_vit_wrappe
     DINOv2STAs,
 )
 from lightly_train._task_models.object_detection_components import tiling_utils
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
 from lightly_train._task_models.object_detection_components.hybrid_encoder import (
     HybridEncoder,
 )
@@ -40,6 +43,38 @@ from lightly_train._task_models.task_model import TaskModel
 from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
+
+_LTDETRDecoder = Literal["rtdetrv2", "dfine"]
+
+
+def _build_decoder(
+    *,
+    config: _DINOv2LTDETRObjectDetectionConfig,
+    decoder: _LTDETRDecoder,
+    num_classes: int,
+    image_size: tuple[int, int],
+    cross_attn_method: str | None = None,
+) -> RTDETRTransformerv2 | DFINETransformer:
+    if decoder == "rtdetrv2":
+        decoder_config = config.rtdetr_transformer.model_dump()
+        if cross_attn_method is not None:
+            decoder_config["cross_attn_method"] = cross_attn_method
+        decoder_config.update({"num_classes": num_classes})
+        return RTDETRTransformerv2(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    elif decoder == "dfine":
+        decoder_config = config.dfine_transformer.model_dump()
+        if cross_attn_method is not None:
+            decoder_config["cross_attn_method"] = cross_attn_method
+        decoder_config.update({"num_classes": num_classes})
+        return DFINETransformer(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    else:
+        raise ValueError(f"Unsupported LTDETR decoder: {decoder}")
 
 
 class _HybridEncoderConfig(PydanticConfig):
@@ -212,6 +247,50 @@ class _RTDETRTransformerv2ViTGConfig(_RTDETRTransformerv2Config):
     dim_feedforward: int = 12288
 
 
+class _DFINETransformerConfig(PydanticConfig):
+    feat_channels: list[int] = [256, 256, 256]
+    feat_strides: list[int] = [8, 16, 32]
+    hidden_dim: int = 256
+    num_levels: int = 3
+    num_layers: int = 6
+    num_queries: int = 300
+    num_denoising: int = 100
+    label_noise_ratio: float = 0.5
+    box_noise_scale: float = 1.0
+    eval_idx: int = -1
+    num_points: list[int] = [3, 6, 3]
+    query_select_method: str = "default"
+    cross_attn_method: str = "default"
+    dim_feedforward: int = 1024
+    reg_max: int = 32
+    reg_scale: float = 4.0
+    layer_scale: float = 1.0
+
+
+class _DFINETransformerViTSConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [224, 224, 224]
+    feat_strides: list[int] = [7, 14, 28]
+    hidden_dim: int = 224
+
+
+class _DFINETransformerViTBConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [768, 768, 768]
+    feat_strides: list[int] = [7, 14, 28]
+    hidden_dim: int = 768
+
+
+class _DFINETransformerViTLConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [1024, 1024, 1024]
+    feat_strides: list[int] = [7, 14, 28]
+    hidden_dim: int = 1024
+
+
+class _DFINETransformerViTGConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [1536, 1536, 1536]
+    feat_strides: list[int] = [7, 14, 28]
+    hidden_dim: int = 1536
+
+
 class _BackboneWrapperViTSConfig(PydanticConfig):
     interaction_indexes: list[int] = [5, 8, 11]
     finetune: bool = True
@@ -245,8 +324,10 @@ class _RTDETRPostProcessorConfig(PydanticConfig):
 
 
 class _DINOv2LTDETRObjectDetectionConfig(PydanticConfig):
+    decoder: _LTDETRDecoder = "rtdetrv2"
     hybrid_encoder: _HybridEncoderConfig
     rtdetr_transformer: _RTDETRTransformerv2Config
+    dfine_transformer: _DFINETransformerConfig
     rtdetr_postprocessor: _RTDETRPostProcessorConfig
 
 
@@ -256,6 +337,9 @@ class _DINOv2LTDETRObjectDetectionViTSConfig(_DINOv2LTDETRObjectDetectionConfig)
     )
     rtdetr_transformer: _RTDETRTransformerv2ViTSConfig = Field(
         default_factory=_RTDETRTransformerv2ViTSConfig
+    )
+    dfine_transformer: _DFINETransformerViTSConfig = Field(
+        default_factory=_DFINETransformerViTSConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -272,6 +356,9 @@ class _DINOv2LTDETRObjectDetectionViTBConfig(_DINOv2LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2ViTBConfig = Field(
         default_factory=_RTDETRTransformerv2ViTBConfig
     )
+    dfine_transformer: _DFINETransformerViTBConfig = Field(
+        default_factory=_DFINETransformerViTBConfig
+    )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
     )
@@ -287,6 +374,9 @@ class _DINOv2LTDETRObjectDetectionViTLConfig(_DINOv2LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2ViTLConfig = Field(
         default_factory=_RTDETRTransformerv2ViTLConfig
     )
+    dfine_transformer: _DFINETransformerViTLConfig = Field(
+        default_factory=_DFINETransformerViTLConfig
+    )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
     )
@@ -301,6 +391,9 @@ class _DINOv2LTDETRObjectDetectionViTGConfig(_DINOv2LTDETRObjectDetectionConfig)
     )
     rtdetr_transformer: _RTDETRTransformerv2ViTGConfig = Field(
         default_factory=_RTDETRTransformerv2ViTGConfig
+    )
+    dfine_transformer: _DFINETransformerViTGConfig = Field(
+        default_factory=_DFINETransformerViTGConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -323,6 +416,7 @@ class DINOv2LTDETRObjectDetection(TaskModel):
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
+        decoder: _LTDETRDecoder = "rtdetrv2",
         load_weights: bool = True,
     ) -> None:
         super().__init__(
@@ -373,6 +467,7 @@ class DINOv2LTDETRObjectDetection(TaskModel):
         config_name = config_name.replace("-noreg", "")
         config_cls = config_mapping[config_name]
         config = config_cls()
+        config.decoder = decoder
 
         # TODO(Guarin, 02/26): Improve how mask tokens are handled for fine-tuning.
         dinov2.mask_token.requires_grad = False  # type: ignore
@@ -388,11 +483,11 @@ class DINOv2LTDETRObjectDetection(TaskModel):
             **config.hybrid_encoder.model_dump()
         )
 
-        decoder_config = config.rtdetr_transformer.model_dump()
-        decoder_config.update({"num_classes": len(self.classes)})
-        self.decoder: RTDETRTransformerv2 = RTDETRTransformerv2(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=self.image_size,  # From global config, otherwise anchors are not generated.
+        self.decoder = _build_decoder(
+            config=config,
+            decoder=config.decoder,
+            num_classes=len(self.classes),
+            image_size=self.image_size,
         )
 
         postprocessor_config = config.rtdetr_postprocessor.model_dump()
@@ -741,6 +836,7 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
+        decoder: _LTDETRDecoder = "rtdetrv2",
     ) -> None:
         super(DINOv2LTDETRObjectDetection, self).__init__(
             init_args=locals(), ignore_args={"backbone_weights"}
@@ -782,6 +878,7 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
         config_name = parsed_name["backbone_name"]
         config_cls = config_mapping[config_name]
         config = config_cls()
+        config.decoder = decoder
 
         self.backbone: DINOv2STAs = DINOv2STAs(
             model=dinov2,
@@ -794,12 +891,12 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
             **config.hybrid_encoder.model_dump()
         )
 
-        decoder_config = config.rtdetr_transformer.model_dump()
-        decoder_config.update({"cross_attn_method": "discrete"})
-        decoder_config.update({"num_classes": len(self.classes)})
-        self.decoder: RTDETRTransformerv2 = RTDETRTransformerv2(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=self.image_size,  # From global config, otherwise anchors are not generated.
+        self.decoder = _build_decoder(
+            config=config,
+            decoder=config.decoder,
+            num_classes=len(self.classes),
+            image_size=self.image_size,
+            cross_attn_method="discrete",
         )
 
         postprocessor_config = config.rtdetr_postprocessor.model_dump()

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
@@ -44,37 +44,7 @@ from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
 
-_LTDETRDecoder = Literal["rtdetrv2", "dfine"]
-
-
-def _build_decoder(
-    *,
-    config: _DINOv2LTDETRObjectDetectionConfig,
-    decoder: _LTDETRDecoder,
-    num_classes: int,
-    image_size: tuple[int, int],
-    cross_attn_method: str | None = None,
-) -> RTDETRTransformerv2 | DFINETransformer:
-    if decoder == "rtdetrv2":
-        decoder_config = config.rtdetr_transformer.model_dump()
-        if cross_attn_method is not None:
-            decoder_config["cross_attn_method"] = cross_attn_method
-        decoder_config.update({"num_classes": num_classes})
-        return RTDETRTransformerv2(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=image_size,
-        )
-    elif decoder == "dfine":
-        decoder_config = config.dfine_transformer.model_dump()
-        if cross_attn_method is not None:
-            decoder_config["cross_attn_method"] = cross_attn_method
-        decoder_config.update({"num_classes": num_classes})
-        return DFINETransformer(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=image_size,
-        )
-    else:
-        raise ValueError(f"Unsupported LTDETR decoder: {decoder}")
+_LTDETRDecoderName = Literal["rtdetrv2", "dfine"]
 
 
 class _HybridEncoderConfig(PydanticConfig):
@@ -261,7 +231,7 @@ class _DFINETransformerConfig(PydanticConfig):
     num_points: list[int] = [3, 6, 3]
     query_select_method: str = "default"
     cross_attn_method: str = "default"
-    dim_feedforward: int = 1024
+    dim_feedforward: int = 2048
     reg_max: int = 32
     reg_scale: float = 4.0
     layer_scale: float = 1.0
@@ -271,24 +241,32 @@ class _DFINETransformerViTSConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [224, 224, 224]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 224
+    num_layers: int = 4
+    dim_feedforward: int = 1792
 
 
 class _DFINETransformerViTBConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [768, 768, 768]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 768
+    num_layers: int = 4
+    dim_feedforward: int = 6144
 
 
 class _DFINETransformerViTLConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [1024, 1024, 1024]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 1024
+    num_layers: int = 4
+    dim_feedforward: int = 8192
 
 
 class _DFINETransformerViTGConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [1536, 1536, 1536]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 1536
+    num_layers: int = 4
+    dim_feedforward: int = 12288
 
 
 class _BackboneWrapperViTSConfig(PydanticConfig):
@@ -324,7 +302,7 @@ class _RTDETRPostProcessorConfig(PydanticConfig):
 
 
 class _DINOv2LTDETRObjectDetectionConfig(PydanticConfig):
-    decoder: _LTDETRDecoder = "rtdetrv2"
+    decoder_name: _LTDETRDecoderName = "rtdetrv2"
     hybrid_encoder: _HybridEncoderConfig
     rtdetr_transformer: _RTDETRTransformerv2Config
     dfine_transformer: _DFINETransformerConfig
@@ -416,7 +394,7 @@ class DINOv2LTDETRObjectDetection(TaskModel):
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
-        decoder: _LTDETRDecoder = "rtdetrv2",
+        decoder_name: _LTDETRDecoderName = "rtdetrv2",
         load_weights: bool = True,
     ) -> None:
         super().__init__(
@@ -467,7 +445,7 @@ class DINOv2LTDETRObjectDetection(TaskModel):
         config_name = config_name.replace("-noreg", "")
         config_cls = config_mapping[config_name]
         config = config_cls()
-        config.decoder = decoder
+        config.decoder_name = decoder_name
 
         # TODO(Guarin, 02/26): Improve how mask tokens are handled for fine-tuning.
         dinov2.mask_token.requires_grad = False  # type: ignore
@@ -485,7 +463,7 @@ class DINOv2LTDETRObjectDetection(TaskModel):
 
         self.decoder = _build_decoder(
             config=config,
-            decoder=config.decoder,
+            decoder_name=config.decoder_name,
             num_classes=len(self.classes),
             image_size=self.image_size,
         )
@@ -836,7 +814,7 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
-        decoder: _LTDETRDecoder = "rtdetrv2",
+        decoder_name: _LTDETRDecoderName = "rtdetrv2",
     ) -> None:
         super(DINOv2LTDETRObjectDetection, self).__init__(
             init_args=locals(), ignore_args={"backbone_weights"}
@@ -878,7 +856,7 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
         config_name = parsed_name["backbone_name"]
         config_cls = config_mapping[config_name]
         config = config_cls()
-        config.decoder = decoder
+        config.decoder_name = decoder_name
 
         self.backbone: DINOv2STAs = DINOv2STAs(
             model=dinov2,
@@ -893,7 +871,7 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
 
         self.decoder = _build_decoder(
             config=config,
-            decoder=config.decoder,
+            decoder_name=config.decoder_name,
             num_classes=len(self.classes),
             image_size=self.image_size,
             cross_attn_method="discrete",
@@ -903,3 +881,33 @@ class DINOv2LTDETRDSPObjectDetection(DINOv2LTDETRObjectDetection):
         self.postprocessor: RTDETRPostProcessor = RTDETRPostProcessor(
             **postprocessor_config
         )
+
+
+def _build_decoder(
+    *,
+    config: _DINOv2LTDETRObjectDetectionConfig,
+    decoder_name: _LTDETRDecoderName,
+    num_classes: int,
+    image_size: tuple[int, int],
+    cross_attn_method: str | None = None,
+) -> RTDETRTransformerv2 | DFINETransformer:
+    if decoder_name == "rtdetrv2":
+        decoder_config = config.rtdetr_transformer.model_dump()
+        if cross_attn_method is not None:
+            decoder_config["cross_attn_method"] = cross_attn_method
+        decoder_config.update({"num_classes": num_classes})
+        return RTDETRTransformerv2(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    elif decoder_name == "dfine":
+        decoder_config = config.dfine_transformer.model_dump()
+        if cross_attn_method is not None:
+            decoder_config["cross_attn_method"] = cross_attn_method
+        decoder_config.update({"num_classes": num_classes})
+        return DFINETransformer(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    else:
+        raise ValueError(f"Unsupported LTDETR decoder: {decoder_name}")

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
@@ -218,11 +218,31 @@ class _RTDETRTransformerv2ViTGConfig(_RTDETRTransformerv2Config):
 
 
 class _DFINETransformerConfig(PydanticConfig):
-    feat_channels: list[int] = [256, 256, 256]
-    feat_strides: list[int] = [8, 16, 32]
-    hidden_dim: int = 256
+    feat_channels: list[int]
+    feat_strides: list[int]
+    hidden_dim: int
+    num_levels: int
+    num_layers: int
+    num_queries: int
+    num_denoising: int
+    label_noise_ratio: float
+    box_noise_scale: float
+    eval_idx: int
+    num_points: list[int]
+    query_select_method: str
+    cross_attn_method: str
+    dim_feedforward: int
+    reg_max: int
+    reg_scale: float
+    layer_scale: float
+
+
+class _DFINETransformerViTSConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [224, 224, 224]
+    feat_strides: list[int] = [7, 14, 28]
+    hidden_dim: int = 224
     num_levels: int = 3
-    num_layers: int = 6
+    num_layers: int = 4
     num_queries: int = 300
     num_denoising: int = 100
     label_noise_ratio: float = 0.5
@@ -231,42 +251,70 @@ class _DFINETransformerConfig(PydanticConfig):
     num_points: list[int] = [3, 6, 3]
     query_select_method: str = "default"
     cross_attn_method: str = "default"
-    dim_feedforward: int = 2048
+    dim_feedforward: int = 1792
     reg_max: int = 32
     reg_scale: float = 4.0
     layer_scale: float = 1.0
-
-
-class _DFINETransformerViTSConfig(_DFINETransformerConfig):
-    feat_channels: list[int] = [224, 224, 224]
-    feat_strides: list[int] = [7, 14, 28]
-    hidden_dim: int = 224
-    num_layers: int = 4
-    dim_feedforward: int = 1792
 
 
 class _DFINETransformerViTBConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [768, 768, 768]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 768
+    num_levels: int = 3
     num_layers: int = 4
+    num_queries: int = 300
+    num_denoising: int = 100
+    label_noise_ratio: float = 0.5
+    box_noise_scale: float = 1.0
+    eval_idx: int = -1
+    num_points: list[int] = [3, 6, 3]
+    query_select_method: str = "default"
+    cross_attn_method: str = "default"
     dim_feedforward: int = 6144
+    reg_max: int = 32
+    reg_scale: float = 4.0
+    layer_scale: float = 1.0
 
 
 class _DFINETransformerViTLConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [1024, 1024, 1024]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 1024
+    num_levels: int = 3
     num_layers: int = 4
+    num_queries: int = 300
+    num_denoising: int = 100
+    label_noise_ratio: float = 0.5
+    box_noise_scale: float = 1.0
+    eval_idx: int = -1
+    num_points: list[int] = [3, 6, 3]
+    query_select_method: str = "default"
+    cross_attn_method: str = "default"
     dim_feedforward: int = 8192
+    reg_max: int = 32
+    reg_scale: float = 4.0
+    layer_scale: float = 1.0
 
 
 class _DFINETransformerViTGConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [1536, 1536, 1536]
     feat_strides: list[int] = [7, 14, 28]
     hidden_dim: int = 1536
+    num_levels: int = 3
     num_layers: int = 4
+    num_queries: int = 300
+    num_denoising: int = 100
+    label_noise_ratio: float = 0.5
+    box_noise_scale: float = 1.0
+    eval_idx: int = -1
+    num_points: list[int] = [3, 6, 3]
+    query_select_method: str = "default"
+    cross_attn_method: str = "default"
     dim_feedforward: int = 12288
+    reg_max: int = 32
+    reg_scale: float = 4.0
+    layer_scale: float = 1.0
 
 
 class _BackboneWrapperViTSConfig(PydanticConfig):

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -80,7 +80,7 @@ class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
     backbone_freeze: bool = False
-    decoder: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
+    decoder_name: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
 
     use_ema_model: bool = True
     ema_momentum: float = 0.9999
@@ -172,7 +172,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             backbone_freeze=model_args.backbone_freeze,
             backbone_weights=model_args.backbone_weights,
             backbone_args=model_args.backbone_args,  # TODO (Lionel, 10/25): Potentially remove in accordance with EoMT.
-            decoder=model_args.decoder,
+            decoder_name=model_args.decoder_name,
             load_weights=load_weights,
         )
 

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -15,7 +15,7 @@ from typing import Any, ClassVar, Literal
 import torch
 from lightning_fabric import Fabric
 from PIL.Image import Image as PILImage
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, computed_field
 from torch import Tensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.optim import AdamW, Optimizer  # type: ignore[attr-defined]
@@ -46,6 +46,12 @@ from lightly_train._task_models.dinov2_ltdetr_object_detection.transforms import
     DINOv2LTDETRObjectDetectionValTransform,
     DINOv2LTDETRObjectDetectionValTransformArgs,
 )
+from lightly_train._task_models.object_detection_components.dfine_criterion import (
+    DFINECriterion,
+)
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
 from lightly_train._task_models.object_detection_components.ema import ModelEMA
 from lightly_train._task_models.object_detection_components.flat_cosine import (
     FlatCosineLRScheduler,
@@ -70,6 +76,17 @@ from lightly_train._torch_compile import TorchCompileArgs
 from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
 
+_RTDETRV2_LOSS_WEIGHT_DICT: dict[str, float] = {
+    "loss_vfl": 1.0,
+    "loss_bbox": 5.0,
+    "loss_giou": 2.0,
+}
+_RTDETRV2_LOSSES: list[str] = ["vfl", "boxes"]
+_RTDETRV2_LOSS_NAMES: list[str] = ["loss", *_RTDETRV2_LOSS_WEIGHT_DICT]
+
+_DFINE_EXTRA_LOSS_WEIGHT_DICT: dict[str, float] = {"loss_fgl": 0.15, "loss_ddf": 1.5}
+_DFINE_EXTRA_LOSSES: list[str] = ["local"]
+_DFINE_LOSS_NAMES: list[str] = [*_RTDETRV2_LOSS_NAMES, *_DFINE_EXTRA_LOSS_WEIGHT_DICT]
 logger = logging.getLogger(__name__)
 
 
@@ -100,9 +117,9 @@ class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
 
     # Criterion configuration
     loss_weight_dict: dict[str, float] = Field(
-        default_factory=lambda: {"loss_vfl": 1.0, "loss_bbox": 5.0, "loss_giou": 2.0}
+        default_factory=lambda: dict(_RTDETRV2_LOSS_WEIGHT_DICT)
     )
-    losses: list[str] = Field(default_factory=lambda: ["vfl", "boxes"])
+    losses: list[str] = Field(default_factory=lambda: list(_RTDETRV2_LOSSES))
     loss_alpha: float = 0.75
     loss_gamma: float = 2.0
 
@@ -130,6 +147,23 @@ class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
         default=2000,
         validation_alias=AliasChoices("lr_warmup_steps", "scheduler_warmup_steps"),
     )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if self.decoder_name == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if self.decoder_name == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
 
 
 class DINOv2LTDETRObjectDetectionTrain(TrainModel):
@@ -196,24 +230,42 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             gamma=model_args.matcher_gamma,
         )
 
-        self.criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
-            matcher=matcher,
-            weight_dict=model_args.loss_weight_dict,
-            losses=model_args.losses,
-            alpha=model_args.loss_alpha,
-            gamma=model_args.loss_gamma,
-            num_classes=len(data_args.included_classes),
-        )
+        criterion: DFINECriterion | RTDETRCriterionv2
+        if model_args.decoder_name == "dfine":
+            self.train_loss_names = _DFINE_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
+            if not isinstance(self.model.decoder, DFINETransformer):
+                raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
+            criterion = DFINECriterion(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+                reg_max=self.model.decoder.reg_max,
+            )
+        else:
+            self.train_loss_names = _RTDETRV2_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
+            criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+            )
+        self.criterion = criterion
 
         class_names = list(data_args.included_classes.values())
-        self.loss_names = ["loss", "loss_vfl", "loss_bbox", "loss_giou"]
         self.metric_args = metric_args
         self.train_metrics = ObjectDetectionTaskMetric(
             task_metric_args=metric_args,
             split="train",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.train_loss_names,
             train_loss_running_mean_window=gradient_accumulation_steps,
         )
         self.val_metrics = ObjectDetectionTaskMetric(
@@ -221,7 +273,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             split="val",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.val_loss_names,
         )
 
         # TODO(Nauryz, 04/2026): These visualization thresholds are currently hardcoded, but we may want to make them configurable in the future (with logger_args).
@@ -302,12 +354,11 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.train_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.train_loss_names,
+            ),
             weight=samples.shape[0],
         )
         if self.metric_args.train:
@@ -410,12 +461,11 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.val_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.val_loss_names,
+            ),
             weight=samples.shape[0],
         )
         self.val_metrics.update_with_predictions(results, targets)
@@ -569,3 +619,31 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
                 max_norm=self.model_args.gradient_clip_val,
                 error_if_nonfinite=False,
             )
+
+
+def _get_loss_log_dict(
+    *,
+    total_loss: Tensor,
+    loss_dict: dict[str, Tensor],
+    loss_names: list[str],
+) -> dict[str, Tensor]:
+    zero = total_loss.new_zeros(())
+    log_dict = {"loss": total_loss.detach()}
+    for loss_name in loss_names:
+        if loss_name == "loss":
+            continue
+        if loss_name == "loss_ddf":
+            loss_values = [
+                v.detach()
+                for k, v in loss_dict.items()
+                if k == "loss_ddf" or k.startswith("loss_ddf_")
+            ]
+            if not loss_values:
+                raise KeyError(
+                    "No loss entries found for 'loss_ddf'. Available losses: "
+                    f"{sorted(loss_dict.keys())}"
+                )
+            log_dict[loss_name] = sum(loss_values, start=zero)
+        else:
+            log_dict[loss_name] = loss_dict[loss_name].detach()
+    return log_dict

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import copy
 import math
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import torch
 from lightning_fabric import Fabric
@@ -80,6 +80,7 @@ class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
     backbone_freeze: bool = False
+    decoder: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
 
     use_ema_model: bool = True
     ema_momentum: float = 0.9999
@@ -171,6 +172,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             backbone_freeze=model_args.backbone_freeze,
             backbone_weights=model_args.backbone_weights,
             backbone_args=model_args.backbone_args,  # TODO (Lionel, 10/25): Potentially remove in accordance with EoMT.
+            decoder=model_args.decoder,
             load_weights=load_weights,
         )
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -36,6 +36,9 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.dinov3_vit_wrappe
     DINOv3STAs,
 )
 from lightly_train._task_models.object_detection_components import tiling_utils
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
 from lightly_train._task_models.object_detection_components.hybrid_encoder import (
     HybridEncoder,
 )
@@ -49,6 +52,33 @@ from lightly_train._task_models.task_model import TaskModel
 from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
+
+_LTDETRDecoder = Literal["rtdetrv2", "dfine"]
+
+
+def _build_decoder(
+    *,
+    config: _DINOv3LTDETRObjectDetectionConfig,
+    decoder: _LTDETRDecoder,
+    num_classes: int,
+    image_size: tuple[int, int],
+) -> RTDETRTransformerv2 | DFINETransformer:
+    if decoder == "rtdetrv2":
+        decoder_config = config.rtdetr_transformer.model_dump()
+        decoder_config.update({"num_classes": num_classes})
+        return RTDETRTransformerv2(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    elif decoder == "dfine":
+        decoder_config = config.dfine_transformer.model_dump()
+        decoder_config.update({"num_classes": num_classes})
+        return DFINETransformer(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    else:
+        raise ValueError(f"Unsupported LTDETR decoder: {decoder}")
 
 
 class _HybridEncoderConfig(PydanticConfig):
@@ -272,6 +302,56 @@ class _RTDETRTransformerv2ViTLConfig(_RTDETRTransformerv2Config):
     dim_feedforward: int = 8192
 
 
+class _DFINETransformerConfig(PydanticConfig):
+    feat_channels: list[int] = [256, 256, 256]
+    feat_strides: list[int] = [8, 16, 32]
+    hidden_dim: int = 256
+    num_levels: int = 3
+    num_layers: int = 6
+    num_queries: int = 300
+    num_denoising: int = 100
+    label_noise_ratio: float = 0.5
+    box_noise_scale: float = 1.0
+    eval_idx: int = -1
+    num_points: list[int] = [3, 6, 3]
+    query_select_method: str = "default"
+    cross_attn_method: str = "default"
+    dim_feedforward: int = 1024
+    reg_max: int = 32
+    reg_scale: float = 4.0
+    layer_scale: float = 1.0
+
+
+class _DFINETransformerConvNextConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [384, 384, 384]
+    hidden_dim: int = 384
+
+
+class _DFINETransformerViTTConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [192, 192, 192]
+    hidden_dim: int = 192
+
+
+class _DFINETransformerViTTPlusConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [256, 256, 256]
+    hidden_dim: int = 256
+
+
+class _DFINETransformerViTSConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [224, 224, 224]
+    hidden_dim: int = 224
+
+
+class _DFINETransformerViTBConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [768, 768, 768]
+    hidden_dim: int = 768
+
+
+class _DFINETransformerViTLConfig(_DFINETransformerConfig):
+    feat_channels: list[int] = [1024, 1024, 1024]
+    hidden_dim: int = 1024
+
+
 class _RTDETRBackboneWrapperViTTConfig(PydanticConfig):
     interaction_indexes: list[int] = [3, 7, 11]
     finetune: bool = True
@@ -312,8 +392,10 @@ class _RTDETRPostProcessorConfig(PydanticConfig):
 
 
 class _DINOv3LTDETRObjectDetectionConfig(PydanticConfig):
+    decoder: _LTDETRDecoder = "rtdetrv2"
     hybrid_encoder: _HybridEncoderConfig
     rtdetr_transformer: _RTDETRTransformerv2Config
+    dfine_transformer: _DFINETransformerConfig
     rtdetr_postprocessor: _RTDETRPostProcessorConfig
 
 
@@ -323,6 +405,9 @@ class _DINOv3LTDETRObjectDetectionLargeConfig(_DINOv3LTDETRObjectDetectionConfig
     )
     rtdetr_transformer: _RTDETRTransformerv2LargeConfig = Field(
         default_factory=_RTDETRTransformerv2LargeConfig
+    )
+    dfine_transformer: _DFINETransformerConvNextConfig = Field(
+        default_factory=_DFINETransformerConvNextConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -336,6 +421,9 @@ class _DINOv3LTDETRObjectDetectionBaseConfig(_DINOv3LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2BaseConfig = Field(
         default_factory=_RTDETRTransformerv2BaseConfig
     )
+    dfine_transformer: _DFINETransformerConvNextConfig = Field(
+        default_factory=_DFINETransformerConvNextConfig
+    )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
     )
@@ -347,6 +435,9 @@ class _DINOv3LTDETRObjectDetectionSmallConfig(_DINOv3LTDETRObjectDetectionConfig
     )
     rtdetr_transformer: _RTDETRTransformerv2SmallConfig = Field(
         default_factory=_RTDETRTransformerv2SmallConfig
+    )
+    dfine_transformer: _DFINETransformerConvNextConfig = Field(
+        default_factory=_DFINETransformerConvNextConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -360,6 +451,9 @@ class _DINOv3LTDETRObjectDetectionTinyConfig(_DINOv3LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2TinyConfig = Field(
         default_factory=_RTDETRTransformerv2TinyConfig
     )
+    dfine_transformer: _DFINETransformerConvNextConfig = Field(
+        default_factory=_DFINETransformerConvNextConfig
+    )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
     )
@@ -371,6 +465,9 @@ class _DINOv3LTDETRObjectDetectionViTTConfig(_DINOv3LTDETRObjectDetectionConfig)
     )
     rtdetr_transformer: _RTDETRTransformerv2ViTTConfig = Field(
         default_factory=_RTDETRTransformerv2ViTTConfig
+    )
+    dfine_transformer: _DFINETransformerViTTConfig = Field(
+        default_factory=_DFINETransformerViTTConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -387,6 +484,9 @@ class _DINOv3LTDETRObjectDetectionViTTPlusConfig(_DINOv3LTDETRObjectDetectionCon
     rtdetr_transformer: _RTDETRTransformerv2ViTTPlusConfig = Field(
         default_factory=_RTDETRTransformerv2ViTTPlusConfig
     )
+    dfine_transformer: _DFINETransformerViTTPlusConfig = Field(
+        default_factory=_DFINETransformerViTTPlusConfig
+    )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
     )
@@ -401,6 +501,9 @@ class _DINOv3LTDETRObjectDetectionViTSConfig(_DINOv3LTDETRObjectDetectionConfig)
     )
     rtdetr_transformer: _RTDETRTransformerv2ViTSConfig = Field(
         default_factory=_RTDETRTransformerv2ViTSConfig
+    )
+    dfine_transformer: _DFINETransformerViTSConfig = Field(
+        default_factory=_DFINETransformerViTSConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -417,6 +520,9 @@ class _DINOv3LTDETRObjectDetectionViTBConfig(_DINOv3LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2ViTBConfig = Field(
         default_factory=_RTDETRTransformerv2ViTBConfig
     )
+    dfine_transformer: _DFINETransformerViTBConfig = Field(
+        default_factory=_DFINETransformerViTBConfig
+    )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
     )
@@ -431,6 +537,9 @@ class _DINOv3LTDETRObjectDetectionViTLConfig(_DINOv3LTDETRObjectDetectionConfig)
     )
     rtdetr_transformer: _RTDETRTransformerv2ViTLConfig = Field(
         default_factory=_RTDETRTransformerv2ViTLConfig
+    )
+    dfine_transformer: _DFINETransformerViTLConfig = Field(
+        default_factory=_DFINETransformerViTLConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -453,6 +562,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
+        decoder: _LTDETRDecoder = "rtdetrv2",
         load_weights: bool = True,
     ) -> None:
         super().__init__(init_args=locals(), ignore_args={"load_weights"})
@@ -527,6 +637,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         config_name = config_name.replace("-eupe", "")
         config_cls, wrapper_cls = config_mapping[config_name]
         config = config_cls()
+        config.decoder = decoder
 
         if hasattr(config, "backbone_wrapper"):
             # TODO(Guarin, 02/26): Improve how mask tokens are handled for fine-tuning.
@@ -546,11 +657,11 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             **config.hybrid_encoder.model_dump()
         )
 
-        decoder_config = config.rtdetr_transformer.model_dump()
-        decoder_config.update({"num_classes": len(self.classes)})
-        self.decoder: RTDETRTransformerv2 = RTDETRTransformerv2(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=self.image_size,  # From global config, otherwise anchors are not generated.
+        self.decoder = _build_decoder(
+            config=config,
+            decoder=config.decoder,
+            num_classes=len(self.classes),
+            image_size=self.image_size,
         )
 
         postprocessor_config = config.rtdetr_postprocessor.model_dump()

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -53,32 +53,7 @@ from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
 
-_LTDETRDecoder = Literal["rtdetrv2", "dfine"]
-
-
-def _build_decoder(
-    *,
-    config: _DINOv3LTDETRObjectDetectionConfig,
-    decoder: _LTDETRDecoder,
-    num_classes: int,
-    image_size: tuple[int, int],
-) -> RTDETRTransformerv2 | DFINETransformer:
-    if decoder == "rtdetrv2":
-        decoder_config = config.rtdetr_transformer.model_dump()
-        decoder_config.update({"num_classes": num_classes})
-        return RTDETRTransformerv2(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=image_size,
-        )
-    elif decoder == "dfine":
-        decoder_config = config.dfine_transformer.model_dump()
-        decoder_config.update({"num_classes": num_classes})
-        return DFINETransformer(  # type: ignore[no-untyped-call]
-            **decoder_config,
-            eval_spatial_size=image_size,
-        )
-    else:
-        raise ValueError(f"Unsupported LTDETR decoder: {decoder}")
+_LTDETRDecoderName = Literal["rtdetrv2", "dfine"]
 
 
 class _HybridEncoderConfig(PydanticConfig):
@@ -316,7 +291,7 @@ class _DFINETransformerConfig(PydanticConfig):
     num_points: list[int] = [3, 6, 3]
     query_select_method: str = "default"
     cross_attn_method: str = "default"
-    dim_feedforward: int = 1024
+    dim_feedforward: int = 2048
     reg_max: int = 32
     reg_scale: float = 4.0
     layer_scale: float = 1.0
@@ -324,32 +299,57 @@ class _DFINETransformerConfig(PydanticConfig):
 
 class _DFINETransformerConvNextConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [384, 384, 384]
-    hidden_dim: int = 384
+
+
+class _DFINETransformerConvNextTinyConfig(_DFINETransformerConvNextConfig):
+    num_layers: int = 3
+
+
+class _DFINETransformerConvNextSmallConfig(_DFINETransformerConvNextConfig):
+    num_layers: int = 3
+
+
+class _DFINETransformerConvNextBaseConfig(_DFINETransformerConvNextConfig):
+    num_layers: int = 4
+
+
+class _DFINETransformerConvNextLargeConfig(_DFINETransformerConvNextConfig):
+    reg_scale: float = 8.0
 
 
 class _DFINETransformerViTTConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [192, 192, 192]
     hidden_dim: int = 192
+    num_layers: int = 4
+    dim_feedforward: int = 512
 
 
 class _DFINETransformerViTTPlusConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [256, 256, 256]
     hidden_dim: int = 256
+    num_layers: int = 4
+    dim_feedforward: int = 512
 
 
 class _DFINETransformerViTSConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [224, 224, 224]
     hidden_dim: int = 224
+    num_layers: int = 4
+    dim_feedforward: int = 1792
 
 
 class _DFINETransformerViTBConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [768, 768, 768]
     hidden_dim: int = 768
+    num_layers: int = 4
+    dim_feedforward: int = 6144
 
 
 class _DFINETransformerViTLConfig(_DFINETransformerConfig):
     feat_channels: list[int] = [1024, 1024, 1024]
     hidden_dim: int = 1024
+    num_layers: int = 4
+    dim_feedforward: int = 8192
 
 
 class _RTDETRBackboneWrapperViTTConfig(PydanticConfig):
@@ -392,7 +392,7 @@ class _RTDETRPostProcessorConfig(PydanticConfig):
 
 
 class _DINOv3LTDETRObjectDetectionConfig(PydanticConfig):
-    decoder: _LTDETRDecoder = "rtdetrv2"
+    decoder_name: _LTDETRDecoderName = "rtdetrv2"
     hybrid_encoder: _HybridEncoderConfig
     rtdetr_transformer: _RTDETRTransformerv2Config
     dfine_transformer: _DFINETransformerConfig
@@ -406,8 +406,8 @@ class _DINOv3LTDETRObjectDetectionLargeConfig(_DINOv3LTDETRObjectDetectionConfig
     rtdetr_transformer: _RTDETRTransformerv2LargeConfig = Field(
         default_factory=_RTDETRTransformerv2LargeConfig
     )
-    dfine_transformer: _DFINETransformerConvNextConfig = Field(
-        default_factory=_DFINETransformerConvNextConfig
+    dfine_transformer: _DFINETransformerConvNextLargeConfig = Field(
+        default_factory=_DFINETransformerConvNextLargeConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -421,8 +421,8 @@ class _DINOv3LTDETRObjectDetectionBaseConfig(_DINOv3LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2BaseConfig = Field(
         default_factory=_RTDETRTransformerv2BaseConfig
     )
-    dfine_transformer: _DFINETransformerConvNextConfig = Field(
-        default_factory=_DFINETransformerConvNextConfig
+    dfine_transformer: _DFINETransformerConvNextBaseConfig = Field(
+        default_factory=_DFINETransformerConvNextBaseConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -436,8 +436,8 @@ class _DINOv3LTDETRObjectDetectionSmallConfig(_DINOv3LTDETRObjectDetectionConfig
     rtdetr_transformer: _RTDETRTransformerv2SmallConfig = Field(
         default_factory=_RTDETRTransformerv2SmallConfig
     )
-    dfine_transformer: _DFINETransformerConvNextConfig = Field(
-        default_factory=_DFINETransformerConvNextConfig
+    dfine_transformer: _DFINETransformerConvNextSmallConfig = Field(
+        default_factory=_DFINETransformerConvNextSmallConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -451,8 +451,8 @@ class _DINOv3LTDETRObjectDetectionTinyConfig(_DINOv3LTDETRObjectDetectionConfig)
     rtdetr_transformer: _RTDETRTransformerv2TinyConfig = Field(
         default_factory=_RTDETRTransformerv2TinyConfig
     )
-    dfine_transformer: _DFINETransformerConvNextConfig = Field(
-        default_factory=_DFINETransformerConvNextConfig
+    dfine_transformer: _DFINETransformerConvNextTinyConfig = Field(
+        default_factory=_DFINETransformerConvNextTinyConfig
     )
     rtdetr_postprocessor: _RTDETRPostProcessorConfig = Field(
         default_factory=_RTDETRPostProcessorConfig
@@ -562,7 +562,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
-        decoder: _LTDETRDecoder = "rtdetrv2",
+        decoder_name: _LTDETRDecoderName = "rtdetrv2",
         load_weights: bool = True,
     ) -> None:
         super().__init__(init_args=locals(), ignore_args={"load_weights"})
@@ -637,7 +637,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         config_name = config_name.replace("-eupe", "")
         config_cls, wrapper_cls = config_mapping[config_name]
         config = config_cls()
-        config.decoder = decoder
+        config.decoder_name = decoder_name
 
         if hasattr(config, "backbone_wrapper"):
             # TODO(Guarin, 02/26): Improve how mask tokens are handled for fine-tuning.
@@ -659,7 +659,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
 
         self.decoder = _build_decoder(
             config=config,
-            decoder=config.decoder,
+            decoder_name=config.decoder_name,
             num_classes=len(self.classes),
             image_size=self.image_size,
         )
@@ -1237,3 +1237,28 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             fp32_attention_scores=True,
             verbose=verbose,
         )
+
+
+def _build_decoder(
+    *,
+    config: _DINOv3LTDETRObjectDetectionConfig,
+    decoder_name: _LTDETRDecoderName,
+    num_classes: int,
+    image_size: tuple[int, int],
+) -> RTDETRTransformerv2 | DFINETransformer:
+    if decoder_name == "rtdetrv2":
+        decoder_config = config.rtdetr_transformer.model_dump()
+        decoder_config.update({"num_classes": num_classes})
+        return RTDETRTransformerv2(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    elif decoder_name == "dfine":
+        decoder_config = config.dfine_transformer.model_dump()
+        decoder_config.update({"num_classes": num_classes})
+        return DFINETransformer(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=image_size,
+        )
+    else:
+        raise ValueError(f"Unsupported LTDETR decoder: {decoder_name}")

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -15,7 +15,7 @@ from typing import Any, ClassVar, Literal
 import torch
 from lightning_fabric import Fabric
 from PIL.Image import Image as PILImage
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, computed_field
 from torch import Tensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.optim import AdamW, Optimizer  # type: ignore[attr-defined]
@@ -46,6 +46,12 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import
     DINOv3LTDETRObjectDetectionValTransform,
     DINOv3LTDETRObjectDetectionValTransformArgs,
 )
+from lightly_train._task_models.object_detection_components.dfine_criterion import (
+    DFINECriterion,
+)
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
 from lightly_train._task_models.object_detection_components.ema import ModelEMA
 from lightly_train._task_models.object_detection_components.flat_cosine import (
     FlatCosineLRScheduler,
@@ -70,6 +76,17 @@ from lightly_train._torch_compile import TorchCompileArgs
 from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
 
+_RTDETRV2_LOSS_WEIGHT_DICT: dict[str, float] = {
+    "loss_vfl": 1.0,
+    "loss_bbox": 5.0,
+    "loss_giou": 2.0,
+}
+_RTDETRV2_LOSSES: list[str] = ["vfl", "boxes"]
+_RTDETRV2_LOSS_NAMES: list[str] = ["loss", *_RTDETRV2_LOSS_WEIGHT_DICT]
+
+_DFINE_EXTRA_LOSS_WEIGHT_DICT: dict[str, float] = {"loss_fgl": 0.15, "loss_ddf": 1.5}
+_DFINE_EXTRA_LOSSES: list[str] = ["local"]
+_DFINE_LOSS_NAMES: list[str] = [*_RTDETRV2_LOSS_NAMES, *_DFINE_EXTRA_LOSS_WEIGHT_DICT]
 logger = logging.getLogger(__name__)
 
 
@@ -99,9 +116,9 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
 
     # Criterion configuration
     loss_weight_dict: dict[str, float] = Field(
-        default_factory=lambda: {"loss_vfl": 1.0, "loss_bbox": 5.0, "loss_giou": 2.0}
+        default_factory=lambda: dict(_RTDETRV2_LOSS_WEIGHT_DICT)
     )
-    losses: list[str] = Field(default_factory=lambda: ["vfl", "boxes"])
+    losses: list[str] = Field(default_factory=lambda: list(_RTDETRV2_LOSSES))
     loss_alpha: float = 0.75
     loss_gamma: float = 2.0
 
@@ -129,6 +146,23 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
         default=2000,
         validation_alias=AliasChoices("lr_warmup_steps", "scheduler_warmup_steps"),
     )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if self.decoder_name == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if self.decoder_name == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
 
 
 class DINOv3LTDETRObjectDetectionTrain(TrainModel):
@@ -195,24 +229,42 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             gamma=model_args.matcher_gamma,
         )
 
-        self.criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
-            matcher=matcher,
-            weight_dict=model_args.loss_weight_dict,
-            losses=model_args.losses,
-            alpha=model_args.loss_alpha,
-            gamma=model_args.loss_gamma,
-            num_classes=len(data_args.included_classes),
-        )
+        criterion: DFINECriterion | RTDETRCriterionv2
+        if model_args.decoder_name == "dfine":
+            self.train_loss_names = _DFINE_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
+            if not isinstance(self.model.decoder, DFINETransformer):
+                raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
+            criterion = DFINECriterion(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+                reg_max=self.model.decoder.reg_max,
+            )
+        else:
+            self.train_loss_names = _RTDETRV2_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
+            criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+            )
+        self.criterion = criterion
 
         class_names = list(data_args.included_classes.values())
-        self.loss_names = ["loss", "loss_vfl", "loss_bbox", "loss_giou"]
         self.metric_args = metric_args
         self.train_metrics = ObjectDetectionTaskMetric(
             task_metric_args=metric_args,
             split="train",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.train_loss_names,
             train_loss_running_mean_window=gradient_accumulation_steps,
         )
         self.val_metrics = ObjectDetectionTaskMetric(
@@ -220,7 +272,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             split="val",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.val_loss_names,
         )
 
         # TODO(Nauryz, 04/2026): These visualization thresholds are currently
@@ -305,12 +357,11 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.train_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.train_loss_names,
+            ),
             weight=samples.shape[0],
         )
         if self.metric_args.train:
@@ -410,12 +461,11 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.val_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.val_loss_names,
+            ),
             weight=samples.shape[0],
         )
         self.val_metrics.update_with_predictions(results, targets)
@@ -572,3 +622,31 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
                 max_norm=self.model_args.gradient_clip_val,
                 error_if_nonfinite=False,
             )
+
+
+def _get_loss_log_dict(
+    *,
+    total_loss: Tensor,
+    loss_dict: dict[str, Tensor],
+    loss_names: list[str],
+) -> dict[str, Tensor]:
+    zero = total_loss.new_zeros(())
+    log_dict = {"loss": total_loss.detach()}
+    for loss_name in loss_names:
+        if loss_name == "loss":
+            continue
+        if loss_name == "loss_ddf":
+            loss_values = [
+                v.detach()
+                for k, v in loss_dict.items()
+                if k == "loss_ddf" or k.startswith("loss_ddf_")
+            ]
+            if not loss_values:
+                raise KeyError(
+                    "No loss entries found for 'loss_ddf'. Available losses: "
+                    f"{sorted(loss_dict.keys())}"
+                )
+            log_dict[loss_name] = sum(loss_values, start=zero)
+        else:
+            log_dict[loss_name] = loss_dict[loss_name].detach()
+    return log_dict

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import copy
 import math
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import torch
 from lightning_fabric import Fabric
@@ -80,6 +80,7 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
     backbone_freeze: bool = False
+    decoder: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
 
     use_ema_model: bool = True
     ema_momentum: float = 0.9999
@@ -170,6 +171,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             backbone_freeze=model_args.backbone_freeze,
             backbone_args=model_args.backbone_args,  # TODO (Lionel, 10/25): Potentially remove in accordance with EoMT.
             backbone_weights=model_args.backbone_weights,
+            decoder=model_args.decoder,
             load_weights=load_weights,
         )
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -80,7 +80,7 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
     backbone_freeze: bool = False
-    decoder: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
+    decoder_name: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
 
     use_ema_model: bool = True
     ema_momentum: float = 0.9999
@@ -171,7 +171,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             backbone_freeze=model_args.backbone_freeze,
             backbone_args=model_args.backbone_args,  # TODO (Lionel, 10/25): Potentially remove in accordance with EoMT.
             backbone_weights=model_args.backbone_weights,
-            decoder=model_args.decoder,
+            decoder_name=model_args.decoder_name,
             load_weights=load_weights,
         )
 

--- a/src/lightly_train/_task_models/object_detection_components/dfine_criterion.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_criterion.py
@@ -1,0 +1,647 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+"""
+D-FINE: Redefine Regression Task of DETRs as Fine-grained Distribution Refinement
+Copyright (c) 2024 The D-FINE Authors. All Rights Reserved.
+---------------------------------------------------------------------------------
+Modified from RT-DETR (https://github.com/lyuwenyu/RT-DETR)
+Copyright (c) 2023 lyuwenyu. All Rights Reserved.
+"""
+
+# Modifications Copyright 2026 Lightly AG:
+#  - Removed upstream registry hooks and adapted imports for LightlyTrain.
+#  - Added explicit ``world_size`` forwarding for LightlyTrain's Fabric training loop.
+#  - Supports validation-time loss computation when auxiliary outputs are absent.
+#  - Added FP32 guards around bbox refinement for stability in mixed precision
+from __future__ import annotations
+
+import copy
+
+import torch
+import torch.distributed
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+
+from lightly_train._task_models.object_detection_components.box_ops import (
+    box_cxcywh_to_xyxy,
+    box_iou,
+    generalized_box_iou,
+    sanitize_boxes_cxcywh_normalized,
+)
+from lightly_train._task_models.object_detection_components.dfine_utils import (
+    bbox2distance,
+)
+from lightly_train._task_models.object_detection_components.dist_utils import (
+    is_dist_available_and_initialized,
+)
+
+
+class DFINECriterion(nn.Module):
+    """This class computes the loss for D-FINE."""
+
+    def __init__(
+        self,
+        matcher,
+        weight_dict,
+        losses,
+        alpha=0.2,
+        gamma=2.0,
+        num_classes=80,
+        reg_max=32,
+        boxes_weight_format=None,
+        share_matched_indices=False,
+    ):
+        """Create the criterion.
+        Parameters:
+            matcher: module able to compute a matching between targets and proposals.
+            weight_dict: dict containing as key the names of the losses and as values their relative weight.
+            losses: list of all the losses to be applied. See get_loss for list of available losses.
+            num_classes: number of object categories, omitting the special no-object category.
+            reg_max (int): Max number of the discrete bins in D-FINE.
+            boxes_weight_format: format for boxes weight (iou, ).
+        """
+        super().__init__()
+        self.num_classes = num_classes
+        self.matcher = matcher
+        self.weight_dict = weight_dict
+        self.losses = losses
+        self.boxes_weight_format = boxes_weight_format
+        self.share_matched_indices = share_matched_indices
+        self.alpha = alpha
+        self.gamma = gamma
+        self.fgl_targets, self.fgl_targets_dn = None, None
+        self.own_targets, self.own_targets_dn = None, None
+        self.reg_max = reg_max
+        self.num_pos, self.num_neg = None, None
+
+    def loss_labels_focal(self, outputs, targets, indices, num_boxes):
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"]
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+        target = F.one_hot(target_classes, num_classes=self.num_classes + 1)[..., :-1]
+        loss = torchvision.ops.sigmoid_focal_loss(
+            src_logits, target, self.alpha, self.gamma, reduction="none"
+        )
+        loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
+
+        return {"loss_focal": loss}
+
+    def loss_labels_vfl(self, outputs, targets, indices, num_boxes, values=None):
+        assert "pred_boxes" in outputs
+        idx = self._get_src_permutation_idx(indices)
+        if values is None:
+            src_boxes = outputs["pred_boxes"][idx]
+            src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
+            target_boxes = torch.cat(
+                [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+            )
+            ious, _ = box_iou(
+                box_cxcywh_to_xyxy(src_boxes), box_cxcywh_to_xyxy(target_boxes)
+            )
+            ious = torch.diag(ious).detach()
+        else:
+            ious = values
+
+        src_logits = outputs["pred_logits"]
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+        target = F.one_hot(target_classes, num_classes=self.num_classes + 1)[..., :-1]
+
+        target_score_o = torch.zeros_like(target_classes, dtype=src_logits.dtype)
+        target_score_o[idx] = ious.to(target_score_o.dtype)
+        target_score = target_score_o.unsqueeze(-1) * target
+
+        pred_score = F.sigmoid(src_logits).detach()
+        weight = self.alpha * pred_score.pow(self.gamma) * (1 - target) + target_score
+
+        loss = F.binary_cross_entropy_with_logits(
+            src_logits, target_score, weight=weight, reduction="none"
+        )
+        loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
+        return {"loss_vfl": loss}
+
+    def loss_boxes(self, outputs, targets, indices, num_boxes, boxes_weight=None):
+        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
+        targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
+        The target boxes are expected in format (center_x, center_y, w, h), normalized by the image size.
+        """
+        assert "pred_boxes" in outputs
+        idx = self._get_src_permutation_idx(indices)
+        src_boxes = outputs["pred_boxes"][idx]
+        src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
+        target_boxes = torch.cat(
+            [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+        )
+        losses = {}
+        loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction="none")
+        losses["loss_bbox"] = loss_bbox.sum() / num_boxes
+
+        loss_giou = 1 - torch.diag(
+            generalized_box_iou(
+                box_cxcywh_to_xyxy(src_boxes), box_cxcywh_to_xyxy(target_boxes)
+            )
+        )
+        loss_giou = loss_giou if boxes_weight is None else loss_giou * boxes_weight
+        losses["loss_giou"] = loss_giou.sum() / num_boxes
+
+        return losses
+
+    def loss_local(self, outputs, targets, indices, num_boxes, T=5):
+        """Compute Fine-Grained Localization (FGL) Loss
+        and Decoupled Distillation Focal (DDF) Loss."""
+
+        losses = {}
+        if "pred_corners" in outputs:
+            idx = self._get_src_permutation_idx(indices)
+            target_boxes = torch.cat(
+                [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+            )
+
+            pred_corners = outputs["pred_corners"][idx].reshape(-1, (self.reg_max + 1))
+            ref_points = outputs["ref_points"][idx].detach()
+            with torch.no_grad():
+                if self.fgl_targets_dn is None and "is_dn" in outputs:
+                    self.fgl_targets_dn = bbox2distance(
+                        ref_points,
+                        box_cxcywh_to_xyxy(target_boxes),
+                        self.reg_max,
+                        outputs["reg_scale"],
+                        outputs["up"],
+                    )
+                if self.fgl_targets is None and "is_dn" not in outputs:
+                    self.fgl_targets = bbox2distance(
+                        ref_points,
+                        box_cxcywh_to_xyxy(target_boxes),
+                        self.reg_max,
+                        outputs["reg_scale"],
+                        outputs["up"],
+                    )
+
+            target_corners, weight_right, weight_left = (
+                self.fgl_targets_dn if "is_dn" in outputs else self.fgl_targets
+            )
+
+            ious = torch.diag(
+                box_iou(
+                    box_cxcywh_to_xyxy(
+                        sanitize_boxes_cxcywh_normalized(outputs["pred_boxes"][idx])
+                    ),
+                    box_cxcywh_to_xyxy(target_boxes),
+                )[0]
+            )
+            weight_targets = ious.unsqueeze(-1).repeat(1, 1, 4).reshape(-1).detach()
+
+            losses["loss_fgl"] = self.unimodal_distribution_focal_loss(
+                pred_corners,
+                target_corners,
+                weight_right,
+                weight_left,
+                weight_targets,
+                avg_factor=num_boxes,
+            )
+
+            if "teacher_corners" in outputs:
+                pred_corners = outputs["pred_corners"].reshape(-1, (self.reg_max + 1))
+                target_corners = outputs["teacher_corners"].reshape(
+                    -1, (self.reg_max + 1)
+                )
+                if torch.equal(pred_corners, target_corners):
+                    losses["loss_ddf"] = pred_corners.sum() * 0
+                else:
+                    weight_targets_local = (
+                        outputs["teacher_logits"].sigmoid().max(dim=-1)[0]
+                    )
+
+                    mask = torch.zeros_like(weight_targets_local, dtype=torch.bool)
+                    mask[idx] = True
+                    mask = mask.unsqueeze(-1).repeat(1, 1, 4).reshape(-1)
+
+                    weight_targets_local[idx] = ious.reshape_as(
+                        weight_targets_local[idx]
+                    ).to(weight_targets_local.dtype)
+                    weight_targets_local = (
+                        weight_targets_local.unsqueeze(-1)
+                        .repeat(1, 1, 4)
+                        .reshape(-1)
+                        .detach()
+                    )
+
+                    loss_match_local = (
+                        weight_targets_local
+                        * (T**2)
+                        * (
+                            nn.KLDivLoss(reduction="none")(
+                                F.log_softmax(pred_corners / T, dim=1),
+                                F.softmax(target_corners.detach() / T, dim=1),
+                            )
+                        ).sum(-1)
+                    )
+                    if "is_dn" not in outputs:
+                        batch_scale = 8 / outputs["pred_boxes"].shape[0]
+                        self.num_pos, self.num_neg = (
+                            (mask.sum() * batch_scale) ** 0.5,
+                            ((~mask).sum() * batch_scale) ** 0.5,
+                        )
+                    loss_match_local1 = (
+                        loss_match_local[mask].mean() if mask.any() else 0
+                    )
+                    loss_match_local2 = (
+                        loss_match_local[~mask].mean() if (~mask).any() else 0
+                    )
+                    losses["loss_ddf"] = (
+                        loss_match_local1 * self.num_pos
+                        + loss_match_local2 * self.num_neg
+                    ) / (self.num_pos + self.num_neg)
+
+        return losses
+
+    def _get_src_permutation_idx(self, indices):
+        # permute predictions following indices
+        batch_idx = torch.cat(
+            [torch.full_like(src, i) for i, (src, _) in enumerate(indices)]
+        )
+        src_idx = torch.cat([src for (src, _) in indices])
+        return batch_idx, src_idx
+
+    def _get_tgt_permutation_idx(self, indices):
+        # permute targets following indices
+        batch_idx = torch.cat(
+            [torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)]
+        )
+        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
+        return batch_idx, tgt_idx
+
+    def _get_go_indices(self, indices, indices_aux_list):
+        """Get a matching union set across all decoder layers."""
+        results = []
+        for indices_aux in indices_aux_list:
+            indices = [
+                (torch.cat([idx1[0], idx2[0]]), torch.cat([idx1[1], idx2[1]]))
+                for idx1, idx2 in zip(indices.copy(), indices_aux.copy())
+            ]
+
+        for ind in [
+            torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices
+        ]:
+            unique, counts = torch.unique(ind, return_counts=True, dim=0)
+            count_sort_indices = torch.argsort(counts, descending=True)
+            unique_sorted = unique[count_sort_indices]
+            column_to_row = {}
+            for idx in unique_sorted:
+                row_idx, col_idx = idx[0].item(), idx[1].item()
+                if row_idx not in column_to_row:
+                    column_to_row[row_idx] = col_idx
+            final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)
+            final_cols = torch.tensor(list(column_to_row.values()), device=ind.device)
+            results.append((final_rows.long(), final_cols.long()))
+        return results
+
+    def _clear_cache(self):
+        self.fgl_targets, self.fgl_targets_dn = None, None
+        self.own_targets, self.own_targets_dn = None, None
+        self.num_pos, self.num_neg = None, None
+
+    def get_loss(self, loss, outputs, targets, indices, num_boxes, **kwargs):
+        loss_map = {
+            "boxes": self.loss_boxes,
+            "focal": self.loss_labels_focal,
+            "vfl": self.loss_labels_vfl,
+            "local": self.loss_local,
+        }
+        assert loss in loss_map, f"do you really want to compute {loss} loss?"
+        return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
+
+    def forward(self, outputs, targets, world_size, **kwargs):
+        """This performs the loss computation.
+        Parameters:
+             outputs: dict of tensors, see the output specification of the model for the format
+             targets: list of dicts, such that len(targets) == batch_size.
+                      The expected keys in each dict depends on the losses applied, see each loss' doc
+        """
+        outputs_without_aux = {k: v for k, v in outputs.items() if "aux" not in k}
+
+        # Retrieve the matching between the outputs of the last layer and the targets
+        indices = self.matcher(outputs_without_aux, targets)["indices"]
+        self._clear_cache()
+
+        # Compute the average number of target boxes accross all nodes, for normalization purposes
+        num_boxes = sum(len(t["labels"]) for t in targets)
+        num_boxes = torch.as_tensor(
+            [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
+        )
+        if is_dist_available_and_initialized():
+            torch.distributed.all_reduce(num_boxes)
+        num_boxes = torch.clamp(num_boxes / world_size, min=1).item()
+
+        # Get the matching union set across all decoder layers.
+        if "aux_outputs" in outputs:
+            indices_aux_list, cached_indices, cached_indices_enc = [], [], []
+            for aux_outputs in outputs["aux_outputs"] + [outputs["pre_outputs"]]:
+                indices_aux = self.matcher(aux_outputs, targets)["indices"]
+                cached_indices.append(indices_aux)
+                indices_aux_list.append(indices_aux)
+            for aux_outputs in outputs["enc_aux_outputs"]:
+                indices_enc = self.matcher(aux_outputs, targets)["indices"]
+                cached_indices_enc.append(indices_enc)
+                indices_aux_list.append(indices_enc)
+            indices_go = self._get_go_indices(indices, indices_aux_list)
+
+            num_boxes_go = sum(len(x[0]) for x in indices_go)
+            num_boxes_go = torch.as_tensor(
+                [num_boxes_go],
+                dtype=torch.float,
+                device=next(iter(outputs.values())).device,
+            )
+            if is_dist_available_and_initialized():
+                torch.distributed.all_reduce(num_boxes_go)
+            num_boxes_go = torch.clamp(num_boxes_go / world_size, min=1).item()
+        else:
+            indices_go = indices
+            num_boxes_go = num_boxes
+
+        # Compute all the requested losses
+        losses = {}
+        for loss in self.losses:
+            indices_in = indices_go if loss in ["boxes", "local"] else indices
+            num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+            meta = self.get_loss_meta_info(loss, outputs, targets, indices_in)
+            l_dict = self.get_loss(
+                loss, outputs, targets, indices_in, num_boxes_in, **meta
+            )
+            l_dict = {
+                k: l_dict[k] * self.weight_dict[k]
+                for k in l_dict
+                if k in self.weight_dict
+            }
+            losses.update(l_dict)
+
+        # In case of auxiliary losses, we repeat this process with the output of each intermediate layer.
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                aux_outputs["up"], aux_outputs["reg_scale"] = (
+                    outputs["up"],
+                    outputs["reg_scale"],
+                )
+                for loss in self.losses:
+                    indices_in = (
+                        indices_go if loss in ["boxes", "local"] else cached_indices[i]
+                    )
+                    num_boxes_in = (
+                        num_boxes_go if loss in ["boxes", "local"] else num_boxes
+                    )
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, targets, indices_in
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices_in, num_boxes_in, **meta
+                    )
+
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_aux_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        # In case of auxiliary traditional head output at first decoder layer.
+        if "pre_outputs" in outputs:
+            aux_outputs = outputs["pre_outputs"]
+            for loss in self.losses:
+                indices_in = (
+                    indices_go if loss in ["boxes", "local"] else cached_indices[-1]
+                )
+                num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+                meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_in)
+                l_dict = self.get_loss(
+                    loss, aux_outputs, targets, indices_in, num_boxes_in, **meta
+                )
+
+                l_dict = {
+                    k: l_dict[k] * self.weight_dict[k]
+                    for k in l_dict
+                    if k in self.weight_dict
+                }
+                l_dict = {k + "_pre": v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+        # In case of encoder auxiliary losses.
+        if "enc_aux_outputs" in outputs:
+            assert "enc_meta" in outputs, ""
+            class_agnostic = outputs["enc_meta"]["class_agnostic"]
+            if class_agnostic:
+                orig_num_classes = self.num_classes
+                self.num_classes = 1
+                enc_targets = copy.deepcopy(targets)
+                for t in enc_targets:
+                    t["labels"] = torch.zeros_like(t["labels"])
+            else:
+                enc_targets = targets
+
+            for i, aux_outputs in enumerate(outputs["enc_aux_outputs"]):
+                for loss in self.losses:
+                    indices_in = (
+                        indices_go if loss == "boxes" else cached_indices_enc[i]
+                    )
+                    num_boxes_in = num_boxes_go if loss == "boxes" else num_boxes
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, enc_targets, indices_in
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, enc_targets, indices_in, num_boxes_in, **meta
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_enc_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+            if class_agnostic:
+                self.num_classes = orig_num_classes
+
+        # In case of cdn auxiliary losses. For dfine
+        if "dn_outputs" in outputs:
+            assert "dn_meta" in outputs, ""
+            indices_dn = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
+            dn_num_boxes = num_boxes * outputs["dn_meta"]["dn_num_group"]
+            dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
+
+            for i, aux_outputs in enumerate(outputs["dn_outputs"]):
+                aux_outputs["is_dn"] = True
+                aux_outputs["up"], aux_outputs["reg_scale"] = (
+                    outputs["up"],
+                    outputs["reg_scale"],
+                )
+                for loss in self.losses:
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, targets, indices_dn
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_dn_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+            # In case of auxiliary traditional head output at first decoder layer.
+            if "dn_pre_outputs" in outputs:
+                aux_outputs = outputs["dn_pre_outputs"]
+                for loss in self.losses:
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, targets, indices_dn
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + "_dn_pre": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        # For debugging Objects365 pre-train.
+        losses = {k: torch.nan_to_num(v, nan=0.0) for k, v in losses.items()}
+        return losses
+
+    def get_loss_meta_info(self, loss, outputs, targets, indices):
+        if self.boxes_weight_format is None:
+            return {}
+
+        src_boxes = outputs["pred_boxes"][self._get_src_permutation_idx(indices)]
+        src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
+        target_boxes = torch.cat(
+            [t["boxes"][j] for t, (_, j) in zip(targets, indices)], dim=0
+        )
+
+        if self.boxes_weight_format == "iou":
+            iou, _ = box_iou(
+                box_cxcywh_to_xyxy(src_boxes.detach()),
+                box_cxcywh_to_xyxy(target_boxes),
+            )
+            iou = torch.diag(iou)
+        elif self.boxes_weight_format == "giou":
+            iou = torch.diag(
+                generalized_box_iou(
+                    box_cxcywh_to_xyxy(src_boxes.detach()),
+                    box_cxcywh_to_xyxy(target_boxes),
+                )
+            )
+        else:
+            raise AttributeError()
+
+        if loss in ("boxes",):
+            meta = {"boxes_weight": iou}
+        elif loss in ("vfl",):
+            meta = {"values": iou}
+        else:
+            meta = {}
+
+        return meta
+
+    @staticmethod
+    def get_cdn_matched_indices(dn_meta, targets):
+        """get_cdn_matched_indices"""
+        dn_positive_idx, dn_num_group = (
+            dn_meta["dn_positive_idx"],
+            dn_meta["dn_num_group"],
+        )
+        num_gts = [len(t["labels"]) for t in targets]
+        device = targets[0]["labels"].device
+
+        dn_match_indices = []
+        for i, num_gt in enumerate(num_gts):
+            if num_gt > 0:
+                gt_idx = torch.arange(num_gt, dtype=torch.int64, device=device)
+                gt_idx = gt_idx.tile(dn_num_group)
+                assert len(dn_positive_idx[i]) == len(gt_idx)
+                dn_match_indices.append((dn_positive_idx[i], gt_idx))
+            else:
+                dn_match_indices.append(
+                    (
+                        torch.zeros(0, dtype=torch.int64, device=device),
+                        torch.zeros(0, dtype=torch.int64, device=device),
+                    )
+                )
+
+        return dn_match_indices
+
+    def feature_loss_function(self, fea, target_fea):
+        loss = (fea - target_fea) ** 2 * ((fea > 0) | (target_fea > 0)).float()
+        return torch.abs(loss)
+
+    def unimodal_distribution_focal_loss(
+        self,
+        pred,
+        label,
+        weight_right,
+        weight_left,
+        weight=None,
+        reduction="sum",
+        avg_factor=None,
+    ):
+        dis_left = label.long()
+        dis_right = dis_left + 1
+
+        loss = F.cross_entropy(pred, dis_left, reduction="none") * weight_left.reshape(
+            -1
+        ) + F.cross_entropy(pred, dis_right, reduction="none") * weight_right.reshape(
+            -1
+        )
+
+        if weight is not None:
+            weight = weight.float()
+            loss = loss * weight
+
+        if avg_factor is not None:
+            loss = loss.sum() / avg_factor
+        elif reduction == "mean":
+            loss = loss.mean()
+        elif reduction == "sum":
+            loss = loss.sum()
+
+        return loss
+
+    def get_gradual_steps(self, outputs):
+        num_layers = len(outputs["aux_outputs"]) + 1 if "aux_outputs" in outputs else 1
+        step = 0.5 / (num_layers - 1)
+        opt_list = (
+            [0.5 + step * i for i in range(num_layers)] if num_layers > 1 else [1]
+        )
+        return opt_list

--- a/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
@@ -10,14 +10,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.#
-"""Copyright(c) 2023 lyuwenyu. All Rights Reserved."""
+"""
+D-FINE: Redefine Regression Task of DETRs as Fine-grained Distribution Refinement
+Copyright (c) 2024 The D-FINE Authors. All Rights Reserved.
+---------------------------------------------------------------------------------
+Modified from RT-DETR (https://github.com/lyuwenyu/RT-DETR)
+Copyright (c) 2023 lyuwenyu. All Rights Reserved.
+"""
 
 # Modifications Copyright 2026 Lightly AG:
 #  - Registered ``score_head_reuse_or_reinit_hook`` and (when denoising is
 #     enabled) ``denoising_class_embed_reuse_or_reinit_hook`` as
 #     load-state-dict pre-hooks, so pretrained D-FINE checkpoints can be
 #     adapted to a new ``num_classes`` at load time.
-# - Added FP32 guards around bbox refinement for stability in mixed precision
+#  - Registered ``anchors`` / ``valid_mask`` for evaluation as non-persistent buffers so they
+#     are not written into checkpoints.
+#  - ``value_op`` returns the flat ``[bs, L, n_head, c]`` tensor that helper expects rather
+#     than a pre-split per-level tuple to reuse existing `deformable_attention_core_func_v2` in `utils.py` without modification.
 from __future__ import annotations
 
 import copy
@@ -30,11 +39,16 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as init
-from torch import Tensor
 
 from lightly_train import _torch_helpers
 
-from .denoising import get_contrastive_denoising_training_group
+from .denoising import (
+    get_contrastive_denoising_training_group,
+)
+from .dfine_utils import (
+    distance2bbox,
+    weighting_function,
+)
 from .hooks import (
     denoising_class_embed_reuse_or_reinit_hook,
     score_head_reuse_or_reinit_hook,
@@ -45,6 +59,8 @@ from .utils import (
     get_activation,
     inverse_sigmoid,
 )
+
+__all__ = ["DFINETransformer"]
 
 
 class MLP(nn.Module):
@@ -74,7 +90,7 @@ class MSDeformableAttention(nn.Module):
         offset_scale=0.5,
     ):
         """Multi-Scale Deformable Attention"""
-        super(MSDeformableAttention, self).__init__()
+        super().__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.num_levels = num_levels
@@ -103,8 +119,6 @@ class MSDeformableAttention(nn.Module):
 
         self.sampling_offsets = nn.Linear(embed_dim, self.total_points * 2)
         self.attention_weights = nn.Linear(embed_dim, self.total_points)
-        self.value_proj = nn.Linear(embed_dim, embed_dim)
-        self.output_proj = nn.Linear(embed_dim, embed_dim)
 
         self.ms_deformable_attn_core = functools.partial(
             deformable_attention_core_func_v2, method=self.method
@@ -137,19 +151,12 @@ class MSDeformableAttention(nn.Module):
         init.constant_(self.attention_weights.weight, 0)
         init.constant_(self.attention_weights.bias, 0)
 
-        # proj
-        init.xavier_uniform_(self.value_proj.weight)
-        init.constant_(self.value_proj.bias, 0)
-        init.xavier_uniform_(self.output_proj.weight)
-        init.constant_(self.output_proj.bias, 0)
-
     def forward(
         self,
-        query: torch.Tensor,
-        reference_points: torch.Tensor,
-        value: torch.Tensor,
-        value_spatial_shapes: List[int],
-        value_mask: torch.Tensor = None,
+        query,
+        reference_points,
+        value,
+        value_spatial_shapes,
     ):
         """
         Args:
@@ -158,21 +165,13 @@ class MSDeformableAttention(nn.Module):
                 bottom-right (1, 1), including padding area
             value (Tensor): [bs, value_length, C]
             value_spatial_shapes (List): [n_levels, 2], [(H_0, W_0), (H_1, W_1), ..., (H_{L-1}, W_{L-1})]
-            value_mask (Tensor): [bs, value_length], True for non-padding elements, False for padding elements
 
         Returns:
             output (Tensor): [bs, Length_{query}, C]
         """
         bs, Len_q = query.shape[:2]
-        Len_v = value.shape[1]
 
-        value = self.value_proj(value)
-        if value_mask is not None:
-            value = value * value_mask.to(value.dtype).unsqueeze(-1)
-
-        value = value.reshape(bs, Len_v, self.num_heads, self.head_dim)
-
-        sampling_offsets: torch.Tensor = self.sampling_offsets(query)
+        sampling_offsets = self.sampling_offsets(query)
         sampling_offsets = sampling_offsets.reshape(
             bs, Len_q, self.num_heads, sum(self.num_points_list), 2
         )
@@ -180,9 +179,7 @@ class MSDeformableAttention(nn.Module):
         attention_weights = self.attention_weights(query).reshape(
             bs, Len_q, self.num_heads, sum(self.num_points_list)
         )
-        attention_weights = F.softmax(attention_weights, dim=-1).reshape(
-            bs, Len_q, self.num_heads, sum(self.num_points_list)
-        )
+        attention_weights = F.softmax(attention_weights, dim=-1)
 
         if reference_points.shape[-1] == 2:
             offset_normalizer = torch.tensor(value_spatial_shapes)
@@ -219,8 +216,6 @@ class MSDeformableAttention(nn.Module):
             self.num_points_list,
         )
 
-        output = self.output_proj(output)
-
         return output
 
 
@@ -235,8 +230,12 @@ class TransformerDecoderLayer(nn.Module):
         n_levels=4,
         n_points=4,
         cross_attn_method="default",
+        layer_scale=None,
     ):
-        super(TransformerDecoderLayer, self).__init__()
+        super().__init__()
+        if layer_scale is not None:
+            dim_feedforward = round(layer_scale * dim_feedforward)
+            d_model = round(layer_scale * d_model)
 
         # self attention
         self.self_attn = nn.MultiheadAttention(
@@ -250,7 +249,9 @@ class TransformerDecoderLayer(nn.Module):
             d_model, n_head, n_levels, n_points, method=cross_attn_method
         )
         self.dropout2 = nn.Dropout(dropout)
-        self.norm2 = nn.LayerNorm(d_model)
+
+        # gate
+        self.gateway = Gate(d_model)
 
         # ffn
         self.linear1 = nn.Linear(d_model, dim_feedforward)
@@ -276,10 +277,9 @@ class TransformerDecoderLayer(nn.Module):
         self,
         target,
         reference_points,
-        memory,
-        memory_spatial_shapes,
+        value,
+        spatial_shapes,
         attn_mask=None,
-        memory_mask=None,
         query_pos_embed=None,
     ):
         # self attention
@@ -293,104 +293,240 @@ class TransformerDecoderLayer(nn.Module):
         target2 = self.cross_attn(
             self.with_pos_embed(target, query_pos_embed),
             reference_points,
-            memory,
-            memory_spatial_shapes,
-            memory_mask,
+            value,
+            spatial_shapes,
         )
-        target = target + self.dropout2(target2)
-        target = self.norm2(target)
+
+        target = self.gateway(target, self.dropout2(target2))
 
         # ffn
         target2 = self.forward_ffn(target)
         target = target + self.dropout4(target2)
-        target = self.norm3(target)
+        target = self.norm3(target.clamp(min=-65504, max=65504))
 
         return target
 
 
+class Gate(nn.Module):
+    def __init__(self, d_model):
+        super().__init__()
+        self.gate = nn.Linear(2 * d_model, 2 * d_model)
+        bias = bias_init_with_prob(0.5)
+        init.constant_(self.gate.bias, bias)
+        init.constant_(self.gate.weight, 0)
+        self.norm = nn.LayerNorm(d_model)
+
+    def forward(self, x1, x2):
+        gate_input = torch.cat([x1, x2], dim=-1)
+        gates = torch.sigmoid(self.gate(gate_input))
+        gate1, gate2 = gates.chunk(2, dim=-1)
+        return self.norm(gate1 * x1 + gate2 * x2)
+
+
+class Integral(nn.Module):
+    """
+    A static layer that calculates integral results from a distribution.
+
+    This layer computes the target location using the formula: `sum{Pr(n) * W(n)}`,
+    where Pr(n) is the softmax probability vector representing the discrete
+    distribution, and W(n) is the non-uniform Weighting Function.
+
+    Args:
+        reg_max (int): Max number of the discrete bins. Default is 32.
+                       It can be adjusted based on the dataset or task requirements.
+    """
+
+    def __init__(self, reg_max=32):
+        super().__init__()
+        self.reg_max = reg_max
+
+    def forward(self, x, project):
+        shape = x.shape
+        x = F.softmax(x.reshape(-1, self.reg_max + 1), dim=1)
+        x = F.linear(x, project.to(x.device)).reshape(-1, 4)
+        return x.reshape(list(shape[:-1]) + [-1])
+
+
+class LQE(nn.Module):
+    def __init__(self, k, hidden_dim, num_layers, reg_max):
+        super().__init__()
+        self.k = k
+        self.reg_max = reg_max
+        self.reg_conf = MLP(4 * (k + 1), hidden_dim, 1, num_layers)
+        init.constant_(self.reg_conf.layers[-1].bias, 0)
+        init.constant_(self.reg_conf.layers[-1].weight, 0)
+
+    def forward(self, scores, pred_corners):
+        B, L, _ = pred_corners.size()
+        prob = F.softmax(pred_corners.reshape(B, L, 4, self.reg_max + 1), dim=-1)
+        prob_topk, _ = prob.topk(self.k, dim=-1)
+        stat = torch.cat([prob_topk, prob_topk.mean(dim=-1, keepdim=True)], dim=-1)
+        quality_score = self.reg_conf(stat.reshape(B, L, -1))
+        return scores + quality_score
+
+
 class TransformerDecoder(nn.Module):
-    def __init__(self, hidden_dim, decoder_layer, num_layers, eval_idx=-1):
-        super(TransformerDecoder, self).__init__()
-        self.layers = nn.ModuleList(
-            [copy.deepcopy(decoder_layer) for _ in range(num_layers)]
-        )
+    """
+    Transformer Decoder implementing Fine-grained Distribution Refinement (FDR).
+
+    This decoder refines object detection predictions through iterative updates across multiple layers,
+    utilizing attention mechanisms, location quality estimators, and distribution refinement techniques
+    to improve bounding box accuracy and robustness.
+    """
+
+    def __init__(
+        self,
+        hidden_dim,
+        decoder_layer,
+        decoder_layer_wide,
+        num_layers,
+        num_head,
+        reg_max,
+        reg_scale,
+        up,
+        eval_idx=-1,
+        layer_scale=2,
+    ):
+        super().__init__()
         self.hidden_dim = hidden_dim
         self.num_layers = num_layers
+        self.layer_scale = layer_scale
+        self.num_head = num_head
         self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
+        self.up, self.reg_scale, self.reg_max = up, reg_scale, reg_max
+        self.layers = nn.ModuleList(
+            [copy.deepcopy(decoder_layer) for _ in range(self.eval_idx + 1)]
+            + [
+                copy.deepcopy(decoder_layer_wide)
+                for _ in range(num_layers - self.eval_idx - 1)
+            ]
+        )
+        self.lqe_layers = nn.ModuleList(
+            [copy.deepcopy(LQE(4, 64, 2, reg_max)) for _ in range(num_layers)]
+        )
+
+    def value_op(
+        self, memory, value_proj, value_scale, memory_mask, memory_spatial_shapes
+    ):
+        """
+        Preprocess values for MSDeformableAttention.
+        """
+        value = value_proj(memory) if value_proj is not None else memory
+        value = (
+            F.interpolate(memory, size=value_scale)
+            if value_scale is not None
+            else value
+        )
+        if memory_mask is not None:
+            value = value * memory_mask.to(value.dtype).unsqueeze(-1)
+        return value.reshape(value.shape[0], value.shape[1], self.num_head, -1)
+
+    def convert_to_deploy(self):
+        self.project = weighting_function(
+            self.reg_max, self.up, self.reg_scale, deploy=True
+        )
+        self.layers = self.layers[: self.eval_idx + 1]
+        self.lqe_layers = nn.ModuleList(
+            [nn.Identity()] * self.eval_idx + [self.lqe_layers[self.eval_idx]]
+        )
 
     def forward(
         self,
         target,
         ref_points_unact,
         memory,
-        memory_spatial_shapes,
+        spatial_shapes,
         bbox_head,
         score_head,
         query_pos_head,
+        pre_bbox_head,
+        integral,
+        up,
+        reg_scale,
         attn_mask=None,
         memory_mask=None,
+        dn_meta=None,
     ):
+        output = target
+        output_detach = pred_corners_undetach = 0
+        value = self.value_op(memory, None, None, memory_mask, spatial_shapes)
+
         dec_out_bboxes = []
         dec_out_logits = []
+        dec_out_pred_corners = []
+        dec_out_refs = []
+        if not hasattr(self, "project"):
+            project = weighting_function(self.reg_max, up, reg_scale)
+        else:
+            project = self.project
+
         ref_points_detach = F.sigmoid(ref_points_unact)
 
-        output = target
         for i, layer in enumerate(self.layers):
             ref_points_input = ref_points_detach.unsqueeze(2)
-            query_pos_embed = query_pos_head(ref_points_detach)
+            query_pos_embed = query_pos_head(ref_points_detach).clamp(min=-10, max=10)
+
+            # TODO Adjust scale if needed for detachable wider layers
+            if i >= self.eval_idx + 1 and self.layer_scale > 1:
+                query_pos_embed = F.interpolate(
+                    query_pos_embed, scale_factor=self.layer_scale
+                )
+                value = self.value_op(
+                    memory, None, query_pos_embed.shape[-1], memory_mask, spatial_shapes
+                )
+                output = F.interpolate(output, size=query_pos_embed.shape[-1])
+                output_detach = output.detach()
 
             output = layer(
                 output,
                 ref_points_input,
-                memory,
-                memory_spatial_shapes,
+                value,
+                spatial_shapes,
                 attn_mask,
-                memory_mask,
                 query_pos_embed,
             )
 
-            # Run the bbox refinement in fp32 to avoid fp16 overflow in the
-            # bbox_head MLP output. The addition of bbox_head(output) and
-            # inverse_sigmoid(ref_points) before sigmoid is a known overflow
-            # hotspot in RTDETR-style decoders, especially with EMA weights
-            # that can drift into regions where the MLP output exceeds fp16's
-            # ~65K range.
-            with torch.amp.autocast(device_type=output.device.type, enabled=False):
-                output_fp32 = output.float()
-                ref_points_detach_fp32 = ref_points_detach.float()
-                bbox_delta_fp32 = bbox_head[i](output_fp32)
-
-                inter_ref_bbox_fp32 = F.sigmoid(
-                    bbox_delta_fp32 + inverse_sigmoid(ref_points_detach_fp32)
+            if i == 0:
+                # Initial bounding box predictions with inverse sigmoid refinement
+                pre_bboxes = F.sigmoid(
+                    pre_bbox_head(output) + inverse_sigmoid(ref_points_detach)
                 )
+                pre_scores = score_head[0](output)
+                ref_points_initial = pre_bboxes.detach()
 
-            ref_points = inter_ref_bbox_fp32.to(dtype=output.dtype)
+            # Refine bounding box corners using FDR, integrating previous layer's corrections
+            pred_corners = bbox_head[i](output + output_detach) + pred_corners_undetach
+            inter_ref_bbox = distance2bbox(
+                ref_points_initial, integral(pred_corners, project), reg_scale
+            )
 
-            if self.training:
-                dec_out_logits.append(score_head[i](output))
-                if i == 0:
-                    dec_out_bboxes.append(inter_ref_bbox_fp32)
-                else:
-                    with torch.amp.autocast(
-                        device_type=output.device.type, enabled=False
-                    ):
-                        dec_out_bboxes.append(
-                            F.sigmoid(
-                                bbox_delta_fp32 + inverse_sigmoid(inter_ref_bbox_fp32)
-                            )
-                        )  # use FP32 for training
+            if self.training or i == self.eval_idx:
+                scores = score_head[i](output)
+                # Lqe does not affect the performance here.
+                scores = self.lqe_layers[i](scores, pred_corners)
+                dec_out_logits.append(scores)
+                dec_out_bboxes.append(inter_ref_bbox)
+                dec_out_pred_corners.append(pred_corners)
+                dec_out_refs.append(ref_points_initial)
 
-            elif i == self.eval_idx:
-                dec_out_logits.append(score_head[i](output))
-                dec_out_bboxes.append(ref_points)  # use FP16 for evaluation
-                break
+                if not self.training:
+                    break
 
-            ref_points_detach = ref_points.detach()
+            pred_corners_undetach = pred_corners
+            ref_points_detach = inter_ref_bbox.detach()
+            output_detach = output.detach()
 
-        return torch.stack(dec_out_bboxes), torch.stack(dec_out_logits)
+        return (
+            torch.stack(dec_out_bboxes),
+            torch.stack(dec_out_logits),
+            torch.stack(dec_out_pred_corners),
+            torch.stack(dec_out_refs),
+            pre_bboxes,
+            pre_scores,
+        )
 
 
-class RTDETRTransformerv2(nn.Module):
+class DFINETransformer(nn.Module):
     def __init__(
         self,
         num_classes=80,
@@ -415,8 +551,19 @@ class RTDETRTransformerv2(nn.Module):
         aux_loss=True,
         cross_attn_method="default",
         query_select_method="default",
+        reg_max=32,
+        reg_scale=4.0,
+        layer_scale=1,
     ):
         super().__init__()
+        # NOTE: ``feat_channels`` / ``feat_strides`` use mutable list defaults to
+        # stay consistent with upstream D-FINE (and ``RTDETRTransformerv2``).
+        # Because the loop below calls ``feat_strides.append(...)``, constructing
+        # ``DFINETransformer`` multiple times without passing explicit
+        # ``feat_strides`` would mutate the shared default list and grow it on
+        # each call. Callers in Lightly Train always pass explicit lists, so the
+        # bug is latent; revisit if that changes (e.g. switch to ``None`` +
+        # in-body fallback, or ``tuple`` defaults + ``list(...)`` copy).
         assert len(feat_channels) <= num_levels
         assert len(feat_strides) == len(feat_channels)
 
@@ -424,6 +571,7 @@ class RTDETRTransformerv2(nn.Module):
             feat_strides.append(feat_strides[-1] * 2)
 
         self.hidden_dim = hidden_dim
+        scaled_dim = round(layer_scale * hidden_dim)
         self.nhead = nhead
         self.feat_strides = feat_strides
         self.num_levels = num_levels
@@ -433,6 +581,7 @@ class RTDETRTransformerv2(nn.Module):
         self.num_layers = num_layers
         self.eval_spatial_size = eval_spatial_size
         self.aux_loss = aux_loss
+        self.reg_max = reg_max
 
         assert query_select_method in ("default", "one2many", "agnostic"), ""
         assert cross_attn_method in ("default", "discrete"), ""
@@ -443,6 +592,8 @@ class RTDETRTransformerv2(nn.Module):
         self._build_input_proj_layer(feat_channels)
 
         # Transformer module
+        self.up = nn.Parameter(torch.tensor([0.5]), requires_grad=False)
+        self.reg_scale = nn.Parameter(torch.tensor([reg_scale]), requires_grad=False)
         decoder_layer = TransformerDecoderLayer(
             hidden_dim,
             nhead,
@@ -453,8 +604,28 @@ class RTDETRTransformerv2(nn.Module):
             num_points,
             cross_attn_method=cross_attn_method,
         )
+        decoder_layer_wide = TransformerDecoderLayer(
+            hidden_dim,
+            nhead,
+            dim_feedforward,
+            dropout,
+            activation,
+            num_levels,
+            num_points,
+            cross_attn_method=cross_attn_method,
+            layer_scale=layer_scale,
+        )
         self.decoder = TransformerDecoder(
-            hidden_dim, decoder_layer, num_layers, eval_idx
+            hidden_dim,
+            decoder_layer,
+            decoder_layer_wide,
+            num_layers,
+            nhead,
+            reg_max,
+            self.reg_scale,
+            self.up,
+            eval_idx,
+            layer_scale,
         )
 
         # denoising
@@ -473,20 +644,11 @@ class RTDETRTransformerv2(nn.Module):
             self.tgt_embed = nn.Embedding(num_queries, hidden_dim)
         self.query_pos_head = MLP(4, 2 * hidden_dim, hidden_dim, 2)
 
-        # if num_select_queries != self.num_queries:
-        #     layer = TransformerEncoderLayer(hidden_dim, nhead, dim_feedforward, activation='gelu')
-        #     self.encoder = TransformerEncoder(layer, 1)
-
         self.enc_output = nn.Sequential(
             OrderedDict(
                 [
                     ("proj", nn.Linear(hidden_dim, hidden_dim)),
-                    (
-                        "norm",
-                        nn.LayerNorm(
-                            hidden_dim,
-                        ),
-                    ),
+                    ("norm", nn.LayerNorm(hidden_dim)),
                 ]
             )
         )
@@ -499,16 +661,28 @@ class RTDETRTransformerv2(nn.Module):
         self.enc_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3)
 
         # decoder head
+        self.eval_idx = eval_idx if eval_idx >= 0 else num_layers + eval_idx
         self.dec_score_head = nn.ModuleList(
-            [nn.Linear(hidden_dim, num_classes) for _ in range(num_layers)]
+            [nn.Linear(hidden_dim, num_classes) for _ in range(self.eval_idx + 1)]
+            + [
+                nn.Linear(scaled_dim, num_classes)
+                for _ in range(num_layers - self.eval_idx - 1)
+            ]
         )
+        self.pre_bbox_head = MLP(hidden_dim, hidden_dim, 4, 3)
         self.dec_bbox_head = nn.ModuleList(
-            [MLP(hidden_dim, hidden_dim, 4, 3) for _ in range(num_layers)]
+            [
+                MLP(hidden_dim, hidden_dim, 4 * (self.reg_max + 1), 3)
+                for _ in range(self.eval_idx + 1)
+            ]
+            + [
+                MLP(scaled_dim, scaled_dim, 4 * (self.reg_max + 1), 3)
+                for _ in range(num_layers - self.eval_idx - 1)
+            ]
         )
+        self.integral = Integral(self.reg_max)
 
         # init encoder output anchors and valid_mask
-        self.anchors: Tensor
-        self.valid_mask: Tensor
         if self.eval_spatial_size:
             anchors, valid_mask = self._generate_anchors()
             self.register_buffer("anchors", anchors, persistent=False)
@@ -522,73 +696,92 @@ class RTDETRTransformerv2(nn.Module):
                 self, denoising_class_embed_reuse_or_reinit_hook
             )
 
-        self._reset_parameters()
+        self._reset_parameters(feat_channels)
 
-    def _reset_parameters(self):
+    def convert_to_deploy(self):
+        self.dec_score_head = nn.ModuleList(
+            [nn.Identity()] * self.eval_idx + [self.dec_score_head[self.eval_idx]]
+        )
+        self.dec_bbox_head = nn.ModuleList(
+            [
+                self.dec_bbox_head[i] if i <= self.eval_idx else nn.Identity()
+                for i in range(len(self.dec_bbox_head))
+            ]
+        )
+
+    def _reset_parameters(self, feat_channels):
         bias = bias_init_with_prob(0.01)
         init.constant_(self.enc_score_head.bias, bias)
         init.constant_(self.enc_bbox_head.layers[-1].weight, 0)
         init.constant_(self.enc_bbox_head.layers[-1].bias, 0)
 
-        for _cls, _reg in zip(self.dec_score_head, self.dec_bbox_head):
-            init.constant_(_cls.bias, bias)
-            init.constant_(_reg.layers[-1].weight, 0)
-            init.constant_(_reg.layers[-1].bias, 0)
+        init.constant_(self.pre_bbox_head.layers[-1].weight, 0)
+        init.constant_(self.pre_bbox_head.layers[-1].bias, 0)
+
+        for cls_, reg_ in zip(self.dec_score_head, self.dec_bbox_head):
+            init.constant_(cls_.bias, bias)
+            if hasattr(reg_, "layers"):
+                init.constant_(reg_.layers[-1].weight, 0)
+                init.constant_(reg_.layers[-1].bias, 0)
 
         init.xavier_uniform_(self.enc_output[0].weight)
         if self.learn_query_content:
             init.xavier_uniform_(self.tgt_embed.weight)
         init.xavier_uniform_(self.query_pos_head.layers[0].weight)
         init.xavier_uniform_(self.query_pos_head.layers[1].weight)
-        for m in self.input_proj:
-            init.xavier_uniform_(m[0].weight)
+        for m, in_channels in zip(self.input_proj, feat_channels):
+            if in_channels != self.hidden_dim:
+                init.xavier_uniform_(m[0].weight)
 
     def _build_input_proj_layer(self, feat_channels):
         self.input_proj = nn.ModuleList()
         for in_channels in feat_channels:
-            self.input_proj.append(
-                nn.Sequential(
-                    OrderedDict(
-                        [
-                            (
-                                "conv",
-                                nn.Conv2d(in_channels, self.hidden_dim, 1, bias=False),
-                            ),
-                            (
-                                "norm",
-                                nn.BatchNorm2d(
-                                    self.hidden_dim,
+            if in_channels == self.hidden_dim:
+                self.input_proj.append(nn.Identity())
+            else:
+                self.input_proj.append(
+                    nn.Sequential(
+                        OrderedDict(
+                            [
+                                (
+                                    "conv",
+                                    nn.Conv2d(
+                                        in_channels, self.hidden_dim, 1, bias=False
+                                    ),
                                 ),
-                            ),
-                        ]
+                                ("norm", nn.BatchNorm2d(self.hidden_dim)),
+                            ]
+                        )
                     )
                 )
-            )
 
         in_channels = feat_channels[-1]
 
         for _ in range(self.num_levels - len(feat_channels)):
-            self.input_proj.append(
-                nn.Sequential(
-                    OrderedDict(
-                        [
-                            (
-                                "conv",
-                                nn.Conv2d(
-                                    in_channels,
-                                    self.hidden_dim,
-                                    3,
-                                    2,
-                                    padding=1,
-                                    bias=False,
+            if in_channels == self.hidden_dim:
+                self.input_proj.append(nn.Identity())
+            else:
+                self.input_proj.append(
+                    nn.Sequential(
+                        OrderedDict(
+                            [
+                                (
+                                    "conv",
+                                    nn.Conv2d(
+                                        in_channels,
+                                        self.hidden_dim,
+                                        3,
+                                        2,
+                                        padding=1,
+                                        bias=False,
+                                    ),
                                 ),
-                            ),
-                            ("norm", nn.BatchNorm2d(self.hidden_dim)),
-                        ]
+                                ("norm", nn.BatchNorm2d(self.hidden_dim)),
+                            ]
+                        )
                     )
                 )
-            )
-            in_channels = self.hidden_dim
+                in_channels = self.hidden_dim
 
     def _get_encoder_input(self, feats: List[torch.Tensor]):
         # get projection features
@@ -604,18 +797,22 @@ class RTDETRTransformerv2(nn.Module):
         # get encoder inputs
         feat_flatten = []
         spatial_shapes = []
-        for i, feat in enumerate(proj_feats):
+        for feat in proj_feats:
             _, _, h, w = feat.shape
             # [b, c, h, w] -> [b, h*w, c]
             feat_flatten.append(feat.flatten(2).permute(0, 2, 1))
             # [num_levels, 2]
             spatial_shapes.append([h, w])
+
         # [b, l, c]
-        feat_flatten = torch.concat(feat_flatten, 1)
-        return feat_flatten, spatial_shapes
+        return torch.concat(feat_flatten, 1), spatial_shapes
 
     def _generate_anchors(
-        self, spatial_shapes=None, grid_size=0.05, dtype=torch.float32, device="cpu"
+        self,
+        spatial_shapes=None,
+        grid_size=0.05,
+        dtype=torch.float32,
+        device="cpu",
     ):
         if spatial_shapes is None:
             spatial_shapes = []
@@ -645,7 +842,7 @@ class RTDETRTransformerv2(nn.Module):
 
     def _get_decoder_input(
         self,
-        memory: torch.Tensor,
+        memory,
         spatial_shapes,
         denoising_logits=None,
         denoising_bbox_unact=None,
@@ -653,34 +850,32 @@ class RTDETRTransformerv2(nn.Module):
         # prepare input for decoder
         if self.training or self.eval_spatial_size is None:
             anchors, valid_mask = self._generate_anchors(
-                spatial_shapes, device=memory.device, dtype=memory.dtype
+                spatial_shapes, device=memory.device
             )
         else:
             anchors = self.anchors
             valid_mask = self.valid_mask
+        if memory.shape[0] > 1:
+            anchors = anchors.repeat(memory.shape[0], 1, 1)
 
         # memory = torch.where(valid_mask, memory, 0)
-        # TODO fix type error for onnx export
+        # TODO: fix type error for onnx export
         memory = valid_mask.to(memory.dtype) * memory
 
-        output_memory: torch.Tensor = self.enc_output(memory)
-        enc_outputs_logits: torch.Tensor = self.enc_score_head(output_memory)
-        enc_outputs_coord_unact: torch.Tensor = (
-            self.enc_bbox_head(output_memory) + anchors
-        )
+        output_memory = self.enc_output(memory)
+        enc_outputs_logits = self.enc_score_head(output_memory)
 
         enc_topk_bboxes_list, enc_topk_logits_list = [], []
-        enc_topk_memory, enc_topk_logits, enc_topk_bbox_unact = self._select_topk(
-            output_memory, enc_outputs_logits, enc_outputs_coord_unact, self.num_queries
+        enc_topk_memory, enc_topk_logits, enc_topk_anchors = self._select_topk(
+            output_memory, enc_outputs_logits, anchors, self.num_queries
         )
+
+        enc_topk_bbox_unact = self.enc_bbox_head(enc_topk_memory) + enc_topk_anchors
 
         if self.training:
             enc_topk_bboxes = F.sigmoid(enc_topk_bbox_unact)
             enc_topk_bboxes_list.append(enc_topk_bboxes)
             enc_topk_logits_list.append(enc_topk_logits)
-
-        # if self.num_select_queries != self.num_queries:
-        #     raise NotImplementedError('')
 
         if self.learn_query_content:
             content = self.tgt_embed.weight.unsqueeze(0).tile([memory.shape[0], 1, 1])
@@ -697,13 +892,7 @@ class RTDETRTransformerv2(nn.Module):
 
         return content, enc_topk_bbox_unact, enc_topk_bboxes_list, enc_topk_logits_list
 
-    def _select_topk(
-        self,
-        memory: torch.Tensor,
-        outputs_logits: torch.Tensor,
-        outputs_coords_unact: torch.Tensor,
-        topk: int,
-    ):
+    def _select_topk(self, memory, outputs_logits, outputs_anchors_unact, topk: int):
         if self.query_select_method == "default":
             _, topk_ind = torch.topk(outputs_logits.max(-1).values, topk, dim=-1)
 
@@ -713,12 +902,12 @@ class RTDETRTransformerv2(nn.Module):
 
         elif self.query_select_method == "agnostic":
             _, topk_ind = torch.topk(outputs_logits.squeeze(-1), topk, dim=-1)
+        else:
+            raise ValueError(f"Unsupported query selection: {self.query_select_method}")
 
-        topk_ind: torch.Tensor
-
-        topk_coords = outputs_coords_unact.gather(
+        topk_anchors = outputs_anchors_unact.gather(
             dim=1,
-            index=topk_ind.unsqueeze(-1).repeat(1, 1, outputs_coords_unact.shape[-1]),
+            index=topk_ind.unsqueeze(-1).repeat(1, 1, outputs_anchors_unact.shape[-1]),
         )
 
         topk_logits = outputs_logits.gather(
@@ -729,7 +918,7 @@ class RTDETRTransformerv2(nn.Module):
             dim=1, index=topk_ind.unsqueeze(-1).repeat(1, 1, memory.shape[-1])
         )
 
-        return topk_memory, topk_logits, topk_coords
+        return topk_memory, topk_logits, topk_anchors
 
     def forward(self, feats, targets=None):
         # input projection and embedding
@@ -745,7 +934,7 @@ class RTDETRTransformerv2(nn.Module):
                     self.denoising_class_embed,
                     num_denoising=self.num_denoising,
                     label_noise_ratio=self.label_noise_ratio,
-                    box_noise_scale=self.box_noise_scale,
+                    box_noise_scale=1.0,
                 )
             )
         else:
@@ -766,15 +955,22 @@ class RTDETRTransformerv2(nn.Module):
         )
 
         # decoder
-        out_bboxes, out_logits = self.decoder(
-            init_ref_contents,
-            init_ref_points_unact,
-            memory,
-            spatial_shapes,
-            self.dec_bbox_head,
-            self.dec_score_head,
-            self.query_pos_head,
-            attn_mask=attn_mask,
+        out_bboxes, out_logits, _out_corners, _out_refs, _pre_bboxes, _pre_logits = (
+            self.decoder(
+                init_ref_contents,
+                init_ref_points_unact,
+                memory,
+                spatial_shapes,
+                self.dec_bbox_head,
+                self.dec_score_head,
+                self.query_pos_head,
+                self.pre_bbox_head,
+                self.integral,
+                self.up,
+                self.reg_scale,
+                attn_mask=attn_mask,
+                dn_meta=dn_meta,
+            )
         )
 
         if self.training and dn_meta is not None:
@@ -784,10 +980,26 @@ class RTDETRTransformerv2(nn.Module):
             dn_out_logits, out_logits = torch.split(
                 out_logits, dn_meta["dn_num_split"], dim=2
             )
+            # TODO (Yutong, 04/26): D-FINE loss also requires splitting ``_out_corners`` /
+            # ``_out_refs`` and ``_pre_logits`` / ``_pre_bboxes`` here, and
+            # returning the denoising halves as ``dn_outputs`` /
+            # ``dn_pre_outputs`` in ``out`` below.
 
-        out = {"pred_logits": out_logits[-1], "pred_boxes": out_bboxes[-1]}
+        out = {
+            "pred_logits": out_logits[-1],
+            "pred_boxes": out_bboxes[-1],
+        }
+        # TODO (Yutong, 04/26): For the D-FINE loss, also expose ``pred_corners``,
+        # ``ref_points``, ``up``, and ``reg_scale`` here during training so that
+        # the FGL/DDF terms can be computed.
 
         if self.training and self.aux_loss:
+            # TODO (Yutong, 04/26): For the D-FINE loss, ``aux_outputs`` / ``dn_outputs`` should
+            # be built with ``_set_aux_loss2`` to also carry ``pred_corners``,
+            # ``ref_points`` and the last-layer teacher distributions
+            # (``teacher_corners`` / ``teacher_logits``) used by the DDF
+            # distillation term. The ``pre_outputs`` / ``dn_pre_outputs`` dicts
+            # (from ``_pre_bboxes`` / ``_pre_logits``) are also missing.
             out["aux_outputs"] = self._set_aux_loss(out_logits[:-1], out_bboxes[:-1])
             out["enc_aux_outputs"] = self._set_aux_loss(
                 enc_topk_logits_list, enc_topk_bboxes_list
@@ -809,3 +1021,10 @@ class RTDETRTransformerv2(nn.Module):
             {"pred_logits": a, "pred_boxes": b}
             for a, b in zip(outputs_class, outputs_coord)
         ]
+
+
+# TODO (Yutong, 04/26):
+# Replace the ``_set_aux_loss`` call for ``aux_outputs`` / ``dn_outputs``
+#     with the ``_set_aux_loss2`` variant that forwards ``out_corners``,
+#     ``out_refs``, and the last-layer ``teacher_corners``/``teacher_logits``
+#     used for self-distillation (DDF).

--- a/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
@@ -525,21 +525,23 @@ class TransformerDecoder(nn.Module):
                 )
 
             if self.training or i == self.eval_idx:
-                scores = score_head[i](output)
-                pred_corners = pred_corners_fp32.to(output.dtype)
-                # Lqe does not affect the performance here.
-                scores = self.lqe_layers[i](scores, pred_corners)
+                with torch.amp.autocast(device_type=output.device.type, enabled=False):
+                    output_fp32 = output.float()
+                    scores_fp32 = score_head[i](output_fp32)
+                    # Lqe does not affect the performance here.
+                    scores_fp32 = self.lqe_layers[i](scores_fp32, pred_corners_fp32)
 
-                dec_out_logits.append(scores)
                 if self.training:
                     # Use FP32 for training (loss numerical stability).
+                    dec_out_logits.append(scores_fp32)
                     dec_out_bboxes.append(inter_ref_bbox_fp32)
                     dec_out_pred_corners.append(pred_corners_fp32)
                     dec_out_refs.append(ref_points_initial_fp32)
                 else:
                     # Use FP16 for evaluation.
+                    dec_out_logits.append(scores_fp32.to(output.dtype))
                     dec_out_bboxes.append(inter_ref_bbox_fp32.to(output.dtype))
-                    dec_out_pred_corners.append(pred_corners)
+                    dec_out_pred_corners.append(pred_corners_fp32.to(output.dtype))
                     dec_out_refs.append(ref_points_initial_fp32.to(output.dtype))
                     break
 

--- a/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
@@ -988,7 +988,7 @@ class DFINETransformer(nn.Module):
         )
 
         # decoder
-        out_bboxes, out_logits, _out_corners, _out_refs, _pre_bboxes, _pre_logits = (
+        out_bboxes, out_logits, out_corners, out_refs, pre_bboxes, pre_logits = (
             self.decoder(
                 init_ref_contents,
                 init_ref_points_unact,
@@ -1007,40 +1007,69 @@ class DFINETransformer(nn.Module):
         )
 
         if self.training and dn_meta is not None:
+            dn_pre_logits, pre_logits = torch.split(
+                pre_logits, dn_meta["dn_num_split"], dim=1
+            )
+            dn_pre_bboxes, pre_bboxes = torch.split(
+                pre_bboxes, dn_meta["dn_num_split"], dim=1
+            )
             dn_out_bboxes, out_bboxes = torch.split(
                 out_bboxes, dn_meta["dn_num_split"], dim=2
             )
             dn_out_logits, out_logits = torch.split(
                 out_logits, dn_meta["dn_num_split"], dim=2
             )
-            # TODO (Yutong, 04/26): D-FINE loss also requires splitting ``_out_corners`` /
-            # ``_out_refs`` and ``_pre_logits`` / ``_pre_bboxes`` here, and
-            # returning the denoising halves as ``dn_outputs`` /
-            # ``dn_pre_outputs`` in ``out`` below.
 
-        out = {
-            "pred_logits": out_logits[-1],
-            "pred_boxes": out_bboxes[-1],
-        }
-        # TODO (Yutong, 04/26): For the D-FINE loss, also expose ``pred_corners``,
-        # ``ref_points``, ``up``, and ``reg_scale`` here during training so that
-        # the FGL/DDF terms can be computed.
+            dn_out_corners, out_corners = torch.split(
+                out_corners, dn_meta["dn_num_split"], dim=2
+            )
+            dn_out_refs, out_refs = torch.split(
+                out_refs, dn_meta["dn_num_split"], dim=2
+            )
+
+        if self.training:
+            out = {
+                "pred_logits": out_logits[-1],
+                "pred_boxes": out_bboxes[-1],
+                "pred_corners": out_corners[-1],
+                "ref_points": out_refs[-1],
+                "up": self.up,
+                "reg_scale": self.reg_scale,
+            }
+        else:
+            out = {
+                "pred_logits": out_logits[-1],
+                "pred_boxes": out_bboxes[-1],
+            }
 
         if self.training and self.aux_loss:
-            # TODO (Yutong, 04/26): For the D-FINE loss, ``aux_outputs`` / ``dn_outputs`` should
-            # be built with ``_set_aux_loss2`` to also carry ``pred_corners``,
-            # ``ref_points`` and the last-layer teacher distributions
-            # (``teacher_corners`` / ``teacher_logits``) used by the DDF
-            # distillation term. The ``pre_outputs`` / ``dn_pre_outputs`` dicts
-            # (from ``_pre_bboxes`` / ``_pre_logits``) are also missing.
-            out["aux_outputs"] = self._set_aux_loss(out_logits[:-1], out_bboxes[:-1])
+            out["aux_outputs"] = self._set_aux_loss2(
+                out_logits[:-1],
+                out_bboxes[:-1],
+                out_corners[:-1],
+                out_refs[:-1],
+                out_corners[-1],
+                out_logits[-1],
+            )
             out["enc_aux_outputs"] = self._set_aux_loss(
                 enc_topk_logits_list, enc_topk_bboxes_list
             )
+            out["pre_outputs"] = {"pred_logits": pre_logits, "pred_boxes": pre_bboxes}
             out["enc_meta"] = {"class_agnostic": self.query_select_method == "agnostic"}
 
             if dn_meta is not None:
-                out["dn_aux_outputs"] = self._set_aux_loss(dn_out_logits, dn_out_bboxes)
+                out["dn_outputs"] = self._set_aux_loss2(
+                    dn_out_logits,
+                    dn_out_bboxes,
+                    dn_out_corners,
+                    dn_out_refs,
+                    dn_out_corners[-1],
+                    dn_out_logits[-1],
+                )
+                out["dn_pre_outputs"] = {
+                    "pred_logits": dn_pre_logits,
+                    "pred_boxes": dn_pre_bboxes,
+                }
                 out["dn_meta"] = dn_meta
 
         return out
@@ -1055,9 +1084,29 @@ class DFINETransformer(nn.Module):
             for a, b in zip(outputs_class, outputs_coord)
         ]
 
-
-# TODO (Yutong, 04/26):
-# Replace the ``_set_aux_loss`` call for ``aux_outputs`` / ``dn_outputs``
-#     with the ``_set_aux_loss2`` variant that forwards ``out_corners``,
-#     ``out_refs``, and the last-layer ``teacher_corners``/``teacher_logits``
-#     used for self-distillation (DDF).
+    @torch.jit.unused
+    def _set_aux_loss2(
+        self,
+        outputs_class,
+        outputs_coord,
+        outputs_corners,
+        outputs_ref,
+        teacher_corners=None,
+        teacher_logits=None,
+    ):
+        # this is a workaround to make torchscript happy, as torchscript
+        # doesn't support dictionary with non-homogeneous values, such
+        # as a dict having both a Tensor and a list.
+        return [
+            {
+                "pred_logits": a,
+                "pred_boxes": b,
+                "pred_corners": c,
+                "ref_points": d,
+                "teacher_corners": teacher_corners,
+                "teacher_logits": teacher_logits,
+            }
+            for a, b, c, d in zip(
+                outputs_class, outputs_coord, outputs_corners, outputs_ref
+            )
+        ]

--- a/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
@@ -27,6 +27,7 @@ Copyright (c) 2023 lyuwenyu. All Rights Reserved.
 #     are not written into checkpoints.
 #  - ``value_op`` returns the flat ``[bs, L, n_head, c]`` tensor that helper expects rather
 #     than a pre-split per-level tuple to reuse existing `deformable_attention_core_func_v2` in `utils.py` without modification.
+#  - Added FP32 guards around bbox refinement for stability in mixed precision
 from __future__ import annotations
 
 import copy
@@ -486,34 +487,64 @@ class TransformerDecoder(nn.Module):
                 query_pos_embed,
             )
 
-            if i == 0:
-                # Initial bounding box predictions with inverse sigmoid refinement
-                pre_bboxes = F.sigmoid(
-                    pre_bbox_head(output) + inverse_sigmoid(ref_points_detach)
-                )
-                pre_scores = score_head[0](output)
-                ref_points_initial = pre_bboxes.detach()
+            # Run the bbox refinement in fp32 to avoid fp16 overflow in the
+            # bbox_head / pre_bbox_head MLP outputs. The addition of MLP
+            # output and inverse_sigmoid(ref_points) before sigmoid is a
+            # known overflow hotspot in RTDETR-style decoders, especially
+            # with EMA weights that can drift into regions where the MLP
+            # output exceeds fp16's ~65K range.
+            with torch.amp.autocast(device_type=output.device.type, enabled=False):
+                output_fp32 = output.float()
 
-            # Refine bounding box corners using FDR, integrating previous layer's corrections
-            pred_corners = bbox_head[i](output + output_detach) + pred_corners_undetach
-            inter_ref_bbox = distance2bbox(
-                ref_points_initial, integral(pred_corners, project), reg_scale
-            )
+                if i == 0:
+                    # Initial bounding box predictions with inverse sigmoid refinement
+                    ref_points_detach_fp32 = ref_points_detach.float()
+                    pre_bboxes_fp32 = F.sigmoid(
+                        pre_bbox_head(output_fp32)
+                        + inverse_sigmoid(ref_points_detach_fp32)
+                    )
+                    ref_points_initial_fp32 = pre_bboxes_fp32.detach()
+
+                    pre_scores = score_head[0](output)
+
+                # Refine bounding box corners using FDR, integrating previous
+                # layer's corrections.
+                bbox_head_input_fp32 = output_fp32
+                if isinstance(output_detach, torch.Tensor):
+                    output_detach_fp32 = output_detach.float()
+                    bbox_head_input_fp32 = bbox_head_input_fp32 + output_detach_fp32
+                pred_corners_fp32 = bbox_head[i](bbox_head_input_fp32)
+                if isinstance(pred_corners_undetach, torch.Tensor):
+                    pred_corners_undetach_fp32 = pred_corners_undetach.float()
+                    pred_corners_fp32 = pred_corners_fp32 + pred_corners_undetach_fp32
+
+                inter_ref_bbox_fp32 = distance2bbox(
+                    ref_points_initial_fp32,
+                    integral(pred_corners_fp32, project),
+                    reg_scale,
+                )
 
             if self.training or i == self.eval_idx:
                 scores = score_head[i](output)
+                pred_corners = pred_corners_fp32.to(output.dtype)
                 # Lqe does not affect the performance here.
                 scores = self.lqe_layers[i](scores, pred_corners)
-                dec_out_logits.append(scores)
-                dec_out_bboxes.append(inter_ref_bbox)
-                dec_out_pred_corners.append(pred_corners)
-                dec_out_refs.append(ref_points_initial)
 
-                if not self.training:
+                dec_out_logits.append(scores)
+                if self.training:
+                    # Use FP32 for training (loss numerical stability).
+                    dec_out_bboxes.append(inter_ref_bbox_fp32)
+                    dec_out_pred_corners.append(pred_corners_fp32)
+                    dec_out_refs.append(ref_points_initial_fp32)
+                else:
+                    # Use FP16 for evaluation.
+                    dec_out_bboxes.append(inter_ref_bbox_fp32.to(output.dtype))
+                    dec_out_pred_corners.append(pred_corners)
+                    dec_out_refs.append(ref_points_initial_fp32.to(output.dtype))
                     break
 
-            pred_corners_undetach = pred_corners
-            ref_points_detach = inter_ref_bbox.detach()
+            pred_corners_undetach = pred_corners_fp32
+            ref_points_detach = inter_ref_bbox_fp32.detach().to(dtype=output.dtype)
             output_detach = output.detach()
 
         return (
@@ -521,7 +552,7 @@ class TransformerDecoder(nn.Module):
             torch.stack(dec_out_logits),
             torch.stack(dec_out_pred_corners),
             torch.stack(dec_out_refs),
-            pre_bboxes,
+            pre_bboxes_fp32,
             pre_scores,
         )
 

--- a/src/lightly_train/_task_models/object_detection_components/dfine_utils.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_utils.py
@@ -1,0 +1,79 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+"""Copyright (c) 2024 The D-FINE Authors. All Rights Reserved."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from lightly_train._task_models.object_detection_components.box_ops import (
+    box_xyxy_to_cxcywh,
+)
+
+
+def weighting_function(
+    reg_max: int,
+    up: Tensor,
+    reg_scale: Tensor,
+    deploy: bool = False,
+) -> Tensor:
+    """Generate the non-uniform weighting function for D-FINE box regression."""
+    if deploy:
+        upper_bound1 = (abs(up[0]) * abs(reg_scale)).item()
+        upper_bound2 = (abs(up[0]) * abs(reg_scale) * 2).item()
+        step = (upper_bound1 + 1) ** (2 / (reg_max - 2))
+        left_values = [-((step) ** i) + 1 for i in range(reg_max // 2 - 1, 0, -1)]
+        right_values = [(step) ** i - 1 for i in range(1, reg_max // 2)]
+        values = (
+            [-upper_bound2]
+            + left_values
+            + [torch.zeros_like(up[0][None])]
+            + right_values
+            + [upper_bound2]
+        )
+        return torch.tensor(values, dtype=up.dtype, device=up.device)
+
+    upper_bound1 = abs(up[0]) * abs(reg_scale)
+    upper_bound2 = abs(up[0]) * abs(reg_scale) * 2
+    step = (upper_bound1 + 1) ** (2 / (reg_max - 2))
+    left_values = [-((step) ** i) + 1 for i in range(reg_max // 2 - 1, 0, -1)]
+    right_values = [(step) ** i - 1 for i in range(1, reg_max // 2)]
+    values = (
+        [-upper_bound2]
+        + left_values
+        + [torch.zeros_like(up[0][None])]
+        + right_values
+        + [upper_bound2]
+    )
+    return torch.cat(values, 0)
+
+
+def distance2bbox(points: Tensor, distance: Tensor, reg_scale: Tensor) -> Tensor:
+    """Decode D-FINE edge distances into ``cxcywh`` boxes."""
+    reg_scale = abs(reg_scale)
+    x1 = points[..., 0] - (0.5 * reg_scale + distance[..., 0]) * (
+        points[..., 2] / reg_scale
+    )
+    y1 = points[..., 1] - (0.5 * reg_scale + distance[..., 1]) * (
+        points[..., 3] / reg_scale
+    )
+    x2 = points[..., 0] + (0.5 * reg_scale + distance[..., 2]) * (
+        points[..., 2] / reg_scale
+    )
+    y2 = points[..., 1] + (0.5 * reg_scale + distance[..., 3]) * (
+        points[..., 3] / reg_scale
+    )
+
+    bboxes = torch.stack([x1, y1, x2, y2], -1)
+    return box_xyxy_to_cxcywh(bboxes)

--- a/src/lightly_train/_task_models/object_detection_components/dfine_utils.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_utils.py
@@ -12,6 +12,9 @@
 # limitations under the License.#
 """Copyright (c) 2024 The D-FINE Authors. All Rights Reserved."""
 
+# Modifications Copyright 2026 Lightly AG:
+#  - Added type annotations.
+
 from __future__ import annotations
 
 import torch
@@ -59,6 +62,66 @@ def weighting_function(
     return torch.cat(values, 0)
 
 
+def translate_gt(
+    gt: Tensor, reg_max: int, reg_scale: Tensor, up: Tensor
+) -> tuple[Tensor, Tensor, Tensor]:
+    """
+    Decodes bounding box ground truth (GT) values into distribution-based GT representations.
+
+    This function maps continuous GT values into discrete distribution bins, which can be used
+    for regression tasks in object detection models. It calculates the indices of the closest
+    bins to each GT value and assigns interpolation weights to these bins based on their proximity
+    to the GT value.
+
+    Args:
+        gt (Tensor): Ground truth bounding box values, shape (N, ).
+        reg_max (int): Maximum number of discrete bins for the distribution.
+        reg_scale (float): Controls the curvature of the Weighting Function.
+        up (Tensor): Controls the upper bounds of the Weighting Function.
+
+    Returns:
+        Tuple[Tensor, Tensor, Tensor]:
+            - indices (Tensor): Index of the left bin closest to each GT value, shape (N, ).
+            - weight_right (Tensor): Weight assigned to the right bin, shape (N, ).
+            - weight_left (Tensor): Weight assigned to the left bin, shape (N, ).
+    """
+    gt = gt.reshape(-1)
+    function_values = weighting_function(reg_max, up, reg_scale)
+
+    diffs = function_values.unsqueeze(0) - gt.unsqueeze(1)
+    mask = diffs <= 0
+    closest_left_indices = torch.sum(mask, dim=1) - 1
+
+    indices = closest_left_indices.float()
+
+    weight_right = torch.zeros_like(indices)
+    weight_left = torch.zeros_like(indices)
+
+    valid_idx_mask = (indices >= 0) & (indices < reg_max)
+    valid_indices = indices[valid_idx_mask].long()
+
+    left_values = function_values[valid_indices]
+    right_values = function_values[valid_indices + 1]
+
+    left_diffs = torch.abs(gt[valid_idx_mask] - left_values)
+    right_diffs = torch.abs(right_values - gt[valid_idx_mask])
+
+    weight_right[valid_idx_mask] = left_diffs / (left_diffs + right_diffs)
+    weight_left[valid_idx_mask] = 1.0 - weight_right[valid_idx_mask]
+
+    invalid_idx_mask_neg = indices < 0
+    weight_right[invalid_idx_mask_neg] = 0.0
+    weight_left[invalid_idx_mask_neg] = 1.0
+    indices[invalid_idx_mask_neg] = 0.0
+
+    invalid_idx_mask_pos = indices >= reg_max
+    weight_right[invalid_idx_mask_pos] = 1.0
+    weight_left[invalid_idx_mask_pos] = 0.0
+    indices[invalid_idx_mask_pos] = reg_max - 0.1
+
+    return indices, weight_right, weight_left
+
+
 def distance2bbox(points: Tensor, distance: Tensor, reg_scale: Tensor) -> Tensor:
     """Decode D-FINE edge distances into ``cxcywh`` boxes."""
     reg_scale = abs(reg_scale)
@@ -77,3 +140,47 @@ def distance2bbox(points: Tensor, distance: Tensor, reg_scale: Tensor) -> Tensor
 
     bboxes = torch.stack([x1, y1, x2, y2], -1)
     return box_xyxy_to_cxcywh(bboxes)
+
+
+def bbox2distance(
+    points: Tensor,
+    bbox: Tensor,
+    reg_max: int,
+    reg_scale: Tensor,
+    up: Tensor,
+    eps: float = 0.1,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """
+    Converts bounding box coordinates to distances from a reference point.
+
+    Args:
+        points (Tensor): (n, 4) [x, y, w, h], where (x, y) is the center.
+        bbox (Tensor): (n, 4) bounding boxes in "xyxy" format.
+        reg_max (float): Maximum bin value.
+        reg_scale (float): Controling curvarture of W(n).
+        up (Tensor): Controling upper bounds of W(n).
+        eps (float): Small value to ensure target < reg_max.
+
+    Returns:
+        Tensor: Decoded distances.
+    """
+    reg_scale = abs(reg_scale)
+    left = (points[:, 0] - bbox[:, 0]) / (
+        points[..., 2] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    top = (points[:, 1] - bbox[:, 1]) / (
+        points[..., 3] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    right = (bbox[:, 2] - points[:, 0]) / (
+        points[..., 2] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    bottom = (bbox[:, 3] - points[:, 1]) / (
+        points[..., 3] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    four_lens = torch.stack([left, top, right, bottom], -1)
+    four_lens, weight_right, weight_left = translate_gt(
+        four_lens, reg_max, reg_scale, up
+    )
+    if reg_max is not None:
+        four_lens = four_lens.clamp(min=0, max=reg_max - eps)
+    return four_lens.reshape(-1).detach(), weight_right.detach(), weight_left.detach()

--- a/src/lightly_train/_task_models/object_detection_components/dist_utils.py
+++ b/src/lightly_train/_task_models/object_detection_components/dist_utils.py
@@ -1,0 +1,29 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+"""
+reference
+- https://github.com/pytorch/vision/blob/main/references/detection/utils.py
+- https://github.com/facebookresearch/detr/blob/master/util/misc.py#L406
+
+Copyright(c) 2023 lyuwenyu. All Rights Reserved.
+"""
+
+import torch
+
+
+def is_dist_available_and_initialized():
+    if not torch.distributed.is_available():
+        return False
+    if not torch.distributed.is_initialized():
+        return False
+    return True

--- a/src/lightly_train/_task_models/object_detection_components/hooks.py
+++ b/src/lightly_train/_task_models/object_detection_components/hooks.py
@@ -1,0 +1,228 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+"""Load-state-dict pre-hooks shared by RT-DETRv2 / D-FINE decoders.
+
+These hooks adapt a pretrained checkpoint to a module configured with a
+different number of classes, by truncating or zero-/re-initializing the
+classification-related weights so ``load_state_dict`` succeeds.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+import torch
+from torch.nn import Module, ModuleList
+
+logger = logging.getLogger(__name__)
+
+
+def denoising_class_embed_reuse_or_reinit_hook(
+    module: Module,
+    state_dict: dict[str, Any],
+    prefix: str,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    """Adjust denoising class embeddings when checkpoint has different number of classes.
+
+    If the checkpoint and module have different numbers of classes, this hook reuses
+    available weights and initializes missing ones from the module's initialization.
+    This allows loading checkpoints trained on different datasets.
+
+    Args:
+        module: The module being loaded.
+        state_dict: The checkpoint state dictionary.
+        prefix: Prefix for parameter names in state_dict.
+    """
+    weight_key = f"{prefix}denoising_class_embed.weight"
+    checkpoint_weight = state_dict.get(weight_key)
+    if checkpoint_weight is None:
+        return
+
+    embed_module = getattr(module, "denoising_class_embed", None)
+    if embed_module is None:
+        return
+
+    num_classes_checkpoint = checkpoint_weight.shape[0]
+    num_classes_module = embed_module.num_embeddings
+    if num_classes_checkpoint == num_classes_module:
+        return
+
+    logger.info(
+        f"Checkpoint has {num_classes_checkpoint - 1} classes, module expects "
+        f"{num_classes_module - 1} classes. Adjusting denoising class embeddings."
+    )
+
+    device = embed_module.weight.device
+
+    # Last class is padding_idx
+    num_user_classes_checkpoint = num_classes_checkpoint - 1
+    num_user_classes_module = num_classes_module - 1
+
+    if num_classes_checkpoint > num_classes_module:
+        # Checkpoint has more classes: reuse checkpoint and discard excess
+        adjusted_weight = torch.cat(
+            [
+                checkpoint_weight[:num_user_classes_module].to(device),
+                checkpoint_weight[-1:].to(device),  # padding class
+            ],
+            dim=0,
+        )
+    else:
+        # Checkpoint has fewer classes: reuse checkpoint and initialize missing from
+        # module
+        adjusted_weight = torch.cat(
+            [
+                checkpoint_weight[:num_user_classes_checkpoint].to(device),
+                embed_module.weight[num_user_classes_checkpoint:].detach().clone(),  # type: ignore[index]
+            ],
+            dim=0,
+        )
+
+    state_dict[weight_key] = adjusted_weight
+
+
+def score_head_reuse_or_reinit_hook(
+    module: Module,
+    state_dict: dict[str, Any],
+    prefix: str,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    _score_head_reuse_or_reinit_hook(
+        module,
+        state_dict,
+        prefix,
+        enc_or_dec="enc",
+    )
+    _score_head_reuse_or_reinit_hook(
+        module,
+        state_dict,
+        prefix,
+        enc_or_dec="dec",
+    )
+
+
+def _score_head_reuse_or_reinit_hook(
+    module: Module,
+    state_dict: dict[str, Any],
+    prefix: str,
+    enc_or_dec: Literal["enc", "dec"],
+) -> None:
+    """Adjust score head weights when checkpoint has different number of classes.
+
+    Handles both single score head (e.g., encoder) and multiple score heads (e.g., decoder layers).
+
+    Args:
+        module: The module being loaded.
+        state_dict: The checkpoint state dictionary.
+        prefix: Prefix for parameter names in state_dict.
+        enc_or_dec: Whether this is for encoder ("enc") or decoder ("dec") score head.
+    """
+    module_name = f"{enc_or_dec}_score_head"
+    score_head = getattr(module, module_name, None)
+    if score_head is None:
+        return
+
+    # Handle both single head and multiple heads (ModuleList)
+    heads_to_process = (
+        enumerate(score_head)
+        if isinstance(score_head, ModuleList)
+        else [(None, score_head)]
+    )
+
+    any_adjusted = False
+    for idx, head_module in heads_to_process:
+        # Construct parameter keys based on whether this is a list or single head
+        if idx is not None:
+            weight_key = f"{prefix}{module_name}.{idx}.weight"
+            bias_key = f"{prefix}{module_name}.{idx}.bias"
+        else:
+            weight_key = f"{prefix}{module_name}.weight"
+            bias_key = f"{prefix}{module_name}.bias"
+
+        was_adjusted = _reuse_or_reinit(
+            head_module, state_dict, weight_key=weight_key, bias_key=bias_key
+        )
+        any_adjusted = any_adjusted or was_adjusted
+
+    if any_adjusted:
+        logger.info(
+            f"Checkpoint has different number of classes for {module_name}. "
+            f"Adjusted weights/biases to match module configuration."
+        )
+
+
+def _reuse_or_reinit(
+    head_module: Module,
+    state_dict: dict[str, Any],
+    *,
+    weight_key: str,
+    bias_key: str,
+) -> bool:
+    """Adjust linear head weights/biases when checkpoint has different number of classes.
+
+    Enables loading checkpoints trained on different number of classes by either:
+    - Truncating weights if checkpoint has more classes (excess classes discarded)
+    - Padding weights if checkpoint has fewer classes (new classes initialized from module)
+
+    Args:
+        head_module: The linear classification head module.
+        state_dict: The checkpoint state dictionary.
+        weight_key: Key to the weight parameter in state_dict.
+        bias_key: Key to the bias parameter in state_dict.
+
+    Returns:
+        True if weights/biases were adjusted, False otherwise.
+    """
+    checkpoint_weight = state_dict.get(weight_key)
+    checkpoint_bias = state_dict.get(bias_key)
+    if checkpoint_weight is None:
+        return False
+
+    num_classes_checkpoint = checkpoint_weight.shape[0]
+    num_classes_module = getattr(head_module, "out_features", None)
+    if num_classes_module is None or num_classes_checkpoint == num_classes_module:
+        return False
+
+    device = head_module.weight.device
+
+    if num_classes_checkpoint > num_classes_module:
+        # Checkpoint has more classes: truncate to module's expected size
+        adjusted_weights = checkpoint_weight[:num_classes_module, :]
+        if checkpoint_bias is not None:
+            adjusted_biases = checkpoint_bias[:num_classes_module]
+    else:
+        # Checkpoint has fewer classes: pad with module's initialized weights
+        adjusted_weights = torch.cat(
+            [
+                checkpoint_weight.to(device),
+                head_module.weight[num_classes_checkpoint:].detach().clone(),  # type: ignore[index]
+            ],
+            dim=0,
+        )
+        if checkpoint_bias is not None:
+            adjusted_biases = torch.cat(
+                [
+                    checkpoint_bias.to(device),
+                    head_module.bias[num_classes_checkpoint:].detach().clone(),  # type: ignore[index]
+                ],
+                dim=0,
+            )
+
+    state_dict[weight_key] = adjusted_weights
+    if checkpoint_bias is not None:
+        state_dict[bias_key] = adjusted_biases
+    return True

--- a/src/lightly_train/_task_models/object_detection_components/hooks.py
+++ b/src/lightly_train/_task_models/object_detection_components/hooks.py
@@ -200,12 +200,12 @@ def _reuse_or_reinit(
     device = head_module.weight.device
 
     if num_classes_checkpoint > num_classes_module:
-        # Checkpoint has more classes: truncate to module's expected size
-        adjusted_weights = checkpoint_weight[:num_classes_module, :]
+        # Checkpoint has more classes: truncate to module's expected size.
+        adjusted_weights = checkpoint_weight[:num_classes_module, :].to(device)
         if checkpoint_bias is not None:
-            adjusted_biases = checkpoint_bias[:num_classes_module]
+            adjusted_biases = checkpoint_bias[:num_classes_module].to(device)
     else:
-        # Checkpoint has fewer classes: pad with module's initialized weights
+        # Checkpoint has fewer classes: pad with module's initialized weights.
         adjusted_weights = torch.cat(
             [
                 checkpoint_weight.to(device),

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_criterion.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_criterion.py
@@ -12,6 +12,9 @@
 # limitations under the License.#
 """Copyright(c) 2023 lyuwenyu. All Rights Reserved."""
 
+# Modifications Copyright 2026 Lightly AG:
+# - Introduce sanitize_boxes_cxcywh_normalized function to ensure boxes are in the expected format
+
 import copy
 
 import torch
@@ -26,14 +29,9 @@ from lightly_train._task_models.object_detection_components.box_ops import (
     generalized_box_iou,
     sanitize_boxes_cxcywh_normalized,
 )
-
-
-def is_dist_available_and_initialized():
-    if not torch.distributed.is_available():
-        return False
-    if not torch.distributed.is_initialized():
-        return False
-    return True
+from lightly_train._task_models.object_detection_components.dist_utils import (
+    is_dist_available_and_initialized,
+)
 
 
 class RTDETRCriterionv2(nn.Module):

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
@@ -15,7 +15,7 @@
 # Modifications Copyright 2026 Lightly AG:
 #  - Registered ``score_head_reuse_or_reinit_hook`` and (when denoising is
 #     enabled) ``denoising_class_embed_reuse_or_reinit_hook`` as
-#     load-state-dict pre-hooks, so pretrained D-FINE checkpoints can be
+#     load-state-dict pre-hooks, so pretrained RT-DETR checkpoints can be
 #     adapted to a new ``num_classes`` at load time.
 # - Added FP32 guards around bbox refinement for stability in mixed precision
 from __future__ import annotations


### PR DESCRIPTION
## What has changed and why?

Add D-FINE decoder based on the [original implementation](https://github.com/Peterande/D-FINE/blob/master/src/zoo/dfine/dfine_decoder.py). Meanwhile, we retain backward compatibility with using the old RTDETRv2 decoder with a configurable `model_args` entry.

Major changes include (based on D-FINE paper):
- replacing original decoder projection layer with a Target Gating Layer
- applying Fine-grained Distribution Refinement (FDR)

The `dfine_decoder.py` and `dfine_utils.py` are mostly carbon copies of the original except for:
- adding ``score_head_reuse_or_reinit_hook`` and (when denoising is enabled) ``denoising_class_embed_reuse_or_reinit_hook`` as `load_state_dict` pre-hooks, so pretrained D-FINE checkpoints can be adapted to a new ``num_classes`` at load time. The same hooks are refactored from the `rtdetrv2_decoder.py` to a separate `hooks.py`.
- registering ``anchors`` / ``valid_mask`` for evaluation as non-persistent buffers instead so they are not written into checkpoints.
- making ``value_op`` return the flat ``[bs, L, n_head, c]`` tensor that helper expects rather than a pre-split per-level tuple to reuse existing `deformable_attention_core_func_v2` in `utils.py` without modification.
- making `bbox_head` and `pre_bbox_head` FP32. See 
  - https://github.com/Peterande/D-FINE/issues/3, 
  - https://github.com/Peterande/D-FINE/issues/43, and 
  - https://github.com/Peterande/D-FINE/issues/199 in D-FINE repo and 
  - #707 in our repo. 
  I also created an issue for potential ONNX export failure.

Note that currently:
- this does not include the necessary changes for the D-FINE losses. Will add in a follow-up PR.
- the default decoder is the original RTDETRv2 decoder. Will switch once we conclude the loss implementation and get proper results from benchmarks.

## How has it been tested?

- N/A (not in any testable state)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (to be added after finishing D-FINE loss)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
