### PR TITLE
Add d-fine losses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added decoder and losses from [D-FINE](https://github.com/Peterande/D-FINE).
+
 ### Changed
 
 ### Deprecated

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ add-header:
 		-x src/lightly_train/_task_models/object_detection_components/tiling_utils.py \
 		   src/lightly_train/_task_models/object_detection_components/dfine_decoder.py \
 		   src/lightly_train/_task_models/object_detection_components/dfine_utils.py \
+		   src/lightly_train/_task_models/object_detection_components/dfine_criterion.py \
 		-E py
 
 	# Apply Lightly's header to tiling_utils.py
@@ -139,6 +140,7 @@ add-header:
 	licenseheaders -t dev_tools/dfine_licenseheader.tmpl \
 		-f src/lightly_train/_task_models/object_detection_components/dfine_decoder.py \
 		src/lightly_train/_task_models/object_detection_components/dfine_utils.py \
+		src/lightly_train/_task_models/object_detection_components/dfine_criterion.py \
 		-E py
 
 	# Apply the PicoDet license header to PicoDet-derived files

--- a/NOTICE
+++ b/NOTICE
@@ -57,6 +57,7 @@ This project incorporates the following third-party components:
   - ``value_op`` returns the flat ``[bs, L, n_head, c]`` tensor to reuse existing ``deformable_attention_core_func_v2`` in ``utils.py``. Affected file: .../dfine_decoder.py
   - Added FP32 guards around bbox refinement for stability in mixed precision. Affected file: .../dfine_decoder.py
   - Added type annotations. Affected file: .../dfine_utils.py
+  - Adapted criterion for LightlyTrain: removed upstream registry hooks, added explicit ``world_size`` forwarding for the Fabric training loop, supports validation-time loss computation when auxiliary outputs are absent, and added FP32 guards around bbox refinement for stability in mixed precision. Affected file: .../dfine_criterion.py
 
 **PicoDet (Picodet_Pytorch)**
 - Source: https://github.com/Bo396543018/Picodet_Pytorch

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -88,31 +88,6 @@ _DFINE_EXTRA_LOSSES: list[str] = ["local"]
 _DFINE_LOSS_NAMES: list[str] = [*_RTDETRV2_LOSS_NAMES, *_DFINE_EXTRA_LOSS_WEIGHT_DICT]
 
 
-def _get_loss_log_dict(
-    *,
-    total_loss: Tensor,
-    loss_dict: dict[str, Tensor],
-    loss_names: list[str],
-) -> dict[str, Tensor]:
-    zero = total_loss.detach() * 0
-    log_dict = {"loss": total_loss.detach()}
-    for loss_name in loss_names:
-        if loss_name == "loss":
-            continue
-        if loss_name == "loss_ddf":
-            log_dict[loss_name] = sum(
-                (
-                    v.detach()
-                    for k, v in loss_dict.items()
-                    if k == "loss_ddf" or k.startswith("loss_ddf_")
-                ),
-                start=zero,
-            )
-        else:
-            log_dict[loss_name] = loss_dict.get(loss_name, zero).detach()
-    return log_dict
-
-
 class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     default_batch_size: ClassVar[int] = 16
     default_steps: ClassVar[int] = (
@@ -238,13 +213,14 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
         loss_weight_dict = model_args.loss_weight_dict
         losses = model_args.losses
         criterion: DFINECriterion | RTDETRCriterionv2
-        if model_args.decoder == "dfine":
+        if model_args.decoder_name == "dfine":
             loss_weight_dict = {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **loss_weight_dict}
             losses = [
                 *losses,
                 *(name for name in _DFINE_EXTRA_LOSSES if name not in losses),
             ]
-            self.loss_names = _DFINE_LOSS_NAMES
+            self.train_loss_names = _DFINE_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
             if not isinstance(self.model.decoder, DFINETransformer):
                 raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
             criterion = DFINECriterion(  # type: ignore[no-untyped-call]
@@ -257,7 +233,8 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
                 reg_max=self.model.decoder.reg_max,
             )
         else:
-            self.loss_names = _RTDETRV2_LOSS_NAMES
+            self.train_loss_names = _RTDETRV2_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
             criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
                 matcher=matcher,
                 weight_dict=loss_weight_dict,
@@ -275,7 +252,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             split="train",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.train_loss_names,
             train_loss_running_mean_window=gradient_accumulation_steps,
         )
         self.val_metrics = ObjectDetectionTaskMetric(
@@ -283,7 +260,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             split="val",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.val_loss_names,
         )
 
         # TODO(Nauryz, 04/2026): These visualization thresholds are currently hardcoded, but we may want to make them configurable in the future (with logger_args).
@@ -367,7 +344,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             loss_dict=_get_loss_log_dict(
                 total_loss=total_loss,
                 loss_dict=loss_dict,
-                loss_names=self.loss_names,
+                loss_names=self.train_loss_names,
             ),
             weight=samples.shape[0],
         )
@@ -474,7 +451,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             loss_dict=_get_loss_log_dict(
                 total_loss=total_loss,
                 loss_dict=loss_dict,
-                loss_names=self.loss_names,
+                loss_names=self.val_loss_names,
             ),
             weight=samples.shape[0],
         )
@@ -610,3 +587,31 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
                 max_norm=self.model_args.gradient_clip_val,
                 error_if_nonfinite=False,
             )
+
+
+def _get_loss_log_dict(
+    *,
+    total_loss: Tensor,
+    loss_dict: dict[str, Tensor],
+    loss_names: list[str],
+) -> dict[str, Tensor]:
+    zero = total_loss.new_zeros(())
+    log_dict = {"loss": total_loss.detach()}
+    for loss_name in loss_names:
+        if loss_name == "loss":
+            continue
+        if loss_name == "loss_ddf":
+            loss_values = [
+                v.detach()
+                for k, v in loss_dict.items()
+                if k == "loss_ddf" or k.startswith("loss_ddf_")
+            ]
+            if not loss_values:
+                raise KeyError(
+                    "No loss entries found for 'loss_ddf'. Available losses: "
+                    f"{sorted(loss_dict.keys())}"
+                )
+            log_dict[loss_name] = sum(loss_values, start=zero)
+        else:
+            log_dict[loss_name] = loss_dict[loss_name].detach()
+    return log_dict

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -45,6 +45,12 @@ from lightly_train._task_models.dinov2_ltdetr_object_detection.transforms import
     DINOv2LTDETRObjectDetectionValTransform,
     DINOv2LTDETRObjectDetectionValTransformArgs,
 )
