### PR TITLE
Feat support variable patch size for DINOv3 LT-DETR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Configurable `patch_size` for DINOv3 LT-DETR models.
+
 ### Changed
 
 ### Deprecated

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -1340,6 +1340,15 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
             model_init_args=model_init_args,
             data_args=config.data,
         )
+        # TODO(Gabriel, 05/26): Split raw model_init_args from resolved
+        # model-dependent init args. For now we patch in values that transforms need,
+        # such as patch_size.
+        resolved_model_init_args = dict(model_init_args)
+        if hasattr(config.model_args, "patch_size"):
+            patch_size = getattr(config.model_args, "patch_size")
+            if patch_size not in (None, "auto"):
+                resolved_model_init_args["patch_size"] = patch_size
+
         config.metric_args = helpers.get_metric_args(
             train_model_cls=train_model_cls,
             metric_args=config.metric_args,
@@ -1377,7 +1386,7 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
             transform_args=config.transform_args,
             # TODO (Lionel, 10/25): Handle ignore_index properly for object detection.
             ignore_index=getattr(config.data, "ignore_index", None),
-            model_init_args=model_init_args,
+            model_init_args=resolved_model_init_args,
             total_steps=no_auto(config.steps),
             train_num_batches=len(train_dataloader),
             gradient_accumulation_steps=no_auto(config.gradient_accumulation_steps),

--- a/src/lightly_train/_models/dinov3/dinov3_package.py
+++ b/src/lightly_train/_models/dinov3/dinov3_package.py
@@ -30,6 +30,19 @@ from lightly_train._models.package import Package
 logger = logging.getLogger(__name__)
 
 
+def _resolve_patch_size(patch_size: str | None, args: dict[str, Any]) -> None:
+    if patch_size is not None:
+        if "patch_size" not in args or args["patch_size"] is None:
+            args["patch_size"] = int(patch_size)
+        elif int(args["patch_size"]) != int(patch_size):
+            logger.warning(
+                f"Patch size from model name {patch_size} got overwritten by patch size argument {args['patch_size']}"
+            )
+
+        if "patch_size" in args:
+            args["patch_size"] = int(args["patch_size"])
+
+
 class _DINOv3ModelInfo(TypedDict):
     builder: Callable[..., DinoVisionTransformer | ConvNeXt]
     default_weights: str | None
@@ -297,16 +310,7 @@ class DINOv3Package(Package):
 
         # Update the patch size argument from the model_builder.
         # If patch_size is None the model is not a ViT and the patch_size should only be set if explicitly given.
-        if patch_size is not None:
-            if "patch_size" not in args:
-                args["patch_size"] = patch_size
-            elif int(args["patch_size"]) != int(patch_size):
-                logger.warning(
-                    f"Patch size from model name {patch_size} got overwritten by patch size argument {args['patch_size']}"
-                )
-
-        if "patch_size" in args:
-            args["patch_size"] = int(args["patch_size"])
+        _resolve_patch_size(patch_size, args)
 
         if (
             load_weights

--- a/src/lightly_train/_models/rfdetr/rfdetr_package.py
+++ b/src/lightly_train/_models/rfdetr/rfdetr_package.py
@@ -35,8 +35,7 @@ class RFDETRPackage(Package):
     @classmethod
     def list_model_names(cls) -> list[str]:
         try:
-            # TODO (Gabriel, 05/26): Use OPEN_SOURCE_MODELS.
-            from rfdetr.main import HOSTED_MODELS  # type: ignore[attr-defined]
+            from rfdetr.main import HOSTED_MODELS
         except ImportError:
             return []
         # We use the model names from the checkpoint .pth filenames Roboflow provided
@@ -68,9 +67,7 @@ class RFDETRPackage(Package):
                 RFDETRSegPreview,
                 RFDETRSmall,
             )
-
-            # TODO (Gabriel, 05/26): Use OPEN_SOURCE_MODELS.
-            from rfdetr.main import HOSTED_MODELS  # type: ignore[attr-defined]
+            from rfdetr.main import HOSTED_MODELS
         except ImportError:
             raise ValueError(
                 f"Cannot create model '{model_name}' because rfdetr is not installed."

--- a/src/lightly_train/_models/rfdetr/rfdetr_package.py
+++ b/src/lightly_train/_models/rfdetr/rfdetr_package.py
@@ -68,7 +68,6 @@ class RFDETRPackage(Package):
                 RFDETRSegPreview,
                 RFDETRSmall,
             )
-
             # TODO (Gabriel, 05/26): Use OPEN_SOURCE_MODELS.
             from rfdetr.main import HOSTED_MODELS  # type: ignore[attr-defined]
         except ImportError:

--- a/src/lightly_train/_models/rfdetr/rfdetr_package.py
+++ b/src/lightly_train/_models/rfdetr/rfdetr_package.py
@@ -35,7 +35,8 @@ class RFDETRPackage(Package):
     @classmethod
     def list_model_names(cls) -> list[str]:
         try:
-            from rfdetr.main import HOSTED_MODELS
+            # TODO (Gabriel, 05/26): Use OPEN_SOURCE_MODELS.
+            from rfdetr.main import HOSTED_MODELS  # type: ignore[attr-defined]
         except ImportError:
             return []
         # We use the model names from the checkpoint .pth filenames Roboflow provided
@@ -67,7 +68,8 @@ class RFDETRPackage(Package):
                 RFDETRSegPreview,
                 RFDETRSmall,
             )
-            from rfdetr.main import HOSTED_MODELS
+            # TODO (Gabriel, 05/26): Use OPEN_SOURCE_MODELS.
+            from rfdetr.main import HOSTED_MODELS  # type: ignore[attr-defined]
         except ImportError:
             raise ValueError(
                 f"Cannot create model '{model_name}' because rfdetr is not installed."

--- a/src/lightly_train/_models/rfdetr/rfdetr_package.py
+++ b/src/lightly_train/_models/rfdetr/rfdetr_package.py
@@ -68,6 +68,7 @@ class RFDETRPackage(Package):
                 RFDETRSegPreview,
                 RFDETRSmall,
             )
+
             # TODO (Gabriel, 05/26): Use OPEN_SOURCE_MODELS.
             from rfdetr.main import HOSTED_MODELS  # type: ignore[attr-defined]
         except ImportError:

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/dinov3_convnext_wrapper.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/dinov3_convnext_wrapper.py
@@ -17,6 +17,7 @@ class DINOv3ConvNextWrapper(Module):
     def __init__(self, model: ConvNeXt) -> None:
         super().__init__()
         self.backbone = model
+        self.patch_size = model.patch_size
 
     def forward(self, x: Tensor) -> tuple[Tensor, ...]:
         feats = self.backbone.get_intermediate_layers(x, n=3, reshape=True)

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/dinov3_vit_wrapper.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/dinov3_vit_wrapper.py
@@ -230,8 +230,22 @@ class DINOv3STAs(Module):
         fused_feats = []
         if self.use_sta:
             detail_feats = self.sta(x)
-            for sem_feat, detail_feat in zip(sem_feats_t, detail_feats):
-                fused_feats.append(torch.cat([sem_feat, detail_feat], dim=1))
+            for semantic_feat, detail_feat in zip(sem_feats_t, detail_feats):
+                detail_feat_interpolated = F.interpolate(
+                    detail_feat,
+                    size=semantic_feat.shape[-2:],
+                    mode="bilinear",
+                    align_corners=False,
+                )
+                fused_feats.append(
+                    torch.cat(
+                        [
+                            semantic_feat,
+                            detail_feat_interpolated,
+                        ],
+                        dim=1,
+                    )
+                )
         else:
             fused_feats = sem_feats_t
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -220,7 +220,8 @@ class _RTDETRTransformerv2Config(PydanticConfig):
     eval_idx: int = -1
     num_points: list[int] = [4, 4, 4]
 
-    def resolve_auto(self, patch_size: int) -> None:
+    def resolve_auto(self, patch_size: int | None) -> None:
+        patch_size = patch_size or 16
         if self.feat_strides == "auto":
             self.feat_strides = [
                 int(patch_size * (2 ** (i - 1))) for i in range(self.num_levels)
@@ -404,7 +405,7 @@ class _DINOv3LTDETRObjectDetectionConfig(PydanticConfig):
     dfine_transformer: _DFINETransformerConfig
     rtdetr_postprocessor: _RTDETRPostProcessorConfig
 
-    def resolve_auto(self, patch_size: int) -> None:
+    def resolve_auto(self, patch_size: int | None) -> None:
         self.rtdetr_transformer.resolve_auto(patch_size=patch_size)
 
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -449,12 +449,38 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         model_name: str,
         classes: dict[int, str],
         image_size: tuple[int, int],
+        patch_size: int,
         image_normalize: dict[str, Any] | None = None,
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,
         backbone_args: dict[str, Any] | None = None,
         load_weights: bool = True,
     ) -> None:
+        """Create a DINOv3 LTDETR object detection model.
+
+        Args:
+            model_name:
+                The model name. For example ``"vitt16-ltdetr"``.
+            classes:
+                A dict mapping class IDs to class names.
+            image_size:
+                The input image size.
+            patch_size:
+                Patch size used to initialize the DINOv3 backbone. This is stored in
+                ``init_args`` so exported checkpoints can be reconstructed with the
+                same backbone patch size.
+            image_normalize:
+                A dict containing normalization statistics with the keys ``"mean"``
+                and ``"std"``.
+            backbone_freeze:
+                Whether to freeze the backbone during training.
+            backbone_weights:
+                Path to the DINOv3 backbone weights.
+            backbone_args:
+                Additional arguments to pass to the DINOv3 backbone.
+            load_weights:
+                If False, then no pretrained weights are loaded.
+        """
         super().__init__(init_args=locals(), ignore_args={"load_weights"})
         parsed_name = self.parse_model_name(model_name=model_name)
 
@@ -480,7 +506,9 @@ class DINOv3LTDETRObjectDetection(TaskModel):
 
         # NOTE(Guarin, 08/25): We don't set drop_path_rate=0 here because it is already
         # set by DINOv3.
