### PR TITLE
Fix DINOv3 patch size precedence

### DIFF
--- a/docs/source/pretrain_distill/models/dinov3.md
+++ b/docs/source/pretrain_distill/models/dinov3.md
@@ -117,7 +117,8 @@ distillation from DINOv3 ViT-L/16.
 For ViT models, the patch size is encoded in the model name by default (for example,
 `vitt16` or `vits16`). You can still override it via `model_args["patch_size"]` when
 loading the model. If you provide `model_args["patch_size"]` for a ViT model whose name
-already encodes a patch size, LightlyTrain will log a warning.
+already encodes a patch size, LightlyTrain will log a warning. See the
+[Training Settings](#train-settings) page for details.
 
 ### ConvNeXt Models
 

--- a/docs/source/pretrain_distill/models/dinov3.md
+++ b/docs/source/pretrain_distill/models/dinov3.md
@@ -114,6 +114,11 @@ distillation from DINOv3 ViT-L/16.
   - `dinov3/vit7b16` (LVD-1689M)
   - `dinov3/vit7b16-sat493m` (SAT-493M)
 
+For ViT models, the patch size is encoded in the model name by default (for example,
+`vitt16` or `vits16`). You can still override it via `model_args["patch_size"]` when
+loading the model, and LightlyTrain will log a warning if the override differs from the
+name.
+
 ### ConvNeXt Models
 
 The following ConvNeXt models are supported. All are

--- a/docs/source/pretrain_distill/models/dinov3.md
+++ b/docs/source/pretrain_distill/models/dinov3.md
@@ -116,8 +116,8 @@ distillation from DINOv3 ViT-L/16.
 
 For ViT models, the patch size is encoded in the model name by default (for example,
 `vitt16` or `vits16`). You can still override it via `model_args["patch_size"]` when
-loading the model, and LightlyTrain will log a warning if the override differs from the
-name.
+loading the model. If you provide `model_args["patch_size"]` for a ViT model whose name
+already encodes a patch size, LightlyTrain will log a warning.
 
 ### ConvNeXt Models
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -223,9 +223,11 @@ if __name__ == "__main__":
 ```
 
 As shown above, the patch size can be set to a value different from the one used in the
-pretrained model without harming compatibility of the pretrained weights. Internally,
-the patch embedding weights are automatically resized to the requested patch size using
-the method introduced in [FlexiViT](https://arxiv.org/pdf/2212.08013).
+pretrained model without harming compatibility of the pretrained weights. For DINOv3 ViT
+models, the patch size encoded in the model name is just the default; `model_args["patch_size"]`
+overrides it and LightlyTrain logs a warning if they differ. Internally, the patch
+embedding weights are automatically resized to the requested patch size using the method
+introduced in [FlexiViT](https://arxiv.org/pdf/2212.08013).
 
 As illustrated in this {ref}`figure <fig-miou-latency>`, increasing the patch size leads
 to a significant speed-up with only a moderate impact on performance.

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -224,10 +224,10 @@ if __name__ == "__main__":
 
 As shown above, the patch size can be set to a value different from the one used in the
 pretrained model without harming compatibility of the pretrained weights. For DINOv3 ViT
-models, the patch size encoded in the model name is just the default; `model_args["patch_size"]`
-overrides it and LightlyTrain logs a warning if they differ. Internally, the patch
-embedding weights are automatically resized to the requested patch size using the method
-introduced in [FlexiViT](https://arxiv.org/pdf/2212.08013).
+models, the patch size encoded in the model name is just the default;
+`model_args["patch_size"]` overrides it and LightlyTrain logs a warning if they differ.
+Internally, the patch embedding weights are automatically resized to the requested patch
+size using the method introduced in [FlexiViT](https://arxiv.org/pdf/2212.08013).
 
 As illustrated in this {ref}`figure <fig-miou-latency>`, increasing the patch size leads
 to a significant speed-up with only a moderate impact on performance.

--- a/docs/source/settings/train_settings.md
+++ b/docs/source/settings/train_settings.md
@@ -102,12 +102,11 @@ restored correctly.
 Dictionary with model-specific training parameters. The available keys vary by
 architecture. The table lists the most commonly tuned options:
 
-| Key                                             | Type                      | Description                                                                   |
-| ----------------------------------------------- | ------------------------- | ----------------------------------------------------------------------------- |
-| [`lr`](#lr)                                     | `float`                   | Base learning rate.                                                           |
-| [`backbone_weights`](#backbone_weights)         | `Path`<br>`str`<br>`None` | Path to backbone weights to load.                                             |
-| [`metric_log_classwise`](#metric_log_classwise) | `bool`                    | Whether to log class-wise metrics.                                            |
-| [`patch_size`](#patch_size)                     | `int`                     | DINOv3 ViT default from model name; overridden by `model_args["patch_size"]`. |
+| Key                                             | Type                      | Description                        |
+| ----------------------------------------------- | ------------------------- | ---------------------------------- |
+| [`lr`](#lr)                                     | `float`                   | Base learning rate.                |
+| [`backbone_weights`](#backbone_weights)         | `Path`<br>`str`<br>`None` | Path to backbone weights to load.  |
+| [`metric_log_classwise`](#metric_log_classwise) | `bool`                    | Whether to log class-wise metrics. |
 
 #### `lr`
 
@@ -195,12 +194,6 @@ lightly_train.train_object_detection(
     },
 )
 ```
-
-#### `patch_size`
-
-DINOv3 ViT models encode a default patch size in the model name (for example, `vitt16`).
-You can override it with `model_args["patch_size"]`; LightlyTrain will log a warning if
-the value differs from the name.
 
 (train-settings-training-loop)=
 

--- a/docs/source/settings/train_settings.md
+++ b/docs/source/settings/train_settings.md
@@ -102,11 +102,11 @@ restored correctly.
 Dictionary with model-specific training parameters. The available keys vary by
 architecture. The table lists the most commonly tuned options:
 
-| Key                                             | Type                      | Description                        |
-| ----------------------------------------------- | ------------------------- | ---------------------------------- |
-| [`lr`](#lr)                                     | `float`                   | Base learning rate.                |
-| [`backbone_weights`](#backbone_weights)         | `Path`<br>`str`<br>`None` | Path to backbone weights to load.  |
-| [`metric_log_classwise`](#metric_log_classwise) | `bool`                    | Whether to log class-wise metrics. |
+| Key                                             | Type                      | Description                                                                   |
+| ----------------------------------------------- | ------------------------- | ----------------------------------------------------------------------------- |
+| [`lr`](#lr)                                     | `float`                   | Base learning rate.                                                           |
+| [`backbone_weights`](#backbone_weights)         | `Path`<br>`str`<br>`None` | Path to backbone weights to load.                                             |
+| [`metric_log_classwise`](#metric_log_classwise) | `bool`                    | Whether to log class-wise metrics.                                            |
 | [`patch_size`](#patch_size)                     | `int`                     | DINOv3 ViT default from model name; overridden by `model_args["patch_size"]`. |
 
 #### `lr`

--- a/docs/source/settings/train_settings.md
+++ b/docs/source/settings/train_settings.md
@@ -196,6 +196,13 @@ lightly_train.train_object_detection(
 )
 ```
 
+#### `patch_size`
+
+DINOv3 ViT models encode a default patch size in the model name (for example,
+`vitt16`). You can override it with `model_args["patch_size"]`; LightlyTrain will log a
+warning if the value differs from the name.
+
+
 (train-settings-training-loop)=
 
 ## Training Loop

--- a/docs/source/settings/train_settings.md
+++ b/docs/source/settings/train_settings.md
@@ -107,6 +107,7 @@ architecture. The table lists the most commonly tuned options:
 | [`lr`](#lr)                                     | `float`                   | Base learning rate.                |
 | [`backbone_weights`](#backbone_weights)         | `Path`<br>`str`<br>`None` | Path to backbone weights to load.  |
 | [`metric_log_classwise`](#metric_log_classwise) | `bool`                    | Whether to log class-wise metrics. |
+| [`patch_size`](#patch_size)                     | `int`                     | DINOv3 ViT default from model name; overridden by `model_args["patch_size"]`. |
 
 #### `lr`
 

--- a/docs/source/settings/train_settings.md
+++ b/docs/source/settings/train_settings.md
@@ -198,10 +198,9 @@ lightly_train.train_object_detection(
 
 #### `patch_size`
 
-DINOv3 ViT models encode a default patch size in the model name (for example,
-`vitt16`). You can override it with `model_args["patch_size"]`; LightlyTrain will log a
-warning if the value differs from the name.
-
+DINOv3 ViT models encode a default patch size in the model name (for example, `vitt16`).
+You can override it with `model_args["patch_size"]`; LightlyTrain will log a warning if
+the value differs from the name.
 
 (train-settings-training-loop)=
 

--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -296,8 +296,9 @@ class DINOv3Package(Package):
 
         # Update the patch size argument from the model_builder.
         # If patch_size is None the model is not a ViT and the patch_size must not be set.
-        if patch_size is not None:
+        if patch_size is not None and "patch_size" not in args:
             args["patch_size"] = int(patch_size)
+
         if (
             load_weights
             and ("weights" not in args)
@@ -305,11 +306,14 @@ class DINOv3Package(Package):
         ):
             weight_path = _maybe_download_weights(model_getter=model_info)
             args["weights"] = str(weight_path)
+
         if not load_weights:
             args["weights"] = None
             args["pretrained"] = False
+
         if load_weights and args.get("weights") is not None:
             args["pretrained"] = True
+
         model = model_builder(**args)
         assert isinstance(model, (DinoVisionTransformer, ConvNeXt))
         return model

--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -281,7 +281,8 @@ class DINOv3Package(Package):
         load_weights: bool = True,
     ) -> DinoVisionTransformer | ConvNeXt:
         """
-        Get a DINOv3 ViT model by name. Here the student version is build.
+        Get a DINOv3 model by name. Can be either a ConvNeXt or ViT.
+        Here the student version is build.
         """
         args: dict[str, Any] = {"in_chans": num_input_channels}
         if model_args is not None:

--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -298,11 +298,14 @@ class DINOv3Package(Package):
         # If patch_size is None the model is not a ViT and the patch_size should only be set if explicitly given.
         if patch_size is not None:
             if "patch_size" not in args:
-                args["patch_size"] = int(patch_size)
-            else:
+                args["patch_size"] = patch_size
+            elif int(args["patch_size"]) != int(patch_size):
                 logger.warning(
                     f"Patch size from model name {patch_size} got overwritten by patch size argument {args['patch_size']}"
                 )
+
+        if "patch_size" in args:
+            args["patch_size"] = int(args["patch_size"])
 
         if (
             load_weights

--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -295,9 +295,14 @@ class DINOv3Package(Package):
         model_builder = model_info["builder"]
 
         # Update the patch size argument from the model_builder.
-        # If patch_size is None the model is not a ViT and the patch_size must not be set.
-        if patch_size is not None and "patch_size" not in args:
-            args["patch_size"] = int(patch_size)
+        # If patch_size is None the model is not a ViT and the patch_size should only be set if explicitly given.
+        if patch_size is not None:
+            if "patch_size" not in args:
+                args["patch_size"] = int(patch_size)
+            else:
+                logger.warning(
+                    f"Patch size from model name {patch_size} got overwritten by patch size argument {args['patch_size']}"
+                )
 
         if (
             load_weights

--- a/tests/_models/dinov3/test_dinov3_package.py
+++ b/tests/_models/dinov3/test_dinov3_package.py
@@ -167,3 +167,15 @@ class TestDINOv3Package:
         # The log should show a format without the 'dinov3/' prefix
         assert "get_model('<XYZ>')" in log_output
         assert "get_model('dinov3/" not in log_output
+
+    @pytest.mark.parametrize(
+        "model_name, patch_size", [("vitt16", 41), ("convnext-tiny", 32)]
+    )
+    def test_get_model__patch_size_arg_gets_precedence_over_model_name(
+        self, model_name: str, patch_size: int
+    ) -> None:
+        model = DINOv3Package.get_model(
+            model_name, model_args={"patch_size": patch_size}
+        )
+
+        assert model.patch_size == patch_size

--- a/tests/_models/dinov3/test_dinov3_package.py
+++ b/tests/_models/dinov3/test_dinov3_package.py
@@ -168,7 +168,7 @@ class TestDINOv3Package:
         assert "get_model('<XYZ>')" in log_output
         assert "get_model('dinov3/" not in log_output
 
-    @pytest.mark.parametrize("model_name, patch_size", [("vitt16", 41), ("vitt32", 22)])
+    @pytest.mark.parametrize("model_name, patch_size", [("vitt16", 41), ("vitt32", 32)])
     def test_get_model__patch_size_arg_gets_precedence_over_model_name(
         self, model_name: str, patch_size: int
     ) -> None:

--- a/tests/_models/dinov3/test_dinov3_package.py
+++ b/tests/_models/dinov3/test_dinov3_package.py
@@ -175,7 +175,21 @@ class TestDINOv3Package:
         self, model_name: str, patch_size: int
     ) -> None:
         model = DINOv3Package.get_model(
-            model_name, model_args={"patch_size": patch_size}
+            model_name, model_args={"patch_size": patch_size}, load_weights=False
         )
 
         assert model.patch_size == patch_size
+
+    def test_get_model__patch_size_arg_overwrites_model_name_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING):
+            model = DINOv3Package.get_model(
+                "vitt16", model_args={"patch_size": 41}, load_weights=False
+            )
+
+        assert model.patch_size == 41
+        assert (
+            "Patch size from model name 16 got overwritten by patch size argument 41"
+            in caplog.text
+        )

--- a/tests/_models/dinov3/test_dinov3_package.py
+++ b/tests/_models/dinov3/test_dinov3_package.py
@@ -168,9 +168,7 @@ class TestDINOv3Package:
         assert "get_model('<XYZ>')" in log_output
         assert "get_model('dinov3/" not in log_output
 
-    @pytest.mark.parametrize(
-        "model_name, patch_size", [("vitt16", 41), ("convnext-tiny", 32)]
-    )
+    @pytest.mark.parametrize("model_name, patch_size", [("vitt16", 41), ("vitt32", 22)])
     def test_get_model__patch_size_arg_gets_precedence_over_model_name(
         self, model_name: str, patch_size: int
     ) -> None:


### PR DESCRIPTION
 ## What has changed and why?

 `DINOv3Package.get_model()` now respects an explicit `model_args["patch_size"]` over the patch size encoded in the model name.

 This fixes the case where passing `patch_size` to DINOv3 models was ineffective, which impacted consumers like DINOv3 EoMT semantic segmentation. When an
override happens, we now log a warning so the behavior is explicit.

 ## How has it been tested?

 - `pytest tests/_models/dinov3/test_dinov3_package.py -k patch_size -q`

 This covers:
 - explicit `patch_size` taking precedence
 - warning logging when the model-name patch size is overwritten

 ## Did you update [CHANGELOG.md](../CHANGELOG.md)?

 - [ ] Yes
 - [x] Not needed (internal change)

 ## Did you update the documentation?

 - [x] Yes
 - [] Not needed (internal change without effects for user)