+from lightly_train._task_models.object_detection_components.dfine_criterion import (
+    DFINECriterion,
+)
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
 from lightly_train._task_models.object_detection_components.ema import ModelEMA
 from lightly_train._task_models.object_detection_components.matcher import (
     HungarianMatcher,
@@ -68,6 +74,43 @@ from lightly_train._visualize.object_detection import (
     plot_object_detection_predictions,
 )
 from lightly_train.types import ObjectDetectionBatch, PathLike
+
+_RTDETRV2_LOSS_WEIGHT_DICT: dict[str, float] = {
+    "loss_vfl": 1.0,
+    "loss_bbox": 5.0,
+    "loss_giou": 2.0,
+}
+_RTDETRV2_LOSSES: list[str] = ["vfl", "boxes"]
+_RTDETRV2_LOSS_NAMES: list[str] = ["loss", *_RTDETRV2_LOSS_WEIGHT_DICT]
+
+_DFINE_EXTRA_LOSS_WEIGHT_DICT: dict[str, float] = {"loss_fgl": 0.15, "loss_ddf": 1.5}
+_DFINE_EXTRA_LOSSES: list[str] = ["local"]
+_DFINE_LOSS_NAMES: list[str] = [*_RTDETRV2_LOSS_NAMES, *_DFINE_EXTRA_LOSS_WEIGHT_DICT]
+
+
+def _get_loss_log_dict(
+    *,
+    total_loss: Tensor,
+    loss_dict: dict[str, Tensor],
+    loss_names: list[str],
+) -> dict[str, Tensor]:
+    zero = total_loss.detach() * 0
+    log_dict = {"loss": total_loss.detach()}
+    for loss_name in loss_names:
+        if loss_name == "loss":
+            continue
+        if loss_name == "loss_ddf":
+            log_dict[loss_name] = sum(
+                (
+                    v.detach()
+                    for k, v in loss_dict.items()
+                    if k == "loss_ddf" or k.startswith("loss_ddf_")
+                ),
+                start=zero,
+            )
+        else:
+            log_dict[loss_name] = loss_dict.get(loss_name, zero).detach()
+    return log_dict
 
 
 class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
@@ -97,9 +140,9 @@ class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
 
     # Criterion configuration
     loss_weight_dict: dict[str, float] = Field(
-        default_factory=lambda: {"loss_vfl": 1.0, "loss_bbox": 5.0, "loss_giou": 2.0}
+        default_factory=lambda: dict(_RTDETRV2_LOSS_WEIGHT_DICT)
     )
-    losses: list[str] = Field(default_factory=lambda: ["vfl", "boxes"])
+    losses: list[str] = Field(default_factory=lambda: list(_RTDETRV2_LOSSES))
     loss_alpha: float = 0.75
     loss_gamma: float = 2.0
 
@@ -192,17 +235,40 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             gamma=model_args.matcher_gamma,
         )
 
-        self.criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
-            matcher=matcher,
-            weight_dict=model_args.loss_weight_dict,
-            losses=model_args.losses,
-            alpha=model_args.loss_alpha,
-            gamma=model_args.loss_gamma,
-            num_classes=len(data_args.included_classes),
-        )
+        loss_weight_dict = model_args.loss_weight_dict
+        losses = model_args.losses
+        criterion: DFINECriterion | RTDETRCriterionv2
+        if model_args.decoder == "dfine":
+            loss_weight_dict = {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **loss_weight_dict}
+            losses = [
+                *losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in losses),
+            ]
+            self.loss_names = _DFINE_LOSS_NAMES
+            if not isinstance(self.model.decoder, DFINETransformer):
+                raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
+            criterion = DFINECriterion(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=loss_weight_dict,
+                losses=losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+                reg_max=self.model.decoder.reg_max,
+            )
+        else:
+            self.loss_names = _RTDETRV2_LOSS_NAMES
+            criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=loss_weight_dict,
+                losses=losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+            )
+        self.criterion = criterion
 
         class_names = list(data_args.included_classes.values())
-        self.loss_names = ["loss", "loss_vfl", "loss_bbox", "loss_giou"]
         self.metric_args = metric_args
         self.train_metrics = ObjectDetectionTaskMetric(
             task_metric_args=metric_args,
@@ -298,12 +364,11 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.train_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.loss_names,
+            ),
             weight=samples.shape[0],
         )
         if self.metric_args.train:
@@ -406,12 +471,11 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.val_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.loss_names,
+            ),
             weight=samples.shape[0],
         )
         self.val_metrics.update_with_predictions(results, targets)

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar, Literal
 import torch
 from lightning_fabric import Fabric
 from PIL.Image import Image as PILImage
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, computed_field
 from torch import Tensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.optim import AdamW, Optimizer  # type: ignore[attr-defined]
@@ -145,6 +145,23 @@ class DINOv2LTDETRObjectDetectionTrainArgs(TrainModelArgs):
         validation_alias=AliasChoices("lr_warmup_steps", "scheduler_warmup_steps"),
     )
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if self.decoder_name == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if self.decoder_name == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
+
 
 class DINOv2LTDETRObjectDetectionTrain(TrainModel):
     task = "object_detection"
@@ -210,23 +227,16 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             gamma=model_args.matcher_gamma,
         )
 
-        loss_weight_dict = model_args.loss_weight_dict
-        losses = model_args.losses
         criterion: DFINECriterion | RTDETRCriterionv2
         if model_args.decoder_name == "dfine":
-            loss_weight_dict = {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **loss_weight_dict}
-            losses = [
-                *losses,
-                *(name for name in _DFINE_EXTRA_LOSSES if name not in losses),
-            ]
             self.train_loss_names = _DFINE_LOSS_NAMES
             self.val_loss_names = _RTDETRV2_LOSS_NAMES
             if not isinstance(self.model.decoder, DFINETransformer):
                 raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
             criterion = DFINECriterion(  # type: ignore[no-untyped-call]
                 matcher=matcher,
-                weight_dict=loss_weight_dict,
-                losses=losses,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
                 alpha=model_args.loss_alpha,
                 gamma=model_args.loss_gamma,
                 num_classes=len(data_args.included_classes),
@@ -237,8 +247,8 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             self.val_loss_names = _RTDETRV2_LOSS_NAMES
             criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
                 matcher=matcher,
-                weight_dict=loss_weight_dict,
-                losses=losses,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
                 alpha=model_args.loss_alpha,
                 gamma=model_args.loss_gamma,
                 num_classes=len(data_args.included_classes),

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -45,6 +45,12 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import
     DINOv3LTDETRObjectDetectionValTransform,
     DINOv3LTDETRObjectDetectionValTransformArgs,
 )
+from lightly_train._task_models.object_detection_components.dfine_criterion import (
+    DFINECriterion,
+)
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
 from lightly_train._task_models.object_detection_components.ema import ModelEMA
 from lightly_train._task_models.object_detection_components.matcher import (
     HungarianMatcher,
@@ -68,6 +74,43 @@ from lightly_train._visualize.object_detection import (
     plot_object_detection_predictions,
 )
 from lightly_train.types import ObjectDetectionBatch, PathLike
+
+_RTDETRV2_LOSS_WEIGHT_DICT: dict[str, float] = {
+    "loss_vfl": 1.0,
+    "loss_bbox": 5.0,
+    "loss_giou": 2.0,
+}
+_RTDETRV2_LOSSES: list[str] = ["vfl", "boxes"]
+_RTDETRV2_LOSS_NAMES: list[str] = ["loss", *_RTDETRV2_LOSS_WEIGHT_DICT]
+
+_DFINE_EXTRA_LOSS_WEIGHT_DICT: dict[str, float] = {"loss_fgl": 0.15, "loss_ddf": 1.5}
+_DFINE_EXTRA_LOSSES: list[str] = ["local"]
+_DFINE_LOSS_NAMES: list[str] = [*_RTDETRV2_LOSS_NAMES, *_DFINE_EXTRA_LOSS_WEIGHT_DICT]
+
+
+def _get_loss_log_dict(
+    *,
+    total_loss: Tensor,
+    loss_dict: dict[str, Tensor],
+    loss_names: list[str],
+) -> dict[str, Tensor]:
+    zero = total_loss.detach() * 0
+    log_dict = {"loss": total_loss.detach()}
+    for loss_name in loss_names:
+        if loss_name == "loss":
+            continue
+        if loss_name == "loss_ddf":
+            log_dict[loss_name] = sum(
+                (
+                    v.detach()
+                    for k, v in loss_dict.items()
+                    if k == "loss_ddf" or k.startswith("loss_ddf_")
+                ),
+                start=zero,
+            )
+        else:
+            log_dict[loss_name] = loss_dict.get(loss_name, zero).detach()
+    return log_dict
 
 
 class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
@@ -96,9 +139,9 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
 
     # Criterion configuration
     loss_weight_dict: dict[str, float] = Field(
-        default_factory=lambda: {"loss_vfl": 1.0, "loss_bbox": 5.0, "loss_giou": 2.0}
+        default_factory=lambda: dict(_RTDETRV2_LOSS_WEIGHT_DICT)
     )
-    losses: list[str] = Field(default_factory=lambda: ["vfl", "boxes"])
+    losses: list[str] = Field(default_factory=lambda: list(_RTDETRV2_LOSSES))
     loss_alpha: float = 0.75
     loss_gamma: float = 2.0
 
@@ -191,17 +234,40 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             gamma=model_args.matcher_gamma,
         )
 