-        backbone_model_args: dict[str, Any] = {}
+        backbone_model_args: dict[str, Any] = {
+            "patch_size": patch_size,
+        }
         if backbone_args is not None:
             backbone_model_args.update(backbone_args)
         if backbone_weights is not None:

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -204,7 +204,7 @@ class _HybridEncoderViTLConfig(_HybridEncoderConfig):
 
 class _RTDETRTransformerv2Config(PydanticConfig):
     feat_channels: list[int] = [256, 256, 256]
-    feat_strides: list[int] = [8, 16, 32]
+    feat_strides: list[int] | Literal["auto"] = "auto"
     hidden_dim: int = 256
     num_levels: int = 3
     num_layers: int = 6
@@ -214,6 +214,12 @@ class _RTDETRTransformerv2Config(PydanticConfig):
     box_noise_scale: float = 1.0
     eval_idx: int = -1
     num_points: list[int] = [4, 4, 4]
+
+    def resolve_auto(self, patch_size: int):
+        if self.feat_strides == "auto":
+            self.feat_strides = [
+                int(patch_size * (2 ** (i - 1))) for i in range(self.num_levels)
+            ]
 
 
 class _RTDETRTransformerv2TinyConfig(_RTDETRTransformerv2Config):
@@ -315,6 +321,9 @@ class _DINOv3LTDETRObjectDetectionConfig(PydanticConfig):
     hybrid_encoder: _HybridEncoderConfig
     rtdetr_transformer: _RTDETRTransformerv2Config
     rtdetr_postprocessor: _RTDETRPostProcessorConfig
+
+    def resolve_auto(self, patch_size: int):
+        self.rtdetr_transformer.resolve_auto(patch_size=patch_size)
 
 
 class _DINOv3LTDETRObjectDetectionLargeConfig(_DINOv3LTDETRObjectDetectionConfig):
@@ -555,6 +564,8 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         config_name = config_name.replace("-eupe", "")
         config_cls, wrapper_cls = config_mapping[config_name]
         config = config_cls()
+
+        config.resolve_auto(patch_size=patch_size)
 
         if hasattr(config, "backbone_wrapper"):
             # TODO(Guarin, 02/26): Improve how mask tokens are handled for fine-tuning.

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -458,7 +458,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         model_name: str,
         classes: dict[int, str],
         image_size: tuple[int, int],
-        patch_size: int,
+        patch_size: int | None = None,
         image_normalize: dict[str, Any] | None = None,
         backbone_freeze: bool = False,
         backbone_weights: PathLike | None = None,

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -215,7 +215,7 @@ class _RTDETRTransformerv2Config(PydanticConfig):
     eval_idx: int = -1
     num_points: list[int] = [4, 4, 4]
 
-    def resolve_auto(self, patch_size: int):
+    def resolve_auto(self, patch_size: int) -> None:
         if self.feat_strides == "auto":
             self.feat_strides = [
                 int(patch_size * (2 ** (i - 1))) for i in range(self.num_levels)
@@ -322,7 +322,7 @@ class _DINOv3LTDETRObjectDetectionConfig(PydanticConfig):
     rtdetr_transformer: _RTDETRTransformerv2Config
     rtdetr_postprocessor: _RTDETRPostProcessorConfig
 
-    def resolve_auto(self, patch_size: int):
+    def resolve_auto(self, patch_size: int) -> None:
         self.rtdetr_transformer.resolve_auto(patch_size=patch_size)
 
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -171,14 +171,14 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
         self.model_args = model_args
         self.data_args = data_args
 
-        model_args_backbone_args_copy: dict[str, Any] = copy.deepcopy(
-            model_args.backbone_args
+        parsed_name = DINOv3LTDETRObjectDetection.parse_model_name(
+            model_name=model_name
         )
-        if isinstance(model_args.patch_size, int):
-            model_args_backbone_args_copy["patch_size"] = model_args.patch_size
-
-        backbone_args: dict[str, Any] | None = model_args_backbone_args_copy
-
+        backbone_args: dict[str, Any] | None = copy.deepcopy(model_args.backbone_args)
+        if backbone_args is not None and parsed_name["backbone_name"].startswith("vit") and isinstance(
+            model_args.patch_size, int
+        ):
+            backbone_args["patch_size"] = model_args.patch_size
         if not backbone_args:
             backbone_args = None
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import math
 import re
 from typing import Any, ClassVar, Literal
@@ -67,6 +68,9 @@ from lightly_train._task_models.train_model import (
 from lightly_train._torch_compile import TorchCompileArgs
 from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
+
+
+logger = logging.getLogger(__name__)
 
 
 class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
@@ -175,10 +179,19 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             model_name=model_name
         )
         backbone_args: dict[str, Any] | None = copy.deepcopy(model_args.backbone_args)
-        if backbone_args is not None and parsed_name["backbone_name"].startswith("vit") and isinstance(
-            model_args.patch_size, int
-        ):
-            backbone_args["patch_size"] = model_args.patch_size
+        if isinstance(model_args.patch_size, int):
+            if parsed_name["backbone_name"].startswith("vit"):
+                if backbone_args is None:
+                    backbone_args = {}
+                backbone_args["patch_size"] = model_args.patch_size
+            else:
+                logger.warning(
+                    "Ignoring top-level `patch_size=%s` for non-ViT backbone '%s'. "
+                    "Set `model_args.backbone_args['patch_size']` instead.",
+                    model_args.patch_size,
+                    parsed_name["backbone_name"],
+                )
+
         if not backbone_args:
             backbone_args = None
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -176,6 +176,7 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
                         "Unable to resolve patch_size='auto' for model "
                         f"{model_name!r}. Please provide a concrete patch_size."
                     )
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def effective_loss_weight_dict(self) -> dict[str, float]:

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -171,13 +171,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
         self.model_args = model_args
         self.data_args = data_args
 
-        model_args_backbone_args_copy: dict[str, Any] = copy.deepcopy(
-            model_args.backbone_args
-        )
-        if isinstance(model_args.patch_size, int):
-            model_args_backbone_args_copy["patch_size"] = model_args.patch_size
-
-        backbone_args: dict[str, Any] | None = model_args_backbone_args_copy
+        backbone_args: dict[str, Any] | None = model_args.backbone_args
 
         if not backbone_args:
             backbone_args = None
@@ -199,6 +193,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             image_normalize=normalize_dict,
             backbone_freeze=model_args.backbone_freeze,
             backbone_args=backbone_args,
+            patch_size=no_auto(model_args.patch_size),
             backbone_weights=model_args.backbone_weights,
             load_weights=load_weights,
         )

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import copy
 import math
-from typing import Any, ClassVar
+import re
+from typing import Any, ClassVar, Literal
 
 import torch
 from lightning_fabric import Fabric
@@ -24,6 +25,7 @@ from torch.optim.lr_scheduler import (  # type: ignore[attr-defined]
 )
 
 from lightly_train._configs.validate import no_auto
+from lightly_train._data.task_data_args import TaskDataArgs
 from lightly_train._data.yolo_object_detection_dataset import (
     YOLOObjectDetectionDataArgs,
 )
@@ -76,6 +78,7 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     backbone_weights: PathLike | None = None
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
+    patch_size: int | Literal["auto"] = "auto"
     backbone_freeze: bool = False
 
     use_ema_model: bool = True
@@ -122,6 +125,25 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
         validation_alias=AliasChoices("lr_warmup_steps", "scheduler_warmup_steps"),
     )
 
+    def resolve_auto(
+        self,
+        total_steps: int,
+        model_name: str,
+        model_init_args: dict[str, Any],
+        data_args: TaskDataArgs,
+    ) -> None:
+        if self.patch_size == "auto":
+            patch_size = model_init_args.get("patch_size", None)
+            if patch_size is not None:
+                self.patch_size = int(patch_size)
+            else:
+                match = re.match(
+                    r"dinov3/(?P<model_size>vit(t|s|l|b|g|h|7b))(?P<patch_size>\d+).*",
+                    model_name,
+                )
+                if match is not None:
+                    self.patch_size = int(match.group("patch_size"))
+
 
 class DINOv3LTDETRObjectDetectionTrain(TrainModel):
     task = "object_detection"
@@ -149,6 +171,17 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
         self.model_args = model_args
         self.data_args = data_args
 
+        parsed_name = DINOv3LTDETRObjectDetection.parse_model_name(
+            model_name=model_name
+        )
+        backbone_args: dict[str, Any] | None = copy.deepcopy(model_args.backbone_args)
+        if backbone_args is not None and parsed_name["backbone_name"].startswith("vit") and isinstance(
+            model_args.patch_size, int
+        ):
+            backbone_args["patch_size"] = model_args.patch_size
+        if not backbone_args:
+            backbone_args = None
+
         # Get the normalization.
         normalize = no_auto(val_transform_args.normalize)
         normalize_dict: dict[str, Any] | None
@@ -165,7 +198,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             classes=data_args.included_classes,
             image_normalize=normalize_dict,
             backbone_freeze=model_args.backbone_freeze,
-            backbone_args=model_args.backbone_args,  # TODO (Lionel, 10/25): Potentially remove in accordance with EoMT.
+            backbone_args=backbone_args,
             backbone_weights=model_args.backbone_weights,
             load_weights=load_weights,
         )

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 import math
 import re
 from typing import Any, ClassVar, Literal
