### PR TITLE
Fix pre-commit bug due to nbdev version.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       description: "Avoid committing large files."
       args: ["--maxkb=2000", "--enforce-all"]
  - repo: https://github.com/fastai/nbdev
-   rev: 3.0.10
+   rev: 3.0.15
    hooks:
     - id: nbdev-clean
       args: [--fname=examples]


### PR DESCRIPTION
## What has changed and why?

I have updated the version of the pre-commit to a newer version due to an import error in the version `3.0.10`.

```
nbdev-clean..............................................................Failed
hook id: nbdev-clean
exit code: 1
Traceback (most recent call last):
File "/Users/gabrielfruet/.cache/pre-commit/repomydsl8om/py_env-python3.13/bin/nbdev-clean", line 3, in <module>
from nbdev.clean import nbdev_clean
File "/Users/gabrielfruet/.cache/pre-commit/repomydsl8om/py_env-python3.13/lib/python3.13/site-packages/nbdev/init.py", line 3, in <module>
from .doclinks import nbdev_export
File "/Users/gabrielfruet/.cache/pre-commit/repomydsl8om/py_env-python3.13/lib/python3.13/site-packages/nbdev/doclinks.py", line 9, in <module>
from .config import *
File "/Users/gabrielfruet/.cache/pre-commit/repomydsl8om/py_env-python3.13/lib/python3.13/site-packages/nbdev/config.py", line 21, in <module>
from execnb.nbio import read_nb,NbCell
ModuleNotFoundError: No module named 'execnb.nbio'
```

## How has it been tested?

Locally I ran the pre-commit and it worked. 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
