### PR TITLE
Fix default font loading to handle TypeError gracefully

### DIFF
--- a/src/lightly_train/_visualize/utils.py
+++ b/src/lightly_train/_visualize/utils.py
@@ -16,7 +16,10 @@ from PIL.Image import Image as PILImage
 from PIL.ImageDraw import ImageDraw as PILDraw
 from torch import Tensor
 
-_DEFAULT_FONT = ImageFont.load_default(size=20)
+try:
+    _DEFAULT_FONT = ImageFont.load_default(size=20)
+except TypeError:
+    _DEFAULT_FONT = ImageFont.load_default()
 
 
 def _draw_bbox_label(


### PR DESCRIPTION
## What has changed and why?

- `ImageFont.load_default(size=20)` raises `TypeError` on Pillow < 10.1.0 because
  the `size` keyword argument was not available in older versions
- Wrapped the call in a `try/except TypeError` so older Pillow installations fall
  back to `ImageFont.load_default()` (the built-in bitmap font at default size)
## How has it been tested?


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