@@ -68,8 +67,6 @@ from lightly_train._task_models.train_model import (
 from lightly_train._torch_compile import TorchCompileArgs
 from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
-
-logger = logging.getLogger(__name__)
 
 
 class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
@@ -174,22 +171,11 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
         self.model_args = model_args
         self.data_args = data_args
 
-        parsed_name = DINOv3LTDETRObjectDetection.parse_model_name(
-            model_name=model_name
-        )
         model_args_backbone_args_copy: dict[str, Any] = copy.deepcopy(
             model_args.backbone_args
         )
         if isinstance(model_args.patch_size, int):
-            if parsed_name["backbone_name"].startswith("vit"):
-                model_args_backbone_args_copy["patch_size"] = model_args.patch_size
-            else:
-                logger.warning(
-                    "Ignoring top-level `patch_size=%s` for non-ViT backbone '%s'. "
-                    "Set `model_args.backbone_args['patch_size']` instead.",
-                    model_args.patch_size,
-                    parsed_name["backbone_name"],
-                )
+            model_args_backbone_args_copy["patch_size"] = model_args.patch_size
 
         backbone_args: dict[str, Any] | None = model_args_backbone_args_copy
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -69,7 +69,6 @@ from lightly_train._torch_compile import TorchCompileArgs
 from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -178,12 +177,12 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
         parsed_name = DINOv3LTDETRObjectDetection.parse_model_name(
             model_name=model_name
         )
-        backbone_args: dict[str, Any] | None = copy.deepcopy(model_args.backbone_args)
+        model_args_backbone_args_copy: dict[str, Any] = copy.deepcopy(
+            model_args.backbone_args
+        )
         if isinstance(model_args.patch_size, int):
             if parsed_name["backbone_name"].startswith("vit"):
-                if backbone_args is None:
-                    backbone_args = {}
-                backbone_args["patch_size"] = model_args.patch_size
+                model_args_backbone_args_copy["patch_size"] = model_args.patch_size
             else:
                 logger.warning(
                     "Ignoring top-level `patch_size=%s` for non-ViT backbone '%s'. "
@@ -191,6 +190,8 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
                     model_args.patch_size,
                     parsed_name["backbone_name"],
                 )
+
+        backbone_args: dict[str, Any] | None = model_args_backbone_args_copy
 
         if not backbone_args:
             backbone_args = None

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -84,7 +84,7 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
     backbone_weights: PathLike | None = None
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
-    patch_size: int | Literal["auto"] = "auto"
+    patch_size: int | Literal["auto"] | None = "auto"
     backbone_freeze: bool = False
 
     use_ema_model: bool = True
@@ -148,8 +148,16 @@ class DINOv3LTDETRObjectDetectionTrainArgs(TrainModelArgs):
                     r"dinov3/(?P<model_size>vit(t|s|l|b|g|h|7b))(?P<patch_size>\d+).*",
                     model_name,
                 )
+
                 if match is not None:
                     self.patch_size = int(match.group("patch_size"))
+                elif re.match(r"dinov3/convnext.*", model_name) is not None:
+                    self.patch_size = None
+                else:
+                    raise ValueError(
+                        "Unable to resolve patch_size='auto' for model "
+                        f"{model_name!r}. Please provide a concrete patch_size."
+                    )
 
 
 class DINOv3LTDETRObjectDetectionTrain(TrainModel):

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -7,6 +7,7 @@
 #
 from __future__ import annotations
 
+import math
 from typing import Any, Literal, Sequence
 
 from albumentations import BboxParams
@@ -37,6 +38,35 @@ from lightly_train.types import ImageSizeTuple
 
 ALBUMENTATIONS_VERSION_GREATER_EQUAL_1_4_5 = RequirementCache("albumentations>=1.4.5")
 ALBUMENTATIONS_VERSION_GREATER_EQUAL_2_0_1 = RequirementCache("albumentations>=2.0.1")