-        self.criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
-            matcher=matcher,
-            weight_dict=model_args.loss_weight_dict,
-            losses=model_args.losses,
-            alpha=model_args.loss_alpha,
-            gamma=model_args.loss_gamma,
-            num_classes=len(data_args.included_classes),
-        )
+        loss_weight_dict = model_args.loss_weight_dict
+        losses = model_args.losses
+        criterion: DFINECriterion | RTDETRCriterionv2
+        if model_args.decoder == "dfine":
+            loss_weight_dict = {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **loss_weight_dict}
+            losses = [
+                *losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in losses),
+            ]
+            self.loss_names = _DFINE_LOSS_NAMES
+            if not isinstance(self.model.decoder, DFINETransformer):
+                raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
+            criterion = DFINECriterion(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=loss_weight_dict,
+                losses=losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+                reg_max=self.model.decoder.reg_max,
+            )
+        else:
+            self.loss_names = _RTDETRV2_LOSS_NAMES
+            criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
+                matcher=matcher,
+                weight_dict=loss_weight_dict,
+                losses=losses,
+                alpha=model_args.loss_alpha,
+                gamma=model_args.loss_gamma,
+                num_classes=len(data_args.included_classes),
+            )
+        self.criterion = criterion
 
         class_names = list(data_args.included_classes.values())
-        self.loss_names = ["loss", "loss_vfl", "loss_bbox", "loss_giou"]
         self.metric_args = metric_args
         self.train_metrics = ObjectDetectionTaskMetric(
             task_metric_args=metric_args,
@@ -301,12 +367,11 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.train_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.loss_names,
+            ),
             weight=samples.shape[0],
         )
         if self.metric_args.train:
@@ -406,12 +471,11 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
 
         # Metrics
         self.val_metrics.update_with_losses(
-            loss_dict={
-                "loss": total_loss.detach(),
-                "loss_vfl": loss_dict["loss_vfl"].detach(),
-                "loss_bbox": loss_dict["loss_bbox"].detach(),
-                "loss_giou": loss_dict["loss_giou"].detach(),
-            },
+            loss_dict=_get_loss_log_dict(
+                total_loss=total_loss,
+                loss_dict=loss_dict,
+                loss_names=self.loss_names,
+            ),
             weight=samples.shape[0],
         )
         self.val_metrics.update_with_predictions(results, targets)

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar, Literal
 import torch
 from lightning_fabric import Fabric
 from PIL.Image import Image as PILImage
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, computed_field
 from torch import Tensor
 from torch.nn.modules.module import _IncompatibleKeys
 from torch.optim import AdamW, Optimizer  # type: ignore[attr-defined]
@@ -144,6 +144,23 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
         validation_alias=AliasChoices("lr_warmup_steps", "scheduler_warmup_steps"),
     )
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if self.decoder_name == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if self.decoder_name == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
+
 
 class DINOv3LTDETRObjectDetectionTrain(TrainModel):
     task = "object_detection"
@@ -209,23 +226,16 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             gamma=model_args.matcher_gamma,
         )
 
-        loss_weight_dict = model_args.loss_weight_dict
-        losses = model_args.losses
         criterion: DFINECriterion | RTDETRCriterionv2
         if model_args.decoder_name == "dfine":
-            loss_weight_dict = {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **loss_weight_dict}
-            losses = [
-                *losses,
-                *(name for name in _DFINE_EXTRA_LOSSES if name not in losses),
-            ]
             self.train_loss_names = _DFINE_LOSS_NAMES
             self.val_loss_names = _RTDETRV2_LOSS_NAMES
             if not isinstance(self.model.decoder, DFINETransformer):
                 raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
             criterion = DFINECriterion(  # type: ignore[no-untyped-call]
                 matcher=matcher,
-                weight_dict=loss_weight_dict,
-                losses=losses,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
                 alpha=model_args.loss_alpha,
                 gamma=model_args.loss_gamma,
                 num_classes=len(data_args.included_classes),
@@ -236,8 +246,8 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             self.val_loss_names = _RTDETRV2_LOSS_NAMES
             criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
                 matcher=matcher,
-                weight_dict=loss_weight_dict,
-                losses=losses,
+                weight_dict=model_args.effective_loss_weight_dict,
+                losses=model_args.effective_losses,
                 alpha=model_args.loss_alpha,
                 gamma=model_args.loss_gamma,
                 num_classes=len(data_args.included_classes),

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -88,31 +88,6 @@ _DFINE_EXTRA_LOSSES: list[str] = ["local"]
 _DFINE_LOSS_NAMES: list[str] = [*_RTDETRV2_LOSS_NAMES, *_DFINE_EXTRA_LOSS_WEIGHT_DICT]
 
 
-def _get_loss_log_dict(
-    *,
-    total_loss: Tensor,
-    loss_dict: dict[str, Tensor],
-    loss_names: list[str],
-) -> dict[str, Tensor]:
-    zero = total_loss.detach() * 0
-    log_dict = {"loss": total_loss.detach()}
-    for loss_name in loss_names:
-        if loss_name == "loss":
-            continue
-        if loss_name == "loss_ddf":
-            log_dict[loss_name] = sum(
-                (
-                    v.detach()
-                    for k, v in loss_dict.items()
-                    if k == "loss_ddf" or k.startswith("loss_ddf_")
-                ),
-                start=zero,
-            )
-        else:
-            log_dict[loss_name] = loss_dict.get(loss_name, zero).detach()
-    return log_dict
-
-
 class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     default_batch_size: ClassVar[int] = 16
     default_steps: ClassVar[int] = (
@@ -237,13 +212,14 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
         loss_weight_dict = model_args.loss_weight_dict
         losses = model_args.losses
         criterion: DFINECriterion | RTDETRCriterionv2
-        if model_args.decoder == "dfine":
+        if model_args.decoder_name == "dfine":
             loss_weight_dict = {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **loss_weight_dict}
             losses = [
                 *losses,
                 *(name for name in _DFINE_EXTRA_LOSSES if name not in losses),
             ]
-            self.loss_names = _DFINE_LOSS_NAMES
+            self.train_loss_names = _DFINE_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
             if not isinstance(self.model.decoder, DFINETransformer):
                 raise TypeError("decoder='dfine' requires a DFINETransformer decoder.")
             criterion = DFINECriterion(  # type: ignore[no-untyped-call]
@@ -256,7 +232,8 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
                 reg_max=self.model.decoder.reg_max,
             )
         else:
-            self.loss_names = _RTDETRV2_LOSS_NAMES
+            self.train_loss_names = _RTDETRV2_LOSS_NAMES
+            self.val_loss_names = _RTDETRV2_LOSS_NAMES
             criterion = RTDETRCriterionv2(  # type: ignore[no-untyped-call]
                 matcher=matcher,
                 weight_dict=loss_weight_dict,
@@ -274,7 +251,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             split="train",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.train_loss_names,
             train_loss_running_mean_window=gradient_accumulation_steps,
         )
         self.val_metrics = ObjectDetectionTaskMetric(
@@ -282,7 +259,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             split="val",
             class_names=class_names,
             box_format="xyxy",
-            loss_names=self.loss_names,
+            loss_names=self.val_loss_names,
         )
 
         # TODO(Nauryz, 04/2026): These visualization thresholds are currently
@@ -370,7 +347,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             loss_dict=_get_loss_log_dict(
                 total_loss=total_loss,
                 loss_dict=loss_dict,
-                loss_names=self.loss_names,
+                loss_names=self.train_loss_names,
             ),
             weight=samples.shape[0],
         )
@@ -474,7 +451,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             loss_dict=_get_loss_log_dict(
                 total_loss=total_loss,
                 loss_dict=loss_dict,
-                loss_names=self.loss_names,
+                loss_names=self.val_loss_names,
             ),
             weight=samples.shape[0],
         )
