### PR TITLE
Fix PicoDet finetune with mismatched num_classes

### DIFF
--- a/src/lightly_train/_task_models/picodet_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/task_model.py
@@ -108,6 +108,7 @@ class PicoDetObjectDetection(TaskModel):
         self.register_buffer(
             "internal_class_to_class",
             torch.tensor(internal_class_to_class, dtype=torch.long),
+            persistent=False,
         )
 
         config = _MODEL_CONFIGS.get(model_name)
@@ -324,7 +325,7 @@ class PicoDetObjectDetection(TaskModel):
         has_ema_weights = any(k.startswith("ema_model.model.") for k in state_dict)
         has_model_weights = any(k.startswith("model.") for k in state_dict)
 
-        new_state_dict = {}
+        new_state_dict: dict[str, Any] = {}
         if has_ema_weights:
             for name, param in state_dict.items():
                 if name.startswith("ema_model.model."):
@@ -336,12 +337,12 @@ class PicoDetObjectDetection(TaskModel):
                     new_name = name[len("model.") :]
                     new_state_dict[new_name] = param
         else:
-            new_state_dict = state_dict
+            new_state_dict = dict(state_dict)
 
-        if "internal_class_to_class" not in new_state_dict:
-            new_state_dict["internal_class_to_class"] = (
-                self.internal_class_to_class.detach().clone()
-            )
+        # Drop the legacy persistent buffer so checkpoints saved before
+        # internal_class_to_class became non-persistent still load cleanly,
+        # even when num_classes differs from the checkpoint.
+        new_state_dict.pop("internal_class_to_class", None)
 
         return self.load_state_dict(new_state_dict, strict=strict, assign=assign)
 

--- a/src/lightly_train/_task_models/picodet_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/task_model.py
@@ -325,7 +325,7 @@ class PicoDetObjectDetection(TaskModel):
         has_ema_weights = any(k.startswith("ema_model.model.") for k in state_dict)
         has_model_weights = any(k.startswith("model.") for k in state_dict)
 
-        new_state_dict: dict[str, Any] = {}
+        new_state_dict = {}
         if has_ema_weights:
             for name, param in state_dict.items():
                 if name.startswith("ema_model.model."):
@@ -337,13 +337,7 @@ class PicoDetObjectDetection(TaskModel):
                     new_name = name[len("model.") :]
                     new_state_dict[new_name] = param
         else:
-            new_state_dict = dict(state_dict)
-
-        # TODO(Nauryzbay, 05/2026): Remove this pop once no PicoDet checkpoints
-        # with the legacy persistent internal_class_to_class buffer exist in
-        # the wild. It is only kept for backwards compatibility with checkpoints
-        # saved before the buffer became non-persistent.
-        new_state_dict.pop("internal_class_to_class", None)
+            new_state_dict = state_dict
 
         return self.load_state_dict(new_state_dict, strict=strict, assign=assign)
 

--- a/src/lightly_train/_task_models/picodet_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/task_model.py
@@ -339,9 +339,10 @@ class PicoDetObjectDetection(TaskModel):
         else:
             new_state_dict = dict(state_dict)
 
-        # Drop the legacy persistent buffer so checkpoints saved before
-        # internal_class_to_class became non-persistent still load cleanly,
-        # even when num_classes differs from the checkpoint.
+        # TODO(Nauryzbay, 05/2026): Remove this pop once no PicoDet checkpoints
+        # with the legacy persistent internal_class_to_class buffer exist in
+        # the wild. It is only kept for backwards compatibility with checkpoints
+        # saved before the buffer became non-persistent.
         new_state_dict.pop("internal_class_to_class", None)
 
         return self.load_state_dict(new_state_dict, strict=strict, assign=assign)


### PR DESCRIPTION
## What has changed and why?

Fixes `RuntimeError: size mismatch for internal_class_to_class` when finetuning PicoDet from a checkpoint with a different `num_classes` (e.g. COCO 80 → custom 70).

`internal_class_to_class` was a persistent buffer, so PyTorch's shape check fired before `strict` gating and raised even under `strict=False`.

Mirrors the `DINOv3LTDETRObjectDetection` pattern:
- Register the buffer with `persistent=False` (it is fully derived from `classes`, which `init_args` already persists).
- Pop the legacy key in `load_train_state_dict` so older checkpoints still load under `strict=True`.

`gfl_cls` reinit is already handled by the existing pre-hook in `pico_head.py`. 

## How has it been tested?

- Re-ran the reported COCO→70-class finetune script; loads cleanly.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