+
+
+def _resolve_image_size_for_patch_size(
+    model_init_args: dict[str, Any],
+    *,
+    default_image_size: tuple[int, int],
+    patch_size: int | None,
+) -> tuple[int, int]:
+    provided_image_size = model_init_args.get("image_size")
+    if provided_image_size is not None:
+        image_size = (
+            int(provided_image_size[0]),
+            int(provided_image_size[1]),
+        )
+        if patch_size is not None and any(
+            size % patch_size != 0 for size in image_size
+        ):
+            raise ValueError(
+                "When providing an image size in model_init_args, it must be divisible by the patch size."
+            )
+        return image_size
+
+    if patch_size is None:
+        return default_image_size
+
+    return (
+        math.ceil(default_image_size[0] / patch_size) * patch_size,
+        math.ceil(default_image_size[1] / patch_size) * patch_size,
+    )
 
 
 class DINOv3LTDETRObjectDetectionRandomPhotometricDistortArgs(
@@ -251,8 +281,14 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
     def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
         super().resolve_auto(model_init_args=model_init_args)
 
+        patch_size: int | None = model_init_args.get("patch_size")
+
         if self.image_size == "auto":
-            self.image_size = tuple(model_init_args.get("image_size", (640, 640)))
+            self.image_size = _resolve_image_size_for_patch_size(
+                model_init_args,
+                default_image_size=(640, 640),
+                patch_size=patch_size,
+            )
 
         height, width = self.image_size
         for field_name in self.__class__.model_fields:
@@ -283,7 +319,7 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
 
         if self.scale_jitter is not None:
             if self.scale_jitter.divisible_by == "auto":
-                if "patch_size" in model_init_args:
+                if patch_size is not None:
                     # This is multiplied by 2 to account for the common ViT design. In
                     # our case (05/26) the ViT output a single (H)x(W) scale feature
                     # map and we make a multi-scale from it with the next scales
@@ -348,8 +384,14 @@ class DINOv3LTDETRObjectDetectionValTransformArgs(ObjectDetectionTransformArgs):
     def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
         super().resolve_auto(model_init_args=model_init_args)
 
+        patch_size: int | None = model_init_args.get("patch_size")
+
         if self.image_size == "auto":
-            self.image_size = tuple(model_init_args.get("image_size", (640, 640)))
+            self.image_size = _resolve_image_size_for_patch_size(
+                model_init_args,
+                default_image_size=(640, 640),
+                patch_size=patch_size,
+            )
 
         height, width = self.image_size
         for field_name in self.__class__.model_fields:

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -135,7 +135,7 @@ class DINOv3LTDETRObjectDetectionScaleJitterArgs(ScaleJitterArgs):
     max_scale: float | None = None
     num_scales: int | None = None
     prob: float = 1.0
-    divisible_by: int | None = None
+    divisible_by: int | None | Literal["auto"] = "auto"
 
     # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
     # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
@@ -280,6 +280,14 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                     self.num_channels = 3
                 else:
                     self.num_channels = len(self.normalize.mean)
+
+        if self.divisible_by == "auto" and "patch_size" in model_init_args:
+            # This is multiplied by 2 to account for the common ViT design. In
+            # our case (05/26) the ViT output a single (H)x(W) scale feature
+            # map and we make a multi-scale from it with the next scales
+            # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
+            # 2*patch_size, to account for this 2x smaller feature map.
+            self.divisible_by = 2 * model_init_args["patch_size"]
 
     def resolve_step_schedule(
         self,

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -281,18 +281,20 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                 else:
                     self.num_channels = len(self.normalize.mean)
 
-        if (
-            self.scale_jitter is not None
-            and self.scale_jitter.divisible_by == "auto"
-            and "patch_size" in model_init_args
-        ):
-            # This is multiplied by 2 to account for the common ViT design. In
-            # our case (05/26) the ViT output a single (H)x(W) scale feature
-            # map and we make a multi-scale from it with the next scales
-            # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
-            # 2*patch_size, to account for this 2x smaller feature map.
-            # You can take a look at the forward of the DINOv3STAs class.
-            self.scale_jitter.divisible_by = 2 * model_init_args["patch_size"]
+        if self.scale_jitter is not None:
+            if (
+                self.scale_jitter.divisible_by == "auto"
+                and "patch_size" in model_init_args
+            ):
+                # This is multiplied by 2 to account for the common ViT design. In
+                # our case (05/26) the ViT output a single (H)x(W) scale feature
+                # map and we make a multi-scale from it with the next scales
+                # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
+                # 2*patch_size, to account for this 2x smaller feature map.
+                # You can take a look at the forward of the DINOv3STAs class.
+                self.scale_jitter.divisible_by = 2 * model_init_args["patch_size"]
+            else:
+                self.scale_jitter.divisible_by = None
 
     def resolve_step_schedule(
         self,

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -282,19 +282,17 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                     self.num_channels = len(self.normalize.mean)
 
         if self.scale_jitter is not None:
-            if (
-                self.scale_jitter.divisible_by == "auto"
-                and "patch_size" in model_init_args
-            ):
-                # This is multiplied by 2 to account for the common ViT design. In
-                # our case (05/26) the ViT output a single (H)x(W) scale feature
-                # map and we make a multi-scale from it with the next scales
-                # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
-                # 2*patch_size, to account for this 2x smaller feature map.
-                # You can take a look at the forward of the DINOv3STAs class.
-                self.scale_jitter.divisible_by = 2 * model_init_args["patch_size"]
-            else:
-                self.scale_jitter.divisible_by = None
+            if self.scale_jitter.divisible_by == "auto":
+                if "patch_size" in model_init_args:
+                    # This is multiplied by 2 to account for the common ViT design. In
+                    # our case (05/26) the ViT output a single (H)x(W) scale feature
+                    # map and we make a multi-scale from it with the next scales
+                    # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
+                    # 2*patch_size, to account for this 2x smaller feature map.
+                    # You can take a look at the forward of the DINOv3STAs class.
+                    self.scale_jitter.divisible_by = 2 * model_init_args["patch_size"]
+                else:
+                    self.scale_jitter.divisible_by = None
 
     def resolve_step_schedule(
         self,

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -52,20 +52,21 @@ def _resolve_image_size_for_patch_size(
             int(provided_image_size[0]),
             int(provided_image_size[1]),
         )
-        if patch_size is not None and any(
-            size % patch_size != 0 for size in image_size
-        ):
-            raise ValueError(
-                "When providing an image size in model_init_args, it must be divisible by the patch size."
-            )
+        if patch_size is not None:
+            divisor = 2 * patch_size
+            if any(size % divisor != 0 for size in image_size):
+                raise ValueError(
+                    "When providing an image size in model_init_args, it must be divisible by 2 * the patch size."
+                )
         return image_size
 
     if patch_size is None:
         return default_image_size
 
+    divisor = 2 * patch_size
     return (
-        math.ceil(default_image_size[0] / patch_size) * patch_size,
-        math.ceil(default_image_size[1] / patch_size) * patch_size,
+        math.ceil(default_image_size[0] / divisor) * divisor,
+        math.ceil(default_image_size[1] / divisor) * divisor,
     )
 
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -14,6 +14,9 @@ from albumentations import BboxParams
 from lightning_utilities.core.imports import RequirementCache
 from pydantic import Field
 
+from lightly_train._task_models.object_detection_components.ltdetr_geometry import (
+    ltdetr_image_size_divisor,
+)
 from lightly_train._transforms.object_detection_transform import (
     ObjectDetectionTransform,
     ObjectDetectionTransformArgs,
@@ -53,7 +56,7 @@ def _resolve_image_size_for_patch_size(
             int(provided_image_size[1]),
         )
         if patch_size is not None:
-            divisor = 2 * patch_size
+            divisor = ltdetr_image_size_divisor(patch_size)
             if any(size % divisor != 0 for size in image_size):
                 raise ValueError(
                     "When providing an image size in model_init_args, it must be divisible by 2 * the patch size."
@@ -63,7 +66,7 @@ def _resolve_image_size_for_patch_size(
     if patch_size is None:
         return default_image_size
 
-    divisor = 2 * patch_size
+    divisor = ltdetr_image_size_divisor(patch_size)
     return (
         math.ceil(default_image_size[0] / divisor) * divisor,
         math.ceil(default_image_size[1] / divisor) * divisor,
@@ -327,7 +330,9 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                     # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
                     # 2*patch_size, to account for this 2x smaller feature map.
                     # You can take a look at the forward of the DINOv3STAs class.
-                    self.scale_jitter.divisible_by = 2 * model_init_args["patch_size"]
+                    self.scale_jitter.divisible_by = ltdetr_image_size_divisor(
+                        patch_size
+                    )
                 else:
                     self.scale_jitter.divisible_by = None
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/transforms.py
@@ -281,13 +281,18 @@ class DINOv3LTDETRObjectDetectionTrainTransformArgs(ObjectDetectionTransformArgs
                 else:
                     self.num_channels = len(self.normalize.mean)
 
-        if self.divisible_by == "auto" and "patch_size" in model_init_args:
+        if (
+            self.scale_jitter is not None
+            and self.scale_jitter.divisible_by == "auto"
+            and "patch_size" in model_init_args
+        ):
             # This is multiplied by 2 to account for the common ViT design. In
             # our case (05/26) the ViT output a single (H)x(W) scale feature
             # map and we make a multi-scale from it with the next scales
             # (H/2)x(W/2), (H)x(W) and (2H)x(2W). That's why we need it to be divisible_by
             # 2*patch_size, to account for this 2x smaller feature map.
-            self.divisible_by = 2 * model_init_args["patch_size"]
+            # You can take a look at the forward of the DINOv3STAs class.
+            self.scale_jitter.divisible_by = 2 * model_init_args["patch_size"]
 
     def resolve_step_schedule(
         self,

--- a/src/lightly_train/_task_models/object_detection_components/hybrid_encoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/hybrid_encoder.py
@@ -307,7 +307,9 @@ class HybridEncoder(nn.Module):
             # unused parameter during distributed training, causing training to fail.
             if self.upsample:
                 self.downsample_convs.append(
-                    ConvNormLayer(hidden_dim, hidden_dim, 3, 2, act=act)
+                    ConvNormLayer(
+                        hidden_dim, hidden_dim, kernel_size=3, stride=2, act=act
+                    )
                 )
             self.pan_blocks.append(
                 CSPRepLayer(

--- a/src/lightly_train/_task_models/object_detection_components/ltdetr_geometry.py
+++ b/src/lightly_train/_task_models/object_detection_components/ltdetr_geometry.py
@@ -1,3 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
 """Geometry helpers for LT-DETR object detection models."""
 
 from __future__ import annotations

--- a/src/lightly_train/_task_models/object_detection_components/ltdetr_geometry.py
+++ b/src/lightly_train/_task_models/object_detection_components/ltdetr_geometry.py
@@ -1,0 +1,13 @@
+"""Geometry helpers for LT-DETR object detection models."""
+
+from __future__ import annotations
+
+
+def ltdetr_image_size_divisor(patch_size: int) -> int:
+    """Return the LT-DETR image-size divisor for a patch size.
+
+    LT-DETR uses a feature map that is 2x smaller than the ViT patch grid, so
+    image sizes must be divisible by 2 * patch_size.
+    """
+
+    return 2 * patch_size

--- a/src/lightly_train/_transforms/object_detection_transform.py
+++ b/src/lightly_train/_transforms/object_detection_transform.py
@@ -627,7 +627,9 @@ class ObjectDetectionCollateFunction(TaskCollateFunction):
                         ),
                         scale_range=self.transform_args.scale_jitter.scale_range,
                         num_scales=self.transform_args.scale_jitter.num_scales,
-                        divisible_by=self.transform_args.scale_jitter.divisible_by,
+                        divisible_by=no_auto(
+                            self.transform_args.scale_jitter.divisible_by
+                        ),
                         p=self.transform_args.scale_jitter.prob,
                     )
                 ],

--- a/src/lightly_train/_transforms/oriented_object_detection_transform.py
+++ b/src/lightly_train/_transforms/oriented_object_detection_transform.py
@@ -186,7 +186,7 @@ class OrientedObjectDetectionCollateFunction(TaskCollateFunction):
                 if transform_args.scale_jitter.sizes is None
                 else None,
                 num_scales=transform_args.scale_jitter.num_scales,
-                divisible_by=transform_args.scale_jitter.divisible_by,
+                divisible_by=no_auto(transform_args.scale_jitter.divisible_by),
                 scale_range=transform_args.scale_jitter.scale_range,
             )
 

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -217,7 +217,7 @@ class ScaleJitterArgs(PydanticConfig):
     max_scale: float | None
     num_scales: int | None
     prob: float = Field(ge=0.0, le=1.0)
-    divisible_by: int | None
+    divisible_by: int | None | Literal["auto"]
 
     # ScaleJitter does not have `step_start`, only `step_stop`.
     step_stop: int | Literal["auto"] | None = None

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -32,7 +32,9 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import
 )
 
 
-def test_get_train_model_args_and_transform_args__propagate_patch_size_to_scale_jitter() -> None:
+def test_get_train_model_args_and_transform_args__propagate_patch_size_to_scale_jitter() -> (
+    None
+):
     data_args = YOLOObjectDetectionDataArgs(
         path=Path("/tmp/data"),
         train=Path("train") / "images",

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -7,14 +7,61 @@
 #
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pytest import LogCaptureFixture
 
 from lightly_train._commands.train_task_helpers import (
     BestAggregatedMetricValues,
     get_best_metrics,
+    get_train_model_args,
+    get_transform_args,
+)
+from lightly_train._data.yolo_object_detection_dataset import (
+    YOLOObjectDetectionDataArgs,
 )
 from lightly_train._metrics.task_metric import AggregatedMetricValues, TaskMetricArgs
+from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model import (
+    DINOv3LTDETRObjectDetectionTrain,
+    DINOv3LTDETRObjectDetectionTrainArgs,
+)
+
+
+def test_get_train_model_args_and_transform_args__propagate_patch_size() -> None:
+    data_args = YOLOObjectDetectionDataArgs(
+        path=Path("/tmp/data"),
+        train=Path("train") / "images",
+        val=Path("val") / "images",
+        names={0: "class_0", 1: "class_1"},
+    )
+
+    train_model_args = get_train_model_args(
+        model_args={"patch_size": 14},
+        model_args_cls=DINOv3LTDETRObjectDetectionTrainArgs,
+        total_steps=1000,
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        model_init_args={},
+        data_args=data_args,
+    )
+
+    resolved_model_init_args: dict[str, int] = {}
+    if train_model_args.patch_size not in (None, "auto"):
+        resolved_model_init_args["patch_size"] = train_model_args.patch_size
+
+    train_transform_args, _ = get_transform_args(
+        train_model_cls=DINOv3LTDETRObjectDetectionTrain,
+        transform_args=None,
+        ignore_index=None,
+        model_init_args=resolved_model_init_args,
+        total_steps=1000,
+        train_num_batches=100,
+        gradient_accumulation_steps=1,
+    )
+
+    assert train_model_args.patch_size == 14
+    assert train_transform_args.scale_jitter is not None
+    assert train_transform_args.scale_jitter.divisible_by == 28
 
 
 def test_get_best_metrics__no_previous_best() -> None:

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 from pytest import LogCaptureFixture
@@ -26,9 +27,12 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model impor
     DINOv3LTDETRObjectDetectionTrain,
     DINOv3LTDETRObjectDetectionTrainArgs,
 )
+from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import (
+    DINOv3LTDETRObjectDetectionTrainTransformArgs,
+)
 
 
-def test_get_train_model_args_and_transform_args__propagate_patch_size() -> None:
+def test_get_train_model_args_and_transform_args__propagate_patch_size_to_scale_jitter() -> None:
     data_args = YOLOObjectDetectionDataArgs(
         path=Path("/tmp/data"),
         train=Path("train") / "images",
@@ -36,17 +40,20 @@ def test_get_train_model_args_and_transform_args__propagate_patch_size() -> None
         names={0: "class_0", 1: "class_1"},
     )
 
-    train_model_args = get_train_model_args(
-        model_args={"patch_size": 14},
-        model_args_cls=DINOv3LTDETRObjectDetectionTrainArgs,
-        total_steps=1000,
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
-        model_init_args={},
-        data_args=data_args,
+    train_model_args = cast(
+        DINOv3LTDETRObjectDetectionTrainArgs,
+        get_train_model_args(
+            model_args={"patch_size": 14},
+            model_args_cls=DINOv3LTDETRObjectDetectionTrainArgs,
+            total_steps=1000,
+            model_name="dinov3/vitt16-notpretrained-ltdetr",
+            model_init_args={},
+            data_args=data_args,
+        ),
     )
 
     resolved_model_init_args: dict[str, int] = {}
-    if train_model_args.patch_size not in (None, "auto"):
+    if isinstance(train_model_args.patch_size, int):
         resolved_model_init_args["patch_size"] = train_model_args.patch_size
 
     train_transform_args, _ = get_transform_args(
@@ -57,6 +64,10 @@ def test_get_train_model_args_and_transform_args__propagate_patch_size() -> None
         total_steps=1000,
         train_num_batches=100,
         gradient_accumulation_steps=1,
+    )
+
+    train_transform_args = cast(
+        DINOv3LTDETRObjectDetectionTrainTransformArgs, train_transform_args
     )
 
     assert train_model_args.patch_size == 14

--- a/tests/_models/dinov3/test_dinov3_package.py
+++ b/tests/_models/dinov3/test_dinov3_package.py
@@ -14,7 +14,10 @@ import pytest
 import torch
 
 from lightly_train._models.dinov3.dinov3_convnext import DINOv3VConvNeXtModelWrapper
-from lightly_train._models.dinov3.dinov3_package import DINOv3Package
+from lightly_train._models.dinov3.dinov3_package import (
+    DINOv3Package,
+    _resolve_patch_size,
+)
 from lightly_train._models.dinov3.dinov3_src.hub import backbones
 from lightly_train._models.dinov3.dinov3_src.models.convnext import ConvNeXt
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
@@ -178,16 +181,33 @@ class TestDINOv3Package:
 
         assert model.patch_size == patch_size
 
-    def test_get_model__patch_size_arg_overwrites_model_name_logs_warning(
-        self, caplog: pytest.LogCaptureFixture
+    @pytest.mark.parametrize(
+        "patch_size, args, expected_args, expected_warning",
+        [
+            (None, {}, {}, None),
+            ("16", {}, {"patch_size": 16}, None),
+            ("16", {"patch_size": None}, {"patch_size": 16}, None),
+            (
+                "16",
+                {"patch_size": 41},
+                {"patch_size": 41},
+                "Patch size from model name 16 got overwritten by patch size argument 41",
+            ),
+        ],
+    )
+    def test_resolve_patch_size(
+        self,
+        patch_size: str | None,
+        args: dict[str, int | None],
+        expected_args: dict[str, int],
+        expected_warning: str | None,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         with caplog.at_level(logging.WARNING):
-            model = DINOv3Package.get_model(
-                "vitt16", model_args={"patch_size": 41}, load_weights=False
-            )
+            _resolve_patch_size(patch_size, args)
 
-        assert model.patch_size == 41
-        assert (
-            "Patch size from model name 16 got overwritten by patch size argument 41"
-            in caplog.text
-        )
+        assert args == expected_args
+        if expected_warning is None:
+            assert caplog.text == ""
+        else:
+            assert expected_warning in caplog.text

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -277,7 +277,9 @@ def test_transform_args__resolve_auto__preserves_explicit_image_size(
     ],
 ) -> None:
     transform_args = transform_args_cls()
-    transform_args.resolve_auto(model_init_args={"patch_size": 14, "image_size": (672, 672)})
+    transform_args.resolve_auto(
+        model_init_args={"patch_size": 14, "image_size": (672, 672)}
+    )
 
     assert transform_args.image_size == (672, 672)
 
@@ -298,7 +300,9 @@ def test_transform_args__resolve_auto__rejects_incompatible_explicit_image_size(
     transform_args = transform_args_cls()
 
     with pytest.raises(ValueError, match="must be divisible by the patch size"):
-        transform_args.resolve_auto(model_init_args={"patch_size": 14, "image_size": (671, 671)})
+        transform_args.resolve_auto(
+            model_init_args={"patch_size": 14, "image_size": (671, 671)}
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -93,7 +93,7 @@ def test_freeze_backbone_on_set_train_mode(should_freeze: bool) -> None:
 
 @pytest.mark.parametrize(
     ("model_name", "expected_patch_size"),
-    [("dinov3/vitt16-ltdetr-coco", 16), ("dinov3/convnext-tiny-ltdetr-coco", "auto")],
+    [("dinov3/vitt16-ltdetr-coco", 16), ("dinov3/convnext-tiny-ltdetr-coco", None)],
 )
 def test_resolve_auto__uses_vit_model_name(
     model_name: str,

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -130,21 +130,6 @@ def test_resolve_auto__keeps_convnext_auto(monkeypatch: pytest.MonkeyPatch) -> N
     assert "patch_size" not in calls[0]["model_args"]
 
 
-def test_resolve_auto__uses_explicit_patch_size_for_convnext(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=14)
-    train_model, calls = _create_train_model_with_capture(
-        model_args,
-        model_name="dinov3/convnext-small-ltdetr",
-        monkeypatch=monkeypatch,
-    )
-
-    assert model_args.patch_size == 14
-    assert calls[0]["model_args"]["patch_size"] == 14
-    assert train_model.model.backbone.patch_size == 14
-
-
 def _create_train_model(
     train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
     *,
@@ -196,10 +181,7 @@ def _create_train_model_with_capture(
         model_args = kwargs.get("model_args", {}) or {}
 
         if str(model_name).startswith("convnext"):
-            convnext_kwargs: dict[str, Any] = {"pretrained": False}
-            if "patch_size" in model_args:
-                convnext_kwargs["patch_size"] = int(model_args["patch_size"])
-            return backbones._dinov3_convnext_test(**convnext_kwargs)
+            return backbones._dinov3_convnext_test(pretrained=False)
 
         return backbones._dinov3_vit_test(
             pretrained=False,

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -157,6 +157,21 @@ def test_resolve_auto__uses_explicit_patch_size_for_convnext(
     assert train_model.model.backbone.patch_size == 14
 
 
+@pytest.mark.parametrize("patch_size", [14, 16, 64])
+def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_size(
+    patch_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task_model = _create_task_model(
+        monkeypatch=monkeypatch,
+        patch_size=patch_size,
+    )
+    train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
+    train_transform_args.resolve_auto(task_model.init_args)
+
+    assert train_transform_args.scale_jitter.divisible_by == patch_size * 2
+
+
 def _create_train_model(
     train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
     *,

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from torch import nn
@@ -16,6 +17,8 @@ from lightly_train._data.yolo_object_detection_dataset import (
     YOLOObjectDetectionDataArgs,
 )
 from lightly_train._metrics.detection.task_metric import ObjectDetectionTaskMetricArgs
+from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
+from lightly_train._models.dinov3.dinov3_src.hub import backbones
 from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model import (
     DINOv3LTDETRObjectDetectionTrain,
     DINOv3LTDETRObjectDetectionTrainArgs,
@@ -71,8 +74,67 @@ def test_freeze_backbone_on_set_train_mode(should_freeze: bool) -> None:
     )
 
 
+def test_resolve_auto__uses_vit_model_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    model_args = DINOv3LTDETRObjectDetectionTrainArgs()
+    train_model, calls = _create_train_model_with_capture(
+        model_args,
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        monkeypatch=monkeypatch,
+    )
+
+    assert model_args.patch_size == 16
+    assert calls[0]["model_args"]["patch_size"] == 16
+    assert train_model.model.backbone.patch_size == 16
+
+
+def test_resolve_auto__uses_model_init_args_patch_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_args = DINOv3LTDETRObjectDetectionTrainArgs()
+    train_model, calls = _create_train_model_with_capture(
+        model_args,
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        model_init_args={"patch_size": 14},
+        monkeypatch=monkeypatch,
+    )
+
+    assert model_args.patch_size == 14
+    assert calls[0]["model_args"]["patch_size"] == 14
+    assert train_model.model.backbone.patch_size == 14
+
+
+def test_resolve_auto__uses_explicit_patch_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=14)
+    train_model, calls = _create_train_model_with_capture(
+        model_args,
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        monkeypatch=monkeypatch,
+    )
+
+    assert model_args.patch_size == 14
+    assert calls[0]["model_args"]["patch_size"] == 14
+    assert train_model.model.backbone.patch_size == 14
+
+
+def test_resolve_auto__keeps_convnext_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    model_args = DINOv3LTDETRObjectDetectionTrainArgs()
+    _, calls = _create_train_model_with_capture(
+        model_args,
+        model_name="dinov3/convnext-small-ltdetr",
+        monkeypatch=monkeypatch,
+    )
+
+    assert model_args.patch_size == "auto"
+    assert "patch_size" not in calls[0]["model_args"]
+
+
 def _create_train_model(
     train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
+    *,
+    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
+    model_init_args: dict[str, Any] | None = None,
 ) -> DINOv3LTDETRObjectDetectionTrain:
     data_args = YOLOObjectDetectionDataArgs(
         path=Path("/tmp/data"),
@@ -82,8 +144,8 @@ def _create_train_model(
     )
     train_model_args.resolve_auto(
         total_steps=1000,
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
-        model_init_args={},
+        model_name=model_name,
+        model_init_args={} if model_init_args is None else model_init_args,
         data_args=data_args,
     )
     train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
@@ -92,7 +154,7 @@ def _create_train_model(
     val_transform_args.resolve_auto(model_init_args={})
 
     train_model = DINOv3LTDETRObjectDetectionTrain(
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        model_name=model_name,
         model_args=train_model_args,
         data_args=data_args,
         train_transform_args=train_transform_args,
@@ -102,3 +164,35 @@ def _create_train_model(
         gradient_accumulation_steps=1,
     )
     return train_model
+
+
+def _create_train_model_with_capture(
+    train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
+    *,
+    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
+    model_init_args: dict[str, Any] | None = None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[DINOv3LTDETRObjectDetectionTrain, list[dict[str, Any]]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake_get_model(*args: Any, **kwargs: Any) -> Any:
+        calls.append(dict(kwargs))
+        model_name = kwargs.get("model_name", args[0] if args else "")
+        model_args = kwargs.get("model_args", {}) or {}
+
+        if str(model_name).startswith("convnext"):
+            return backbones._dinov3_convnext_test(pretrained=False)
+
+        return backbones._dinov3_vit_test(
+            pretrained=False,
+            patch_size=int(model_args.get("patch_size", 16)),
+        )
+
+    monkeypatch.setattr(DINOV3_PACKAGE, "get_model", fake_get_model)
+
+    train_model = _create_train_model(
+        train_model_args,
+        model_name=model_name,
+        model_init_args=model_init_args,
+    )
+    return train_model, calls

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -249,8 +249,8 @@ def _create_train_model_with_capture(
         model_init_args=model_init_args,
     )
     return train_model, calls
-  
-  
+
+
 @pytest.mark.parametrize(
     ("scheduler_name", "scheduler_cls"),
     [

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -213,6 +213,24 @@ def test_task_model_init_args_roundtrip_preserves_patch_size() -> None:
     assert roundtrip_model.init_args["patch_size"] == 14
 
 
+@pytest.mark.parametrize(
+    ("patch_size", "expected_image_size"),
+    [
+        (14, (644, 644)),
+        (16, (640, 640)),
+        (64, (640, 640)),
+    ],
+)
+def test_train_transform_args__resolve_auto__image_size_is_patch_size_compatible(
+    patch_size: int,
+    expected_image_size: tuple[int, int],
+) -> None:
+    train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
+    train_transform_args.resolve_auto(model_init_args={"patch_size": patch_size})
+
+    assert train_transform_args.image_size == expected_image_size
+
+
 @pytest.mark.parametrize("patch_size", [14, 16, 64])
 def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_size(
     patch_size: int,
@@ -225,6 +243,24 @@ def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_siz
     )
 
     assert train_transform_args.scale_jitter.divisible_by == patch_size * 2
+
+
+@pytest.mark.parametrize(
+    ("patch_size", "expected_image_size"),
+    [
+        (14, (644, 644)),
+        (16, (640, 640)),
+        (64, (640, 640)),
+    ],
+)
+def test_val_transform_args__resolve_auto__image_size_is_patch_size_compatible(
+    patch_size: int,
+    expected_image_size: tuple[int, int],
+) -> None:
+    val_transform_args = DINOv3LTDETRObjectDetectionValTransformArgs()
+    val_transform_args.resolve_auto(model_init_args={"patch_size": patch_size})
+
+    assert val_transform_args.image_size == expected_image_size
 
 
 @pytest.mark.parametrize(

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -169,6 +169,10 @@ def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_siz
     train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
     train_transform_args.resolve_auto(task_model.init_args)
 
+    assert train_transform_args.scale_jitter is not None, (
+        "scale_jitter should not be None after resolve_auto"
+    )
+
     assert train_transform_args.scale_jitter.divisible_by == patch_size * 2
 
 
@@ -340,7 +344,7 @@ def test_get_optimizer__linear_warns_when_warmup_exceeds_training(
 )
 def test_rtdetr_transformer_v2_config__resolve_auto__patch_size(
     patch_size: int, feat_strides: list[int], num_levels: int
-):
+) -> None:
     config = _RTDETRTransformerv2Config(
         num_levels=num_levels, feat_channels=[-1] * num_levels
     )

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -264,6 +264,44 @@ def test_val_transform_args__resolve_auto__image_size_is_patch_size_compatible(
 
 
 @pytest.mark.parametrize(
+    "transform_args_cls",
+    [
+        DINOv3LTDETRObjectDetectionTrainTransformArgs,
+        DINOv3LTDETRObjectDetectionValTransformArgs,
+    ],
+)
+def test_transform_args__resolve_auto__preserves_explicit_image_size(
+    transform_args_cls: type[
+        DINOv3LTDETRObjectDetectionTrainTransformArgs
+        | DINOv3LTDETRObjectDetectionValTransformArgs
+    ],
+) -> None:
+    transform_args = transform_args_cls()
+    transform_args.resolve_auto(model_init_args={"patch_size": 14, "image_size": (672, 672)})
+
+    assert transform_args.image_size == (672, 672)
+
+
+@pytest.mark.parametrize(
+    "transform_args_cls",
+    [
+        DINOv3LTDETRObjectDetectionTrainTransformArgs,
+        DINOv3LTDETRObjectDetectionValTransformArgs,
+    ],
+)
+def test_transform_args__resolve_auto__rejects_incompatible_explicit_image_size(
+    transform_args_cls: type[
+        DINOv3LTDETRObjectDetectionTrainTransformArgs
+        | DINOv3LTDETRObjectDetectionValTransformArgs
+    ],
+) -> None:
+    transform_args = transform_args_cls()
+
+    with pytest.raises(ValueError, match="must be divisible by the patch size"):
+        transform_args.resolve_auto(model_init_args={"patch_size": 14, "image_size": (671, 671)})
+
+
+@pytest.mark.parametrize(
     ("scheduler_name", "scheduler_cls"),
     [
         ("linear", LinearLR),

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -23,6 +23,7 @@ from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.hub import backbones
 from lightly_train._task_models.dinov3_ltdetr_object_detection.task_model import (
     DINOv3LTDETRObjectDetection,
+    _RTDETRTransformerv2Config,
 )
 from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model import (
     DINOv3LTDETRObjectDetectionTrain,
@@ -309,3 +310,26 @@ def test_get_optimizer__linear_warns_when_warmup_exceeds_training(
         train_model.get_optimizer(total_steps=1000, global_batch_size=16)
 
     assert "the schedule will not complete as intended" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("patch_size", "feat_strides", "num_levels"),
+    [
+        (16, [8, 16, 32, 64], 4),
+        (14, [7, 14, 28, 56], 4),
+        (64, [32, 64, 128, 256], 4),
+        (16, [8, 16, 32], 3),
+        (14, [7, 14, 28], 3),
+        (64, [32, 64, 128], 3),
+    ],
+)
+def test_rtdetr_transformer_v2_config__resolve_auto__patch_size(
+    patch_size: int, feat_strides: list[int], num_levels: int
+):
+    config = _RTDETRTransformerv2Config(
+        num_levels=num_levels, feat_channels=[-1] * num_levels
+    )
+
+    config.resolve_auto(patch_size=patch_size)
+
+    assert config.feat_strides == feat_strides

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -7,7 +7,6 @@
 #
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Any
 
@@ -131,24 +130,19 @@ def test_resolve_auto__keeps_convnext_auto(monkeypatch: pytest.MonkeyPatch) -> N
     assert "patch_size" not in calls[0]["model_args"]
 
 
-def test_warns_when_patch_size_is_ignored_for_convnext(
+def test_resolve_auto__uses_explicit_patch_size_for_convnext(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=14)
-    with caplog.at_level(logging.WARNING):
-        _, calls = _create_train_model_with_capture(
-            model_args,
-            model_name="dinov3/convnext-small-ltdetr",
-            monkeypatch=monkeypatch,
-        )
+    train_model, calls = _create_train_model_with_capture(
+        model_args,
+        model_name="dinov3/convnext-small-ltdetr",
+        monkeypatch=monkeypatch,
+    )
 
     assert model_args.patch_size == 14
-    assert "patch_size" not in calls[0]["model_args"]
-    assert (
-        "Ignoring top-level `patch_size=14` for non-ViT backbone 'convnext-small'"
-        in caplog.text
-    )
+    assert calls[0]["model_args"]["patch_size"] == 14
+    assert train_model.model.backbone.patch_size == 14
 
 
 def _create_train_model(
@@ -202,7 +196,10 @@ def _create_train_model_with_capture(
         model_args = kwargs.get("model_args", {}) or {}
 
         if str(model_name).startswith("convnext"):
-            return backbones._dinov3_convnext_test(pretrained=False)
+            convnext_kwargs: dict[str, Any] = {"pretrained": False}
+            if "patch_size" in model_args:
+                convnext_kwargs["patch_size"] = int(model_args["patch_size"])
+            return backbones._dinov3_convnext_test(**convnext_kwargs)
 
         return backbones._dinov3_vit_test(
             pretrained=False,

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -19,8 +19,6 @@ from lightly_train._data.yolo_object_detection_dataset import (
     YOLOObjectDetectionDataArgs,
 )
 from lightly_train._metrics.detection.task_metric import ObjectDetectionTaskMetricArgs
-from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
-from lightly_train._models.dinov3.dinov3_src.hub import backbones
 from lightly_train._task_models.dinov3_ltdetr_object_detection.task_model import (
     DINOv3LTDETRObjectDetection,
     _RTDETRTransformerv2Config,
@@ -29,12 +27,12 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model impor
     DINOv3LTDETRObjectDetectionTrain,
     DINOv3LTDETRObjectDetectionTrainArgs,
 )
+from lightly_train._task_models.object_detection_components.flat_cosine import (
+    FlatCosineLRScheduler,
+)
 from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import (
     DINOv3LTDETRObjectDetectionTrainTransformArgs,
     DINOv3LTDETRObjectDetectionValTransformArgs,
-)
-from lightly_train._task_models.object_detection_components.flat_cosine import (
-    FlatCosineLRScheduler,
 )
 
 
@@ -63,6 +61,16 @@ def _is_module_frozen(m: nn.Module) -> bool:
     return all(not param.requires_grad for param in m.parameters())
 
 
+@pytest.fixture()
+def dummy_yolo_detection_data_args() -> YOLOObjectDetectionDataArgs:
+    return YOLOObjectDetectionDataArgs(
+        path=Path("/tmp/data"),
+        train=Path("train") / "images",
+        val=Path("val") / "images",
+        names={0: "class_0", 1: "class_1"},
+    )
+
+
 @pytest.mark.parametrize("should_freeze", [True, False])
 def test_freeze_backbone_on_set_train_mode(should_freeze: bool) -> None:
     model_args = DINOv3LTDETRObjectDetectionTrainArgs(
@@ -83,54 +91,81 @@ def test_freeze_backbone_on_set_train_mode(should_freeze: bool) -> None:
     )
 
 
-def test_resolve_auto__uses_vit_model_name(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("model_name", "expected_patch_size"),
+    [("dinov3/vitt16-ltdetr-coco", 16), ("dinov3/convnext-tiny-ltdetr-coco", "auto")],
+)
+def test_resolve_auto__uses_vit_model_name(
+    model_name: str,
+    expected_patch_size: int | str,
+    dummy_yolo_detection_data_args: YOLOObjectDetectionDataArgs,
+) -> None:
     model_args = DINOv3LTDETRObjectDetectionTrainArgs()
-    train_model, calls = _create_train_model_with_capture(
-        model_args,
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
-        monkeypatch=monkeypatch,
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        model_name=model_name,
+        model_init_args={},
+        data_args=dummy_yolo_detection_data_args,
     )
 
-    assert model_args.patch_size == 16
-    assert calls[0]["model_args"]["patch_size"] == 16
-    assert train_model.model.backbone.patch_size == 16
+    assert model_args.patch_size == expected_patch_size
 
 
+@pytest.mark.parametrize(
+    ("model_name", "expected_patch_size"),
+    [("dinov3/vitt16-ltdetr-coco", 36), ("dinov3/convnext-tiny-ltdetr-coco", 47)],
+)
 def test_resolve_auto__uses_model_init_args_patch_size(
-    monkeypatch: pytest.MonkeyPatch,
+    model_name: str,
+    expected_patch_size: int,
+    dummy_yolo_detection_data_args: YOLOObjectDetectionDataArgs,
 ) -> None:
     model_args = DINOv3LTDETRObjectDetectionTrainArgs()
-    train_model, calls = _create_train_model_with_capture(
-        model_args,
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
-        model_init_args={"patch_size": 14},
-        monkeypatch=monkeypatch,
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        model_name=model_name,
+        model_init_args={"patch_size": expected_patch_size},
+        data_args=dummy_yolo_detection_data_args,
     )
 
-    assert model_args.patch_size == 14
-    assert calls[0]["model_args"]["patch_size"] == 14
-    assert train_model.model.backbone.patch_size == 14
+    assert model_args.patch_size == expected_patch_size
 
 
-def test_resolve_auto__uses_explicit_patch_size(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    ("model_name", "expected_patch_size"),
+    [("dinov3/vitt16-ltdetr-coco", 36), ("dinov3/convnext-tiny-ltdetr-coco", 47)],
+)
+def test_resolve_auto__uses_model_explicit_patch_size_arg(
+    model_name: str,
+    expected_patch_size: int,
+    dummy_yolo_detection_data_args: YOLOObjectDetectionDataArgs,
 ) -> None:
-    model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=14)
-    train_model, calls = _create_train_model_with_capture(
-        model_args,
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
-        monkeypatch=monkeypatch,
+    model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=expected_patch_size)
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        model_name=model_name,
+        model_init_args={},
+        data_args=dummy_yolo_detection_data_args,
     )
 
-    assert model_args.patch_size == 14
-    assert calls[0]["model_args"]["patch_size"] == 14
-    assert train_model.model.backbone.patch_size == 14
+    assert model_args.patch_size == expected_patch_size
 
 
-def test_task_model_init_args_roundtrip_preserves_patch_size(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    model = _create_task_model(monkeypatch=monkeypatch, patch_size=14)
+def test_task_model_init_args_roundtrip_preserves_patch_size() -> None:
+    model = DINOv3LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(640, 640),
+        patch_size=14,
+        image_normalize=None,
+        backbone_freeze=False,
+        backbone_weights=None,
+        backbone_args=None,
+        load_weights=False,
+    )
 
     assert model.init_args["patch_size"] == 14
 
@@ -142,32 +177,12 @@ def test_task_model_init_args_roundtrip_preserves_patch_size(
     assert roundtrip_model.init_args["patch_size"] == 14
 
 
-def test_resolve_auto__uses_explicit_patch_size_for_convnext(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=14)
-    train_model, calls = _create_train_model_with_capture(
-        model_args,
-        model_name="dinov3/convnext-small-ltdetr",
-        monkeypatch=monkeypatch,
-    )
-
-    assert model_args.patch_size == 14
-    assert calls[0]["model_args"]["patch_size"] == 14
-    assert train_model.model.backbone.patch_size == 14
-
-
 @pytest.mark.parametrize("patch_size", [14, 16, 64])
 def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_size(
     patch_size: int,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    task_model = _create_task_model(
-        monkeypatch=monkeypatch,
-        patch_size=patch_size,
-    )
     train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
-    train_transform_args.resolve_auto(task_model.init_args)
+    train_transform_args.resolve_auto(model_init_args={"patch_size": patch_size})
 
     assert train_transform_args.scale_jitter is not None, (
         "scale_jitter should not be None after resolve_auto"
@@ -210,65 +225,6 @@ def _create_train_model(
         gradient_accumulation_steps=1,
     )
     return train_model
-
-
-def _create_task_model(
-    *,
-    monkeypatch: pytest.MonkeyPatch,
-    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
-    patch_size: int = 16,
-) -> DINOv3LTDETRObjectDetection:
-    monkeypatch.setattr(DINOV3_PACKAGE, "get_model", _fake_get_model)
-    return DINOv3LTDETRObjectDetection(
-        model_name=model_name,
-        classes={0: "class_0", 1: "class_1"},
-        image_size=(640, 640),
-        patch_size=patch_size,
-        image_normalize=None,
-        backbone_freeze=False,
-        backbone_weights=None,
-        backbone_args=None,
-        load_weights=False,
-    )
-
-
-def _fake_get_model(*args: Any, **kwargs: Any) -> Any:
-    model_name = kwargs.get("model_name", args[0] if args else "")
-    model_args = kwargs.get("model_args", {}) or {}
-
-    if str(model_name).startswith("convnext"):
-        convnext_kwargs: dict[str, Any] = {"pretrained": False}
-        if "patch_size" in model_args:
-            convnext_kwargs["patch_size"] = int(model_args["patch_size"])
-        return backbones._dinov3_convnext_test(**convnext_kwargs)
-
-    return backbones._dinov3_vit_test(
-        pretrained=False,
-        patch_size=int(model_args.get("patch_size", 16)),
-    )
-
-
-def _create_train_model_with_capture(
-    train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
-    *,
-    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
-    model_init_args: dict[str, Any] | None = None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> tuple[DINOv3LTDETRObjectDetectionTrain, list[dict[str, Any]]]:
-    calls: list[dict[str, Any]] = []
-
-    def fake_get_model(*args: Any, **kwargs: Any) -> Any:
-        calls.append(dict(kwargs))
-        return _fake_get_model(*args, **kwargs)
-
-    monkeypatch.setattr(DINOV3_PACKAGE, "get_model", fake_get_model)
-
-    train_model = _create_train_model(
-        train_model_args,
-        model_name=model_name,
-        model_init_args=model_init_args,
-    )
-    return train_model, calls
 
 
 @pytest.mark.parametrize(
@@ -352,3 +308,4 @@ def test_rtdetr_transformer_v2_config__resolve_auto__patch_size(
     config.resolve_auto(patch_size=patch_size)
 
     assert config.feat_strides == feat_strides
+

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -7,6 +7,7 @@
 #
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -128,6 +129,23 @@ def test_resolve_auto__keeps_convnext_auto(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert model_args.patch_size == "auto"
     assert "patch_size" not in calls[0]["model_args"]
+
+
+def test_warns_when_patch_size_is_ignored_for_convnext(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    model_args = DINOv3LTDETRObjectDetectionTrainArgs(patch_size=14)
+    with caplog.at_level(logging.WARNING):
+        _, calls = _create_train_model_with_capture(
+            model_args,
+            model_name="dinov3/convnext-small-ltdetr",
+            monkeypatch=monkeypatch,
+        )
+
+    assert model_args.patch_size == 14
+    assert "patch_size" not in calls[0]["model_args"]
+    assert "Ignoring top-level `patch_size=14` for non-ViT backbone 'convnext-small'" in caplog.text
 
 
 def _create_train_model(

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -218,10 +218,11 @@ def test_task_model_init_args_roundtrip_preserves_patch_size() -> None:
     [
         (14, (644, 644)),
         (16, (640, 640)),
+        (24, (672, 672)),
         (64, (640, 640)),
     ],
 )
-def test_train_transform_args__resolve_auto__image_size_is_patch_size_compatible(
+def test_train_transform_args__resolve_auto__image_size_is_2x_patch_size_compatible(
     patch_size: int,
     expected_image_size: tuple[int, int],
 ) -> None:
@@ -250,10 +251,11 @@ def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_siz
     [
         (14, (644, 644)),
         (16, (640, 640)),
+        (24, (672, 672)),
         (64, (640, 640)),
     ],
 )
-def test_val_transform_args__resolve_auto__image_size_is_patch_size_compatible(
+def test_val_transform_args__resolve_auto__image_size_is_2x_patch_size_compatible(
     patch_size: int,
     expected_image_size: tuple[int, int],
 ) -> None:
@@ -299,9 +301,9 @@ def test_transform_args__resolve_auto__rejects_incompatible_explicit_image_size(
 ) -> None:
     transform_args = transform_args_cls()
 
-    with pytest.raises(ValueError, match="must be divisible by the patch size"):
+    with pytest.raises(ValueError, match=r"2 \* the patch size"):
         transform_args.resolve_auto(
-            model_init_args={"patch_size": 14, "image_size": (671, 671)}
+            model_init_args={"patch_size": 14, "image_size": (658, 658)}
         )
 
 

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -22,10 +22,7 @@ from lightly_train._data.yolo_object_detection_dataset import (
 from lightly_train._metrics.detection.task_metric import ObjectDetectionTaskMetricArgs
 from lightly_train._task_models.dinov3_ltdetr_object_detection.task_model import (
     DINOv3LTDETRObjectDetection,
-<<<<<<< gabriel-trn-1983-support-dinov3-lt-detr-variable-patch-size
     _RTDETRTransformerv2Config,
-=======
->>>>>>> main
 )
 from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model import (
     DINOv3LTDETRObjectDetectionTrain,
@@ -371,7 +368,6 @@ def test_get_optimizer__linear_warns_when_warmup_exceeds_training(
     assert "the schedule will not complete as intended" in caplog.text
 
 
-<<<<<<< gabriel-trn-1983-support-dinov3-lt-detr-variable-patch-size
 @pytest.mark.parametrize(
     ("patch_size", "feat_strides", "num_levels"),
     [
@@ -392,8 +388,7 @@ def test_rtdetr_transformer_v2_config__resolve_auto__patch_size(
 
     config.resolve_auto(patch_size=patch_size)
 
-    assert config.feat_strides == feat_strides
-=======
+
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
@@ -452,4 +447,3 @@ def test_export_onnx__static_batch_size(tmp_path: Path) -> None:
     model.export_onnx(
         out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
     )
->>>>>>> main

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -145,7 +145,10 @@ def test_warns_when_patch_size_is_ignored_for_convnext(
 
     assert model_args.patch_size == 14
     assert "patch_size" not in calls[0]["model_args"]
-    assert "Ignoring top-level `patch_size=14` for non-ViT backbone 'convnext-small'" in caplog.text
+    assert (
+        "Ignoring top-level `patch_size=14` for non-ViT backbone 'convnext-small'"
+        in caplog.text
+    )
 
 
 def _create_train_model(

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -19,6 +19,9 @@ from lightly_train._data.yolo_object_detection_dataset import (
 from lightly_train._metrics.detection.task_metric import ObjectDetectionTaskMetricArgs
 from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.hub import backbones
+from lightly_train._task_models.dinov3_ltdetr_object_detection.task_model import (
+    DINOv3LTDETRObjectDetection,
+)
 from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model import (
     DINOv3LTDETRObjectDetectionTrain,
     DINOv3LTDETRObjectDetectionTrainArgs,
@@ -118,16 +121,19 @@ def test_resolve_auto__uses_explicit_patch_size(
     assert train_model.model.backbone.patch_size == 14
 
 
-def test_resolve_auto__keeps_convnext_auto(monkeypatch: pytest.MonkeyPatch) -> None:
-    model_args = DINOv3LTDETRObjectDetectionTrainArgs()
-    _, calls = _create_train_model_with_capture(
-        model_args,
-        model_name="dinov3/convnext-small-ltdetr",
-        monkeypatch=monkeypatch,
-    )
+def test_task_model_init_args_roundtrip_preserves_patch_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _create_task_model(monkeypatch=monkeypatch, patch_size=14)
 
-    assert model_args.patch_size == "auto"
-    assert "patch_size" not in calls[0]["model_args"]
+    assert model.init_args["patch_size"] == 14
+
+    roundtrip_model = DINOv3LTDETRObjectDetection(
+        **model.init_args,
+        load_weights=False,
+    )
+    assert roundtrip_model.init_args == model.init_args
+    assert roundtrip_model.init_args["patch_size"] == 14
 
 
 def test_resolve_auto__uses_explicit_patch_size_for_convnext(
@@ -181,6 +187,42 @@ def _create_train_model(
     return train_model
 
 
+def _create_task_model(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
+    patch_size: int = 16,
+) -> DINOv3LTDETRObjectDetection:
+    monkeypatch.setattr(DINOV3_PACKAGE, "get_model", _fake_get_model)
+    return DINOv3LTDETRObjectDetection(
+        model_name=model_name,
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(640, 640),
+        patch_size=patch_size,
+        image_normalize=None,
+        backbone_freeze=False,
+        backbone_weights=None,
+        backbone_args=None,
+        load_weights=False,
+    )
+
+
+def _fake_get_model(*args: Any, **kwargs: Any) -> Any:
+    model_name = kwargs.get("model_name", args[0] if args else "")
+    model_args = kwargs.get("model_args", {}) or {}
+
+    if str(model_name).startswith("convnext"):
+        convnext_kwargs: dict[str, Any] = {"pretrained": False}
+        if "patch_size" in model_args:
+            convnext_kwargs["patch_size"] = int(model_args["patch_size"])
+        return backbones._dinov3_convnext_test(**convnext_kwargs)
+
+    return backbones._dinov3_vit_test(
+        pretrained=False,
+        patch_size=int(model_args.get("patch_size", 16)),
+    )
+
+
 def _create_train_model_with_capture(
     train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
     *,
@@ -192,19 +234,7 @@ def _create_train_model_with_capture(
 
     def fake_get_model(*args: Any, **kwargs: Any) -> Any:
         calls.append(dict(kwargs))
-        model_name = kwargs.get("model_name", args[0] if args else "")
-        model_args = kwargs.get("model_args", {}) or {}
-
-        if str(model_name).startswith("convnext"):
-            convnext_kwargs: dict[str, Any] = {"pretrained": False}
-            if "patch_size" in model_args:
-                convnext_kwargs["patch_size"] = int(model_args["patch_size"])
-            return backbones._dinov3_convnext_test(**convnext_kwargs)
-
-        return backbones._dinov3_vit_test(
-            pretrained=False,
-            patch_size=int(model_args.get("patch_size", 16)),
-        )
+        return _fake_get_model(*args, **kwargs)
 
     monkeypatch.setattr(DINOV3_PACKAGE, "get_model", fake_get_model)
 

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -36,6 +36,56 @@ from lightly_train._task_models.object_detection_components.flat_cosine import (
 )
 
 
+def _is_module_frozen(m: nn.Module) -> bool:
+    return all(not param.requires_grad for param in m.parameters())
+
+
+def _create_train_model(
+    train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
+    *,
+    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
+    model_init_args: dict[str, Any] | None = None,
+) -> DINOv3LTDETRObjectDetectionTrain:
+    data_args = YOLOObjectDetectionDataArgs(
+        path=Path("/tmp/data"),
+        train=Path("train") / "images",
+        val=Path("val") / "images",
+        names={0: "class_0", 1: "class_1"},
+    )
+    train_model_args.resolve_auto(
+        total_steps=1000,
+        model_name=model_name,
+        model_init_args={} if model_init_args is None else model_init_args,
+        data_args=data_args,
+    )
+    train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
+    train_transform_args.resolve_auto(model_init_args={})
+    val_transform_args = DINOv3LTDETRObjectDetectionValTransformArgs()
+    val_transform_args.resolve_auto(model_init_args={})
+
+    train_model = DINOv3LTDETRObjectDetectionTrain(
+        model_name=model_name,
+        model_args=train_model_args,
+        data_args=data_args,
+        train_transform_args=train_transform_args,
+        val_transform_args=val_transform_args,
+        metric_args=ObjectDetectionTaskMetricArgs(),
+        load_weights=False,
+        gradient_accumulation_steps=1,
+    )
+    return train_model
+
+
+@pytest.fixture()
+def dummy_yolo_detection_data_args() -> YOLOObjectDetectionDataArgs:
+    return YOLOObjectDetectionDataArgs(
+        path=Path("/tmp/data"),
+        train=Path("train") / "images",
+        val=Path("val") / "images",
+        names={0: "class_0", 1: "class_1"},
+    )
+
+
 @pytest.mark.parametrize("use_ema_model", [True, False])
 def test_load_train_state_dict__from_exported(use_ema_model: bool) -> None:
     model_args = DINOv3LTDETRObjectDetectionTrainArgs(use_ema_model=use_ema_model)
@@ -55,20 +105,6 @@ def test_load_train_state_dict__no_ema_weights() -> None:
     # copying the non-EMA weights to the EMA model.
     state_dict = {k: v for k, v in state_dict.items() if not k.startswith("ema_model.")}
     task_model.load_train_state_dict(state_dict)
-
-
-def _is_module_frozen(m: nn.Module) -> bool:
-    return all(not param.requires_grad for param in m.parameters())
-
-
-@pytest.fixture()
-def dummy_yolo_detection_data_args() -> YOLOObjectDetectionDataArgs:
-    return YOLOObjectDetectionDataArgs(
-        path=Path("/tmp/data"),
-        train=Path("train") / "images",
-        val=Path("val") / "images",
-        names={0: "class_0", 1: "class_1"},
-    )
 
 
 @pytest.mark.parametrize("should_freeze", [True, False])
@@ -189,42 +225,6 @@ def test_train_transform_args__resolve_auto__scale_jitter_divisible_by_patch_siz
     )
 
     assert train_transform_args.scale_jitter.divisible_by == patch_size * 2
-
-
-def _create_train_model(
-    train_model_args: DINOv3LTDETRObjectDetectionTrainArgs,
-    *,
-    model_name: str = "dinov3/vitt16-notpretrained-ltdetr",
-    model_init_args: dict[str, Any] | None = None,
-) -> DINOv3LTDETRObjectDetectionTrain:
-    data_args = YOLOObjectDetectionDataArgs(
-        path=Path("/tmp/data"),
-        train=Path("train") / "images",
-        val=Path("val") / "images",
-        names={0: "class_0", 1: "class_1"},
-    )
-    train_model_args.resolve_auto(
-        total_steps=1000,
-        model_name=model_name,
-        model_init_args={} if model_init_args is None else model_init_args,
-        data_args=data_args,
-    )
-    train_transform_args = DINOv3LTDETRObjectDetectionTrainTransformArgs()
-    train_transform_args.resolve_auto(model_init_args={})
-    val_transform_args = DINOv3LTDETRObjectDetectionValTransformArgs()
-    val_transform_args.resolve_auto(model_init_args={})
-
-    train_model = DINOv3LTDETRObjectDetectionTrain(
-        model_name=model_name,
-        model_args=train_model_args,
-        data_args=data_args,
-        train_transform_args=train_transform_args,
-        val_transform_args=val_transform_args,
-        metric_args=ObjectDetectionTaskMetricArgs(),
-        load_weights=False,
-        gradient_accumulation_steps=1,
-    )
-    return train_model
 
 
 @pytest.mark.parametrize(

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -27,12 +27,12 @@ from lightly_train._task_models.dinov3_ltdetr_object_detection.train_model impor
     DINOv3LTDETRObjectDetectionTrain,
     DINOv3LTDETRObjectDetectionTrainArgs,
 )
-from lightly_train._task_models.object_detection_components.flat_cosine import (
-    FlatCosineLRScheduler,
-)
 from lightly_train._task_models.dinov3_ltdetr_object_detection.transforms import (
     DINOv3LTDETRObjectDetectionTrainTransformArgs,
     DINOv3LTDETRObjectDetectionValTransformArgs,
+)
+from lightly_train._task_models.object_detection_components.flat_cosine import (
+    FlatCosineLRScheduler,
 )
 
 
@@ -308,4 +308,3 @@ def test_rtdetr_transformer_v2_config__resolve_auto__patch_size(
     config.resolve_auto(patch_size=patch_size)
 
     assert config.feat_strides == feat_strides
-

--- a/tests/_task_models/object_detection_components/test_ltdetr_geometry.py
+++ b/tests/_task_models/object_detection_components/test_ltdetr_geometry.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from lightly_train._task_models.object_detection_components.ltdetr_geometry import (
+    ltdetr_image_size_divisor,
+)
+
+
+def test_ltdetr_image_size_divisor() -> None:
+    assert ltdetr_image_size_divisor(14) == 28
+    assert ltdetr_image_size_divisor(16) == 32

--- a/tests/_task_models/object_detection_components/test_ltdetr_geometry.py
+++ b/tests/_task_models/object_detection_components/test_ltdetr_geometry.py
@@ -1,3 +1,10 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
 from __future__ import annotations
 
 from lightly_train._task_models.object_detection_components.ltdetr_geometry import (


### PR DESCRIPTION
## What has changed and why?

This PR adds configurable `patch_size` support for DINOv3 LT-DETR.

- `patch_size` now resolves from:
  1. an explicit `model_args.patch_size`
  2. `model_init_args["patch_size"]`
  3. the DINOv3 model name when `patch_size="auto"`
- The resolved value is forwarded to the backbone, including the ConvNeXt wrapper, so LT-DETR can work with variable patch sizes consistently.

## How has it been tested?

- Added/updated tests in `tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py` covering:
  - auto resolution from model name
  - resolution from `model_init_args`
  - explicit `patch_size`
  - ConvNeXt `auto` passthrough
  - explicit ConvNeXt override

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