@@ -613,3 +590,31 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
                 max_norm=self.model_args.gradient_clip_val,
                 error_if_nonfinite=False,
             )
+
+
+def _get_loss_log_dict(
+    *,
+    total_loss: Tensor,
+    loss_dict: dict[str, Tensor],
+    loss_names: list[str],
+) -> dict[str, Tensor]:
+    zero = total_loss.new_zeros(())
+    log_dict = {"loss": total_loss.detach()}
+    for loss_name in loss_names:
+        if loss_name == "loss":
+            continue
+        if loss_name == "loss_ddf":
+            loss_values = [
+                v.detach()
+                for k, v in loss_dict.items()
+                if k == "loss_ddf" or k.startswith("loss_ddf_")
+            ]
+            if not loss_values:
+                raise KeyError(
+                    "No loss entries found for 'loss_ddf'. Available losses: "
+                    f"{sorted(loss_dict.keys())}"
+                )
+            log_dict[loss_name] = sum(loss_values, start=zero)
+        else:
+            log_dict[loss_name] = loss_dict[loss_name].detach()
+    return log_dict

--- a/src/lightly_train/_task_models/object_detection_components/dfine_criterion.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_criterion.py
@@ -1,0 +1,647 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+"""
+D-FINE: Redefine Regression Task of DETRs as Fine-grained Distribution Refinement
+Copyright (c) 2024 The D-FINE Authors. All Rights Reserved.
+---------------------------------------------------------------------------------
+Modified from RT-DETR (https://github.com/lyuwenyu/RT-DETR)
+Copyright (c) 2023 lyuwenyu. All Rights Reserved.
+"""
+
+# Modifications Copyright 2026 Lightly AG:
+#  - Removed upstream registry hooks and adapted imports for LightlyTrain.
+#  - Added explicit ``world_size`` forwarding for LightlyTrain's Fabric training loop.
+#  - Supports validation-time loss computation when auxiliary outputs are absent.
+#  - Added FP32 guards around bbox refinement for stability in mixed precision
+from __future__ import annotations
+
+import copy
+
+import torch
+import torch.distributed
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+
+from lightly_train._task_models.object_detection_components.box_ops import (
+    box_cxcywh_to_xyxy,
+    box_iou,
+    generalized_box_iou,
+    sanitize_boxes_cxcywh_normalized,
+)
+from lightly_train._task_models.object_detection_components.dfine_utils import (
+    bbox2distance,
+)
+from lightly_train._task_models.object_detection_components.dist_utils import (
+    is_dist_available_and_initialized,
+)
+
+
+class DFINECriterion(nn.Module):
+    """This class computes the loss for D-FINE."""
+
+    def __init__(
+        self,
+        matcher,
+        weight_dict,
+        losses,
+        alpha=0.2,
+        gamma=2.0,
+        num_classes=80,
+        reg_max=32,
+        boxes_weight_format=None,
+        share_matched_indices=False,
+    ):
+        """Create the criterion.
+        Parameters:
+            matcher: module able to compute a matching between targets and proposals.
+            weight_dict: dict containing as key the names of the losses and as values their relative weight.
+            losses: list of all the losses to be applied. See get_loss for list of available losses.
+            num_classes: number of object categories, omitting the special no-object category.
+            reg_max (int): Max number of the discrete bins in D-FINE.
+            boxes_weight_format: format for boxes weight (iou, ).
+        """
+        super().__init__()
+        self.num_classes = num_classes
+        self.matcher = matcher
+        self.weight_dict = weight_dict
+        self.losses = losses
+        self.boxes_weight_format = boxes_weight_format
+        self.share_matched_indices = share_matched_indices
+        self.alpha = alpha
+        self.gamma = gamma
+        self.fgl_targets, self.fgl_targets_dn = None, None
+        self.own_targets, self.own_targets_dn = None, None
+        self.reg_max = reg_max
+        self.num_pos, self.num_neg = None, None
+
+    def loss_labels_focal(self, outputs, targets, indices, num_boxes):
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"]
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+        target = F.one_hot(target_classes, num_classes=self.num_classes + 1)[..., :-1]
+        loss = torchvision.ops.sigmoid_focal_loss(
+            src_logits, target, self.alpha, self.gamma, reduction="none"
+        )
+        loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
+
+        return {"loss_focal": loss}
+
+    def loss_labels_vfl(self, outputs, targets, indices, num_boxes, values=None):
+        assert "pred_boxes" in outputs
+        idx = self._get_src_permutation_idx(indices)
+        if values is None:
+            src_boxes = outputs["pred_boxes"][idx]
+            src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
+            target_boxes = torch.cat(
+                [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+            )
+            ious, _ = box_iou(
+                box_cxcywh_to_xyxy(src_boxes), box_cxcywh_to_xyxy(target_boxes)
+            )
+            ious = torch.diag(ious).detach()
+        else:
+            ious = values
+
+        src_logits = outputs["pred_logits"]
+        target_classes_o = torch.cat(
+            [t["labels"][J] for t, (_, J) in zip(targets, indices)]
+        )
+        target_classes = torch.full(
+            src_logits.shape[:2],
+            self.num_classes,
+            dtype=torch.int64,
+            device=src_logits.device,
+        )
+        target_classes[idx] = target_classes_o
+        target = F.one_hot(target_classes, num_classes=self.num_classes + 1)[..., :-1]
+
+        target_score_o = torch.zeros_like(target_classes, dtype=src_logits.dtype)
+        target_score_o[idx] = ious.to(target_score_o.dtype)
+        target_score = target_score_o.unsqueeze(-1) * target
+
+        pred_score = F.sigmoid(src_logits).detach()
+        weight = self.alpha * pred_score.pow(self.gamma) * (1 - target) + target_score
+
+        loss = F.binary_cross_entropy_with_logits(
+            src_logits, target_score, weight=weight, reduction="none"
+        )
+        loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
+        return {"loss_vfl": loss}
+
+    def loss_boxes(self, outputs, targets, indices, num_boxes, boxes_weight=None):
+        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
+        targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
+        The target boxes are expected in format (center_x, center_y, w, h), normalized by the image size.
+        """
+        assert "pred_boxes" in outputs
+        idx = self._get_src_permutation_idx(indices)
+        src_boxes = outputs["pred_boxes"][idx]
+        src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
+        target_boxes = torch.cat(
+            [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+        )
+        losses = {}
+        loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction="none")
+        losses["loss_bbox"] = loss_bbox.sum() / num_boxes
+
+        loss_giou = 1 - torch.diag(
+            generalized_box_iou(
+                box_cxcywh_to_xyxy(src_boxes), box_cxcywh_to_xyxy(target_boxes)
+            )
+        )
+        loss_giou = loss_giou if boxes_weight is None else loss_giou * boxes_weight
+        losses["loss_giou"] = loss_giou.sum() / num_boxes
+
+        return losses
+
+    def loss_local(self, outputs, targets, indices, num_boxes, T=5):
+        """Compute Fine-Grained Localization (FGL) Loss
+        and Decoupled Distillation Focal (DDF) Loss."""
+
+        losses = {}
+        if "pred_corners" in outputs:
+            idx = self._get_src_permutation_idx(indices)
+            target_boxes = torch.cat(
+                [t["boxes"][i] for t, (_, i) in zip(targets, indices)], dim=0
+            )
+
+            pred_corners = outputs["pred_corners"][idx].reshape(-1, (self.reg_max + 1))
+            ref_points = outputs["ref_points"][idx].detach()
+            with torch.no_grad():
+                if self.fgl_targets_dn is None and "is_dn" in outputs:
+                    self.fgl_targets_dn = bbox2distance(
+                        ref_points,
+                        box_cxcywh_to_xyxy(target_boxes),
+                        self.reg_max,
+                        outputs["reg_scale"],
+                        outputs["up"],
+                    )
+                if self.fgl_targets is None and "is_dn" not in outputs:
+                    self.fgl_targets = bbox2distance(
+                        ref_points,
+                        box_cxcywh_to_xyxy(target_boxes),
+                        self.reg_max,
+                        outputs["reg_scale"],
+                        outputs["up"],
+                    )
+
+            target_corners, weight_right, weight_left = (
+                self.fgl_targets_dn if "is_dn" in outputs else self.fgl_targets
+            )
+
+            ious = torch.diag(
+                box_iou(
+                    box_cxcywh_to_xyxy(
+                        sanitize_boxes_cxcywh_normalized(outputs["pred_boxes"][idx])
+                    ),
+                    box_cxcywh_to_xyxy(target_boxes),
+                )[0]
+            )
+            weight_targets = ious.unsqueeze(-1).repeat(1, 1, 4).reshape(-1).detach()
+
+            losses["loss_fgl"] = self.unimodal_distribution_focal_loss(
+                pred_corners,
+                target_corners,
+                weight_right,
+                weight_left,
+                weight_targets,
+                avg_factor=num_boxes,
+            )
+
+            if "teacher_corners" in outputs:
+                pred_corners = outputs["pred_corners"].reshape(-1, (self.reg_max + 1))
+                target_corners = outputs["teacher_corners"].reshape(
+                    -1, (self.reg_max + 1)
+                )
+                if torch.equal(pred_corners, target_corners):
+                    losses["loss_ddf"] = pred_corners.sum() * 0
+                else:
+                    weight_targets_local = (
+                        outputs["teacher_logits"].sigmoid().max(dim=-1)[0]
+                    )
+
+                    mask = torch.zeros_like(weight_targets_local, dtype=torch.bool)
+                    mask[idx] = True
+                    mask = mask.unsqueeze(-1).repeat(1, 1, 4).reshape(-1)
+
+                    weight_targets_local[idx] = ious.reshape_as(
+                        weight_targets_local[idx]
+                    ).to(weight_targets_local.dtype)
+                    weight_targets_local = (
+                        weight_targets_local.unsqueeze(-1)
+                        .repeat(1, 1, 4)
+                        .reshape(-1)
+                        .detach()
+                    )
+
+                    loss_match_local = (
+                        weight_targets_local
+                        * (T**2)
+                        * (
+                            nn.KLDivLoss(reduction="none")(
+                                F.log_softmax(pred_corners / T, dim=1),
+                                F.softmax(target_corners.detach() / T, dim=1),
+                            )
+                        ).sum(-1)
+                    )
+                    if "is_dn" not in outputs:
+                        batch_scale = 8 / outputs["pred_boxes"].shape[0]
+                        self.num_pos, self.num_neg = (
+                            (mask.sum() * batch_scale) ** 0.5,
+                            ((~mask).sum() * batch_scale) ** 0.5,
+                        )
+                    loss_match_local1 = (
+                        loss_match_local[mask].mean() if mask.any() else 0
+                    )
+                    loss_match_local2 = (
+                        loss_match_local[~mask].mean() if (~mask).any() else 0
+                    )
+                    losses["loss_ddf"] = (
+                        loss_match_local1 * self.num_pos
+                        + loss_match_local2 * self.num_neg
+                    ) / (self.num_pos + self.num_neg)
+
+        return losses
+
+    def _get_src_permutation_idx(self, indices):
+        # permute predictions following indices
+        batch_idx = torch.cat(
+            [torch.full_like(src, i) for i, (src, _) in enumerate(indices)]
+        )
+        src_idx = torch.cat([src for (src, _) in indices])
+        return batch_idx, src_idx
+
+    def _get_tgt_permutation_idx(self, indices):
+        # permute targets following indices
+        batch_idx = torch.cat(
+            [torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)]
+        )
+        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
+        return batch_idx, tgt_idx
+
+    def _get_go_indices(self, indices, indices_aux_list):
+        """Get a matching union set across all decoder layers."""
+        results = []
+        for indices_aux in indices_aux_list:
+            indices = [
+                (torch.cat([idx1[0], idx2[0]]), torch.cat([idx1[1], idx2[1]]))
+                for idx1, idx2 in zip(indices.copy(), indices_aux.copy())
+            ]
+
+        for ind in [
+            torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices
+        ]:
+            unique, counts = torch.unique(ind, return_counts=True, dim=0)
+            count_sort_indices = torch.argsort(counts, descending=True)
+            unique_sorted = unique[count_sort_indices]
+            column_to_row = {}
+            for idx in unique_sorted:
+                row_idx, col_idx = idx[0].item(), idx[1].item()
+                if row_idx not in column_to_row:
+                    column_to_row[row_idx] = col_idx
+            final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)
+            final_cols = torch.tensor(list(column_to_row.values()), device=ind.device)
+            results.append((final_rows.long(), final_cols.long()))
+        return results
+
+    def _clear_cache(self):
+        self.fgl_targets, self.fgl_targets_dn = None, None
+        self.own_targets, self.own_targets_dn = None, None
+        self.num_pos, self.num_neg = None, None
+
+    def get_loss(self, loss, outputs, targets, indices, num_boxes, **kwargs):
+        loss_map = {
+            "boxes": self.loss_boxes,
+            "focal": self.loss_labels_focal,
+            "vfl": self.loss_labels_vfl,
+            "local": self.loss_local,
+        }
+        assert loss in loss_map, f"do you really want to compute {loss} loss?"
+        return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)
+
+    def forward(self, outputs, targets, world_size, **kwargs):
+        """This performs the loss computation.
+        Parameters:
+             outputs: dict of tensors, see the output specification of the model for the format
+             targets: list of dicts, such that len(targets) == batch_size.
+                      The expected keys in each dict depends on the losses applied, see each loss' doc
+        """
+        outputs_without_aux = {k: v for k, v in outputs.items() if "aux" not in k}
+
+        # Retrieve the matching between the outputs of the last layer and the targets
+        indices = self.matcher(outputs_without_aux, targets)["indices"]
+        self._clear_cache()
+
+        # Compute the average number of target boxes accross all nodes, for normalization purposes
+        num_boxes = sum(len(t["labels"]) for t in targets)
+        num_boxes = torch.as_tensor(
+            [num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device
+        )
+        if is_dist_available_and_initialized():
+            torch.distributed.all_reduce(num_boxes)
+        num_boxes = torch.clamp(num_boxes / world_size, min=1).item()
+
+        # Get the matching union set across all decoder layers.
+        if "aux_outputs" in outputs:
+            indices_aux_list, cached_indices, cached_indices_enc = [], [], []
+            for aux_outputs in outputs["aux_outputs"] + [outputs["pre_outputs"]]:
+                indices_aux = self.matcher(aux_outputs, targets)["indices"]
+                cached_indices.append(indices_aux)
+                indices_aux_list.append(indices_aux)
+            for aux_outputs in outputs["enc_aux_outputs"]:
+                indices_enc = self.matcher(aux_outputs, targets)["indices"]
+                cached_indices_enc.append(indices_enc)
+                indices_aux_list.append(indices_enc)
+            indices_go = self._get_go_indices(indices, indices_aux_list)
+
+            num_boxes_go = sum(len(x[0]) for x in indices_go)
+            num_boxes_go = torch.as_tensor(
+                [num_boxes_go],
+                dtype=torch.float,
+                device=next(iter(outputs.values())).device,
+            )
+            if is_dist_available_and_initialized():
+                torch.distributed.all_reduce(num_boxes_go)
+            num_boxes_go = torch.clamp(num_boxes_go / world_size, min=1).item()
+        else:
+            indices_go = indices
+            num_boxes_go = num_boxes
+
+        # Compute all the requested losses
+        losses = {}
+        for loss in self.losses:
+            indices_in = indices_go if loss in ["boxes", "local"] else indices
+            num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+            meta = self.get_loss_meta_info(loss, outputs, targets, indices_in)
+            l_dict = self.get_loss(
+                loss, outputs, targets, indices_in, num_boxes_in, **meta
+            )
+            l_dict = {
+                k: l_dict[k] * self.weight_dict[k]
+                for k in l_dict
+                if k in self.weight_dict
+            }
+            losses.update(l_dict)
+
+        # In case of auxiliary losses, we repeat this process with the output of each intermediate layer.
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                aux_outputs["up"], aux_outputs["reg_scale"] = (
+                    outputs["up"],
+                    outputs["reg_scale"],
+                )
+                for loss in self.losses:
+                    indices_in = (
+                        indices_go if loss in ["boxes", "local"] else cached_indices[i]
+                    )
+                    num_boxes_in = (
+                        num_boxes_go if loss in ["boxes", "local"] else num_boxes
+                    )
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, targets, indices_in
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices_in, num_boxes_in, **meta
+                    )
+
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_aux_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        # In case of auxiliary traditional head output at first decoder layer.
+        if "pre_outputs" in outputs:
+            aux_outputs = outputs["pre_outputs"]
+            for loss in self.losses:
+                indices_in = (
+                    indices_go if loss in ["boxes", "local"] else cached_indices[-1]
+                )
+                num_boxes_in = num_boxes_go if loss in ["boxes", "local"] else num_boxes
+                meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_in)
+                l_dict = self.get_loss(
+                    loss, aux_outputs, targets, indices_in, num_boxes_in, **meta
+                )
+
+                l_dict = {
+                    k: l_dict[k] * self.weight_dict[k]
+                    for k in l_dict
+                    if k in self.weight_dict
+                }
+                l_dict = {k + "_pre": v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+        # In case of encoder auxiliary losses.
+        if "enc_aux_outputs" in outputs:
+            assert "enc_meta" in outputs, ""
+            class_agnostic = outputs["enc_meta"]["class_agnostic"]
+            if class_agnostic:
+                orig_num_classes = self.num_classes
+                self.num_classes = 1
+                enc_targets = copy.deepcopy(targets)
+                for t in enc_targets:
+                    t["labels"] = torch.zeros_like(t["labels"])
+            else:
+                enc_targets = targets
+
+            for i, aux_outputs in enumerate(outputs["enc_aux_outputs"]):
+                for loss in self.losses:
+                    indices_in = (
+                        indices_go if loss == "boxes" else cached_indices_enc[i]
+                    )
+                    num_boxes_in = num_boxes_go if loss == "boxes" else num_boxes
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, enc_targets, indices_in
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, enc_targets, indices_in, num_boxes_in, **meta
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_enc_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+            if class_agnostic:
+                self.num_classes = orig_num_classes
+
+        # In case of cdn auxiliary losses. For dfine
+        if "dn_outputs" in outputs:
+            assert "dn_meta" in outputs, ""
+            indices_dn = self.get_cdn_matched_indices(outputs["dn_meta"], targets)
+            dn_num_boxes = num_boxes * outputs["dn_meta"]["dn_num_group"]
+            dn_num_boxes = dn_num_boxes if dn_num_boxes > 0 else 1
+
+            for i, aux_outputs in enumerate(outputs["dn_outputs"]):
+                aux_outputs["is_dn"] = True
+                aux_outputs["up"], aux_outputs["reg_scale"] = (
+                    outputs["up"],
+                    outputs["reg_scale"],
+                )
+                for loss in self.losses:
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, targets, indices_dn
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + f"_dn_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+            # In case of auxiliary traditional head output at first decoder layer.
+            if "dn_pre_outputs" in outputs:
+                aux_outputs = outputs["dn_pre_outputs"]
+                for loss in self.losses:
+                    meta = self.get_loss_meta_info(
+                        loss, aux_outputs, targets, indices_dn
+                    )
+                    l_dict = self.get_loss(
+                        loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta
+                    )
+                    l_dict = {
+                        k: l_dict[k] * self.weight_dict[k]
+                        for k in l_dict
+                        if k in self.weight_dict
+                    }
+                    l_dict = {k + "_dn_pre": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        # For debugging Objects365 pre-train.
+        losses = {k: torch.nan_to_num(v, nan=0.0) for k, v in losses.items()}
+        return losses
+
+    def get_loss_meta_info(self, loss, outputs, targets, indices):
+        if self.boxes_weight_format is None:
+            return {}
+
+        src_boxes = outputs["pred_boxes"][self._get_src_permutation_idx(indices)]
+        src_boxes = sanitize_boxes_cxcywh_normalized(src_boxes)
+        target_boxes = torch.cat(
+            [t["boxes"][j] for t, (_, j) in zip(targets, indices)], dim=0
+        )
+
+        if self.boxes_weight_format == "iou":
+            iou, _ = box_iou(
+                box_cxcywh_to_xyxy(src_boxes.detach()),
+                box_cxcywh_to_xyxy(target_boxes),
+            )
+            iou = torch.diag(iou)
+        elif self.boxes_weight_format == "giou":
+            iou = torch.diag(
+                generalized_box_iou(
+                    box_cxcywh_to_xyxy(src_boxes.detach()),
+                    box_cxcywh_to_xyxy(target_boxes),
+                )
+            )
+        else:
+            raise AttributeError()
+
+        if loss in ("boxes",):
+            meta = {"boxes_weight": iou}
+        elif loss in ("vfl",):
+            meta = {"values": iou}
+        else:
+            meta = {}
+
+        return meta
+
+    @staticmethod
+    def get_cdn_matched_indices(dn_meta, targets):
+        """get_cdn_matched_indices"""
+        dn_positive_idx, dn_num_group = (
+            dn_meta["dn_positive_idx"],
+            dn_meta["dn_num_group"],
+        )
+        num_gts = [len(t["labels"]) for t in targets]
+        device = targets[0]["labels"].device
+
+        dn_match_indices = []
+        for i, num_gt in enumerate(num_gts):
+            if num_gt > 0:
+                gt_idx = torch.arange(num_gt, dtype=torch.int64, device=device)
+                gt_idx = gt_idx.tile(dn_num_group)
+                assert len(dn_positive_idx[i]) == len(gt_idx)
+                dn_match_indices.append((dn_positive_idx[i], gt_idx))
+            else:
+                dn_match_indices.append(
+                    (
+                        torch.zeros(0, dtype=torch.int64, device=device),
+                        torch.zeros(0, dtype=torch.int64, device=device),
+                    )
+                )
+
+        return dn_match_indices
+
+    def feature_loss_function(self, fea, target_fea):
+        loss = (fea - target_fea) ** 2 * ((fea > 0) | (target_fea > 0)).float()
+        return torch.abs(loss)
+
+    def unimodal_distribution_focal_loss(
+        self,
+        pred,
+        label,
+        weight_right,
+        weight_left,
+        weight=None,
+        reduction="sum",
+        avg_factor=None,
+    ):
+        dis_left = label.long()
+        dis_right = dis_left + 1
+
+        loss = F.cross_entropy(pred, dis_left, reduction="none") * weight_left.reshape(
+            -1
+        ) + F.cross_entropy(pred, dis_right, reduction="none") * weight_right.reshape(
+            -1
+        )
+
+        if weight is not None:
+            weight = weight.float()
+            loss = loss * weight
+
+        if avg_factor is not None:
+            loss = loss.sum() / avg_factor
+        elif reduction == "mean":
+            loss = loss.mean()
+        elif reduction == "sum":
+            loss = loss.sum()
+
+        return loss
+
+    def get_gradual_steps(self, outputs):
+        num_layers = len(outputs["aux_outputs"]) + 1 if "aux_outputs" in outputs else 1
+        step = 0.5 / (num_layers - 1)
+        opt_list = (
+            [0.5 + step * i for i in range(num_layers)] if num_layers > 1 else [1]
+        )
+        return opt_list

--- a/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
@@ -988,7 +988,7 @@ class DFINETransformer(nn.Module):
         )
 
         # decoder
-        out_bboxes, out_logits, _out_corners, _out_refs, _pre_bboxes, _pre_logits = (
+        out_bboxes, out_logits, out_corners, out_refs, pre_bboxes, pre_logits = (
             self.decoder(
                 init_ref_contents,
                 init_ref_points_unact,
@@ -1007,40 +1007,69 @@ class DFINETransformer(nn.Module):
         )
 
         if self.training and dn_meta is not None:
+            dn_pre_logits, pre_logits = torch.split(
+                pre_logits, dn_meta["dn_num_split"], dim=1
+            )
+            dn_pre_bboxes, pre_bboxes = torch.split(
+                pre_bboxes, dn_meta["dn_num_split"], dim=1
+            )
             dn_out_bboxes, out_bboxes = torch.split(
                 out_bboxes, dn_meta["dn_num_split"], dim=2
             )
             dn_out_logits, out_logits = torch.split(
                 out_logits, dn_meta["dn_num_split"], dim=2
             )
-            # TODO (Yutong, 04/26): D-FINE loss also requires splitting ``_out_corners`` /
-            # ``_out_refs`` and ``_pre_logits`` / ``_pre_bboxes`` here, and
-            # returning the denoising halves as ``dn_outputs`` /
-            # ``dn_pre_outputs`` in ``out`` below.
 
-        out = {
-            "pred_logits": out_logits[-1],
-            "pred_boxes": out_bboxes[-1],
-        }
-        # TODO (Yutong, 04/26): For the D-FINE loss, also expose ``pred_corners``,
-        # ``ref_points``, ``up``, and ``reg_scale`` here during training so that
-        # the FGL/DDF terms can be computed.
+            dn_out_corners, out_corners = torch.split(
+                out_corners, dn_meta["dn_num_split"], dim=2
+            )
+            dn_out_refs, out_refs = torch.split(
+                out_refs, dn_meta["dn_num_split"], dim=2
+            )
+
+        if self.training:
+            out = {
+                "pred_logits": out_logits[-1],
+                "pred_boxes": out_bboxes[-1],
+                "pred_corners": out_corners[-1],
+                "ref_points": out_refs[-1],
+                "up": self.up,
+                "reg_scale": self.reg_scale,
+            }
+        else:
+            out = {
+                "pred_logits": out_logits[-1],
+                "pred_boxes": out_bboxes[-1],
+            }
 
         if self.training and self.aux_loss:
-            # TODO (Yutong, 04/26): For the D-FINE loss, ``aux_outputs`` / ``dn_outputs`` should
-            # be built with ``_set_aux_loss2`` to also carry ``pred_corners``,
-            # ``ref_points`` and the last-layer teacher distributions
-            # (``teacher_corners`` / ``teacher_logits``) used by the DDF
-            # distillation term. The ``pre_outputs`` / ``dn_pre_outputs`` dicts
-            # (from ``_pre_bboxes`` / ``_pre_logits``) are also missing.
-            out["aux_outputs"] = self._set_aux_loss(out_logits[:-1], out_bboxes[:-1])
+            out["aux_outputs"] = self._set_aux_loss2(
+                out_logits[:-1],
+                out_bboxes[:-1],
+                out_corners[:-1],
+                out_refs[:-1],
+                out_corners[-1],
+                out_logits[-1],
+            )
             out["enc_aux_outputs"] = self._set_aux_loss(
                 enc_topk_logits_list, enc_topk_bboxes_list
             )
+            out["pre_outputs"] = {"pred_logits": pre_logits, "pred_boxes": pre_bboxes}
             out["enc_meta"] = {"class_agnostic": self.query_select_method == "agnostic"}
 
             if dn_meta is not None:
-                out["dn_aux_outputs"] = self._set_aux_loss(dn_out_logits, dn_out_bboxes)
+                out["dn_outputs"] = self._set_aux_loss2(
+                    dn_out_logits,
+                    dn_out_bboxes,
+                    dn_out_corners,
+                    dn_out_refs,
+                    dn_out_corners[-1],
+                    dn_out_logits[-1],
+                )
+                out["dn_pre_outputs"] = {
+                    "pred_logits": dn_pre_logits,
+                    "pred_boxes": dn_pre_bboxes,
+                }
                 out["dn_meta"] = dn_meta
 
         return out
@@ -1055,9 +1084,29 @@ class DFINETransformer(nn.Module):
             for a, b in zip(outputs_class, outputs_coord)
         ]
 
-
-# TODO (Yutong, 04/26):
-# Replace the ``_set_aux_loss`` call for ``aux_outputs`` / ``dn_outputs``
-#     with the ``_set_aux_loss2`` variant that forwards ``out_corners``,
-#     ``out_refs``, and the last-layer ``teacher_corners``/``teacher_logits``
-#     used for self-distillation (DDF).
+    @torch.jit.unused
+    def _set_aux_loss2(
+        self,
+        outputs_class,
+        outputs_coord,
+        outputs_corners,
+        outputs_ref,
+        teacher_corners=None,
+        teacher_logits=None,
+    ):
+        # this is a workaround to make torchscript happy, as torchscript
+        # doesn't support dictionary with non-homogeneous values, such
+        # as a dict having both a Tensor and a list.
+        return [
+            {
+                "pred_logits": a,
+                "pred_boxes": b,
+                "pred_corners": c,
+                "ref_points": d,
+                "teacher_corners": teacher_corners,
+                "teacher_logits": teacher_logits,
+            }
+            for a, b, c, d in zip(
+                outputs_class, outputs_coord, outputs_corners, outputs_ref
+            )
+        ]

--- a/src/lightly_train/_task_models/object_detection_components/dfine_utils.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_utils.py
@@ -12,6 +12,9 @@
 # limitations under the License.#
 """Copyright (c) 2024 The D-FINE Authors. All Rights Reserved."""
 
+# Modifications Copyright 2026 Lightly AG:
+#  - Added type annotations.
+
 from __future__ import annotations
 
 import torch
@@ -59,6 +62,66 @@ def weighting_function(
     return torch.cat(values, 0)
 
 
+def translate_gt(
+    gt: Tensor, reg_max: int, reg_scale: Tensor, up: Tensor
+) -> tuple[Tensor, Tensor, Tensor]:
+    """
+    Decodes bounding box ground truth (GT) values into distribution-based GT representations.
+
+    This function maps continuous GT values into discrete distribution bins, which can be used
+    for regression tasks in object detection models. It calculates the indices of the closest
+    bins to each GT value and assigns interpolation weights to these bins based on their proximity
+    to the GT value.
+
+    Args:
+        gt (Tensor): Ground truth bounding box values, shape (N, ).
+        reg_max (int): Maximum number of discrete bins for the distribution.
+        reg_scale (float): Controls the curvature of the Weighting Function.
+        up (Tensor): Controls the upper bounds of the Weighting Function.
+
+    Returns:
+        Tuple[Tensor, Tensor, Tensor]:
+            - indices (Tensor): Index of the left bin closest to each GT value, shape (N, ).
+            - weight_right (Tensor): Weight assigned to the right bin, shape (N, ).
+            - weight_left (Tensor): Weight assigned to the left bin, shape (N, ).
+    """
+    gt = gt.reshape(-1)
+    function_values = weighting_function(reg_max, up, reg_scale)
+
+    diffs = function_values.unsqueeze(0) - gt.unsqueeze(1)
+    mask = diffs <= 0
+    closest_left_indices = torch.sum(mask, dim=1) - 1
+
+    indices = closest_left_indices.float()
+
+    weight_right = torch.zeros_like(indices)
+    weight_left = torch.zeros_like(indices)
+
+    valid_idx_mask = (indices >= 0) & (indices < reg_max)
+    valid_indices = indices[valid_idx_mask].long()
+
+    left_values = function_values[valid_indices]
+    right_values = function_values[valid_indices + 1]
+
+    left_diffs = torch.abs(gt[valid_idx_mask] - left_values)
+    right_diffs = torch.abs(right_values - gt[valid_idx_mask])
+
+    weight_right[valid_idx_mask] = left_diffs / (left_diffs + right_diffs)
+    weight_left[valid_idx_mask] = 1.0 - weight_right[valid_idx_mask]
+
+    invalid_idx_mask_neg = indices < 0
+    weight_right[invalid_idx_mask_neg] = 0.0
+    weight_left[invalid_idx_mask_neg] = 1.0
+    indices[invalid_idx_mask_neg] = 0.0
+
+    invalid_idx_mask_pos = indices >= reg_max
+    weight_right[invalid_idx_mask_pos] = 1.0
+    weight_left[invalid_idx_mask_pos] = 0.0
+    indices[invalid_idx_mask_pos] = reg_max - 0.1
+
+    return indices, weight_right, weight_left
+
+
 def distance2bbox(points: Tensor, distance: Tensor, reg_scale: Tensor) -> Tensor:
     """Decode D-FINE edge distances into ``cxcywh`` boxes."""
     reg_scale = abs(reg_scale)
@@ -77,3 +140,47 @@ def distance2bbox(points: Tensor, distance: Tensor, reg_scale: Tensor) -> Tensor
 
     bboxes = torch.stack([x1, y1, x2, y2], -1)
     return box_xyxy_to_cxcywh(bboxes)
+
+
+def bbox2distance(
+    points: Tensor,
+    bbox: Tensor,
+    reg_max: int,
+    reg_scale: Tensor,
+    up: Tensor,
+    eps: float = 0.1,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """
+    Converts bounding box coordinates to distances from a reference point.
+
+    Args:
+        points (Tensor): (n, 4) [x, y, w, h], where (x, y) is the center.
+        bbox (Tensor): (n, 4) bounding boxes in "xyxy" format.
+        reg_max (float): Maximum bin value.
+        reg_scale (float): Controling curvarture of W(n).
+        up (Tensor): Controling upper bounds of W(n).
+        eps (float): Small value to ensure target < reg_max.
+
+    Returns:
+        Tensor: Decoded distances.
+    """
+    reg_scale = abs(reg_scale)
+    left = (points[:, 0] - bbox[:, 0]) / (
+        points[..., 2] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    top = (points[:, 1] - bbox[:, 1]) / (
+        points[..., 3] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    right = (bbox[:, 2] - points[:, 0]) / (
+        points[..., 2] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    bottom = (bbox[:, 3] - points[:, 1]) / (
+        points[..., 3] / reg_scale + 1e-16
+    ) - 0.5 * reg_scale
+    four_lens = torch.stack([left, top, right, bottom], -1)
+    four_lens, weight_right, weight_left = translate_gt(
+        four_lens, reg_max, reg_scale, up
+    )
+    if reg_max is not None:
+        four_lens = four_lens.clamp(min=0, max=reg_max - eps)
+    return four_lens.reshape(-1).detach(), weight_right.detach(), weight_left.detach()

--- a/src/lightly_train/_task_models/object_detection_components/dist_utils.py
+++ b/src/lightly_train/_task_models/object_detection_components/dist_utils.py
@@ -1,0 +1,29 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+"""
+reference
+- https://github.com/pytorch/vision/blob/main/references/detection/utils.py
+- https://github.com/facebookresearch/detr/blob/master/util/misc.py#L406
+
+Copyright(c) 2023 lyuwenyu. All Rights Reserved.
+"""
+
+import torch
+
+
+def is_dist_available_and_initialized():
+    if not torch.distributed.is_available():
+        return False
+    if not torch.distributed.is_initialized():
+        return False
+    return True

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_criterion.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_criterion.py
@@ -12,6 +12,9 @@
 # limitations under the License.#
 """Copyright(c) 2023 lyuwenyu. All Rights Reserved."""
 
+# Modifications Copyright 2026 Lightly AG:
+# - Introduce sanitize_boxes_cxcywh_normalized function to ensure boxes are in the expected format
+
 import copy
 
 import torch
@@ -26,14 +29,9 @@ from lightly_train._task_models.object_detection_components.box_ops import (
     generalized_box_iou,
     sanitize_boxes_cxcywh_normalized,
 )
-
-
-def is_dist_available_and_initialized():
-    if not torch.distributed.is_available():
-        return False
-    if not torch.distributed.is_initialized():
-        return False
-    return True
+from lightly_train._task_models.object_detection_components.dist_utils import (
+    is_dist_available_and_initialized,
+)
 
 
 class RTDETRCriterionv2(nn.Module):


### PR DESCRIPTION
## What has changed and why?

Add D-FINE losses based on the [original implementation](https://github.com/Peterande/D-FINE/blob/master/src/zoo/dfine/dfine_criterion.py). Meanwhile, we retain backward compatibility with using the old RTDETRv2 losses if the decoder is configured to "rtdetrv2".

Major changes include (based on D-FINE paper):
- Applying Fine-grained Localization (FGL) Loss
- Applying Decoupled Distillation Focal (DDF) Loss

The `dfine_criterion.py`, `dfine_utils.py`, and `dist_utils.py` are mostly carbon copies of the original except for:
 - Removing upstream registry hooks and adapted imports for LightlyTrain.
 - Adding explicit ``world_size`` forwarding for LightlyTrain's Fabric training loop.
 - Supporting validation-time loss computation when auxiliary outputs are absent.
 - Adding FP32 guards around bbox refinement for stability in mixed precision.

Note that currently the default decoder is the original RTDETRv2 decoder. Will switch once we conclude the loss implementation and get proper results from benchmarks

## How has it been tested?

- Manually

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (in a separate issue)
