### PR TITLE
Add image logging for instance segmentation training

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -114,7 +114,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
             torch.tensor(internal_class_to_class, dtype=torch.long),
             persistent=False,  # No need to save it in the state dict.
         )
-        
+
         self.included_classes: dict[int, str] = {
             internal_class_id: class_name
             for internal_class_id, class_name in enumerate(self.classes.values())

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -114,6 +114,11 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
             torch.tensor(internal_class_to_class, dtype=torch.long),
             persistent=False,  # No need to save it in the state dict.
         )
+        
+        self.included_classes: dict[int, str] = {
+            internal_class_id: class_name
+            for internal_class_id, class_name in enumerate(self.classes.values())
+        }
 
         # Disable drop path by default.
         backbone_model_args = {

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
@@ -51,10 +51,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.instance_segmentation import (
-    plot_instance_segmentation_labels,
-    plot_instance_segmentation_predictions,
-)
+from lightly_train._visualize import instance_segmentation
 from lightly_train.types import InstanceSegmentationBatch, PathLike
 
 
@@ -322,7 +319,7 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
 
         label_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_instance_segmentation_labels(
+            label_image = instance_segmentation.plot_instance_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -431,21 +428,23 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_instance_segmentation_labels(
+            label_image = instance_segmentation.plot_instance_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 max_images=self.viz_max_images,
                 image_normalize=self.model.image_normalize,
                 alpha=self.viz_alpha,
             )
-            prediction_image = plot_instance_segmentation_predictions(
-                batch=batch,
-                predictions=predictions,
-                class_names=self.model.included_classes,
-                max_images=self.viz_max_images,
-                image_normalize=self.model.image_normalize,
-                alpha=self.viz_alpha,
-                score_threshold=self.viz_score_threshold,
+            prediction_image = (
+                instance_segmentation.plot_instance_segmentation_predictions(
+                    batch=batch,
+                    predictions=predictions,
+                    class_names=self.model.included_classes,
+                    max_images=self.viz_max_images,
+                    image_normalize=self.model.image_normalize,
+                    alpha=self.viz_alpha,
+                    score_threshold=self.viz_score_threshold,
+                )
             )
 
         return TaskStepResult(

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, Literal
 import torch
 import torch.nn.functional as F
 from lightning_fabric import Fabric
+from PIL.Image import Image as PILImage
 from torch import Tensor
 from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import LRScheduler
@@ -50,6 +51,10 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
+from lightly_train._visualize.instance_segmentation import (
+    plot_instance_segmentation_labels,
+    plot_instance_segmentation_predictions,
+)
 from lightly_train.types import InstanceSegmentationBatch, PathLike
 
 
@@ -233,6 +238,12 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
         _torch_helpers.register_load_state_dict_pre_hook(
             self, hooks.criterion_empty_weight_reinit_hook
         )
+        # TODO(Nauryz, 04/2026): These visualization thresholds are currently
+        # hardcoded, but we may want to make them configurable in the future
+        # (with logger_args).
+        self.viz_max_images = 4
+        self.viz_alpha = 0.5
+        self.viz_score_threshold = 0.1
 
     def get_task_model(self) -> DINOv2EoMTInstanceSegmentation:
         return self.model
@@ -309,10 +320,21 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
                 final_iter=no_auto(self.model_args.attn_mask_annealing_steps_end)[i],
             )
 
+        label_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = plot_instance_segmentation_labels(
+                batch=batch,
+                class_names=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
+            )
+
         return TaskStepResult(
             loss=loss,
             log_dict=mask_prob_dict,
             metrics=self.train_metrics,
+            label_image=label_image,
         )
 
     def validation_step(
@@ -406,10 +428,32 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
 
         self.val_metrics.update_with_predictions(preds=predictions, target=binary_masks)
 
+        label_image: PILImage | None = None
+        prediction_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = plot_instance_segmentation_labels(
+                batch=batch,
+                class_names=self.model.included_classes,
+                max_images=self.viz_max_images,
+                image_normalize=self.model.image_normalize,
+                alpha=self.viz_alpha,
+            )
+            prediction_image = plot_instance_segmentation_predictions(
+                batch=batch,
+                predictions=predictions,
+                class_names=self.model.included_classes,
+                max_images=self.viz_max_images,
+                image_normalize=self.model.image_normalize,
+                alpha=self.viz_alpha,
+                score_threshold=self.viz_score_threshold,
+            )
+
         return TaskStepResult(
             loss=loss,
             log_dict={},
             metrics=self.val_metrics,
+            label_image=label_image,
+            prediction_image=prediction_image,
         )
 
     def mask_annealing(

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -330,7 +330,7 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_semantic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -425,7 +425,7 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_semantic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -434,7 +434,7 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
                 prediction_image = plot_semantic_segmentation_predictions(
                     batch=batch,
                     logits=pred_logits,
-                    included_classes=self.model.included_classes,
+                    class_names=self.model.included_classes,
                     image_normalize=self.model.image_normalize,
                     max_images=self.viz_max_images,
                     alpha=self.viz_alpha,

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/train_model.py
@@ -51,10 +51,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.semantic_segmentation import (
-    plot_semantic_segmentation_labels,
-    plot_semantic_segmentation_predictions,
-)
+from lightly_train._visualize import semantic_segmentation
 from lightly_train.types import MaskSemanticSegmentationBatch, PathLike
 
 
@@ -328,7 +325,7 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
             )
         label_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_semantic_segmentation_labels(
+            label_image = semantic_segmentation.plot_semantic_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -423,7 +420,7 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_semantic_segmentation_labels(
+            label_image = semantic_segmentation.plot_semantic_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -431,13 +428,15 @@ class DINOv2EoMTSemanticSegmentationTrain(TrainModel):
                 alpha=self.viz_alpha,
             )
             if pred_logits is not None:
-                prediction_image = plot_semantic_segmentation_predictions(
-                    batch=batch,
-                    logits=pred_logits,
-                    class_names=self.model.included_classes,
-                    image_normalize=self.model.image_normalize,
-                    max_images=self.viz_max_images,
-                    alpha=self.viz_alpha,
+                prediction_image = (
+                    semantic_segmentation.plot_semantic_segmentation_predictions(
+                        batch=batch,
+                        logits=pred_logits,
+                        class_names=self.model.included_classes,
+                        image_normalize=self.model.image_normalize,
+                        max_images=self.viz_max_images,
+                        alpha=self.viz_alpha,
+                    )
                 )
 
         return TaskStepResult(

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/train_model.py
@@ -179,7 +179,7 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_semantic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -231,7 +231,7 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_semantic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -240,7 +240,7 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
                 prediction_image = plot_semantic_segmentation_predictions(
                     batch=batch,
                     logits=logits,
-                    included_classes=self.model.included_classes,
+                    class_names=self.model.included_classes,
                     image_normalize=self.model.image_normalize,
                     max_images=self.viz_max_images,
                     alpha=self.viz_alpha,

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/train_model.py
@@ -45,10 +45,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.semantic_segmentation import (
-    plot_semantic_segmentation_labels,
-    plot_semantic_segmentation_predictions,
-)
+from lightly_train._visualize import semantic_segmentation
 from lightly_train.types import MaskSemanticSegmentationBatch, PathLike
 
 
@@ -177,7 +174,7 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
 
         label_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_semantic_segmentation_labels(
+            label_image = semantic_segmentation.plot_semantic_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -229,7 +226,7 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_semantic_segmentation_labels(
+            label_image = semantic_segmentation.plot_semantic_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -237,13 +234,15 @@ class DINOv2LinearSemanticSegmentationTrain(TrainModel):
                 alpha=self.viz_alpha,
             )
             if logits is not None:
-                prediction_image = plot_semantic_segmentation_predictions(
-                    batch=batch,
-                    logits=logits,
-                    class_names=self.model.included_classes,
-                    image_normalize=self.model.image_normalize,
-                    max_images=self.viz_max_images,
-                    alpha=self.viz_alpha,
+                prediction_image = (
+                    semantic_segmentation.plot_semantic_segmentation_predictions(
+                        batch=batch,
+                        logits=logits,
+                        class_names=self.model.included_classes,
+                        image_normalize=self.model.image_normalize,
+                        max_images=self.viz_max_images,
+                        alpha=self.viz_alpha,
+                    )
                 )
 
         return TaskStepResult(

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -330,7 +330,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             )
             label_image = plot_object_detection_labels(
                 batch=batch,
-                included_classes=self.data_args.included_classes,
+                class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 max_images=self.viz_max_images,
@@ -425,7 +425,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             )
             label_image = plot_object_detection_labels(
                 batch=batch,
-                included_classes=self.data_args.included_classes,
+                class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 max_images=self.viz_max_images,
@@ -433,7 +433,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             prediction_image = plot_object_detection_predictions(
                 batch=batch,
                 results=results,
-                included_classes=self.data_args.included_classes,
+                class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 score_threshold=self.viz_score_threshold,

--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/train_model.py
@@ -63,10 +63,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.object_detection import (
-    plot_object_detection_labels,
-    plot_object_detection_predictions,
-)
+from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
 
 
@@ -328,7 +325,7 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             normalize_std = (
                 tuple(self._normalize.std) if self._normalize is not None else None
             )
-            label_image = plot_object_detection_labels(
+            label_image = object_detection.plot_object_detection_labels(
                 batch=batch,
                 class_names=self.data_args.included_classes,
                 mean=normalize_mean,
@@ -423,14 +420,14 @@ class DINOv2LTDETRObjectDetectionTrain(TrainModel):
             normalize_std = (
                 tuple(self._normalize.std) if self._normalize is not None else None
             )
-            label_image = plot_object_detection_labels(
+            label_image = object_detection.plot_object_detection_labels(
                 batch=batch,
                 class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 max_images=self.viz_max_images,
             )
-            prediction_image = plot_object_detection_predictions(
+            prediction_image = object_detection.plot_object_detection_predictions(
                 batch=batch,
                 results=results,
                 class_names=self.data_args.included_classes,

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -116,6 +116,12 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
             persistent=False,  # No need to save it in the state dict.
         )
 
+        self.included_classes: dict[int, str] = {
+            internal_class_id: class_name
+            for internal_class_id, class_name in enumerate(self.classes.values())
+        }
+
+
         # NOTE(Guarin, 08/25): We don't set drop_path_rate=0 here because it is already
         # set by DINOv3.
         backbone_model_args: dict[str, Any] = {}

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -121,7 +121,6 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
             for internal_class_id, class_name in enumerate(self.classes.values())
         }
 
-
         # NOTE(Guarin, 08/25): We don't set drop_path_rate=0 here because it is already
         # set by DINOv3.
         backbone_model_args: dict[str, Any] = {}

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -248,6 +248,8 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         # hardcoded, but we may want to make them configurable in the future
         # (with logger_args).
         self.viz_max_images = 4
+        self.viz_alpha = 0.5
+        self.viz_score_threshold = 0.1
 
     def get_task_model(self) -> DINOv3EoMTInstanceSegmentation:
         return self.model
@@ -326,9 +328,10 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_instance_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
             )
 
         return TaskStepResult(
@@ -437,16 +440,19 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_instance_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
-                image_normalize=self.model.image_normalize,
+                class_names=self.model.included_classes,
                 max_images=self.viz_max_images,
+                image_normalize=self.model.image_normalize,
+                alpha=self.viz_alpha,
             )
             prediction_image = plot_instance_segmentation_predictions(
                 batch=batch,
                 predictions=predictions,
-                included_classes=self.model.included_classes,
-                image_normalize=self.model.image_normalize,
+                class_names=self.model.included_classes,
                 max_images=self.viz_max_images,
+                image_normalize=self.model.image_normalize,
+                alpha=self.viz_alpha,
+                score_threshold=self.viz_score_threshold,
             )
         return TaskStepResult(
             loss=loss,

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -51,10 +51,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.instance_segmentation import (
-    plot_instance_segmentation_labels,
-    plot_instance_segmentation_predictions,
-)
+from lightly_train._visualize import instance_segmentation
 from lightly_train.types import InstanceSegmentationBatch, PathLike
 
 
@@ -326,7 +323,7 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
 
         label_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_instance_segmentation_labels(
+            label_image = instance_segmentation.plot_instance_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -438,21 +435,23 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_instance_segmentation_labels(
+            label_image = instance_segmentation.plot_instance_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 max_images=self.viz_max_images,
                 image_normalize=self.model.image_normalize,
                 alpha=self.viz_alpha,
             )
-            prediction_image = plot_instance_segmentation_predictions(
-                batch=batch,
-                predictions=predictions,
-                class_names=self.model.included_classes,
-                max_images=self.viz_max_images,
-                image_normalize=self.model.image_normalize,
-                alpha=self.viz_alpha,
-                score_threshold=self.viz_score_threshold,
+            prediction_image = (
+                instance_segmentation.plot_instance_segmentation_predictions(
+                    batch=batch,
+                    predictions=predictions,
+                    class_names=self.model.included_classes,
+                    max_images=self.viz_max_images,
+                    image_normalize=self.model.image_normalize,
+                    alpha=self.viz_alpha,
+                    score_threshold=self.viz_score_threshold,
+                )
             )
         return TaskStepResult(
             loss=loss,

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -244,7 +244,6 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
             self, hooks.criterion_empty_weight_reinit_hook
         )
 
-
         # TODO(Nauryz, 04/2026): These visualization thresholds are currently
         # hardcoded, but we may want to make them configurable in the future
         # (with logger_args).
@@ -433,7 +432,6 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
             target=binary_masks,
         )
 
-
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
@@ -457,7 +455,6 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
             label_image=label_image,
             prediction_image=prediction_image,
         )
-
 
     def mask_annealing(
         self,

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, Literal
 import torch
 import torch.nn.functional as F
 from lightning_fabric import Fabric
+from PIL.Image import Image as PILImage
 from torch import Tensor
 from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import LRScheduler
@@ -50,6 +51,10 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
+from lightly_train._visualize.instance_segmentation import (
+    plot_instance_segmentation_labels,
+    plot_instance_segmentation_predictions,
+)
 from lightly_train.types import InstanceSegmentationBatch, PathLike
 
 
@@ -239,6 +244,12 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
             self, hooks.criterion_empty_weight_reinit_hook
         )
 
+
+        # TODO(Nauryz, 04/2026): These visualization thresholds are currently
+        # hardcoded, but we may want to make them configurable in the future
+        # (with logger_args).
+        self.viz_max_images = 4
+
     def get_task_model(self) -> DINOv3EoMTInstanceSegmentation:
         return self.model
 
@@ -312,10 +323,20 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
                 final_iter=no_auto(self.model_args.attn_mask_annealing_steps_end)[i],
             )
 
+        label_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = plot_instance_segmentation_labels(
+                batch=batch,
+                included_classes=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+            )
+
         return TaskStepResult(
             loss=loss,
             log_dict=mask_prob_dict,
             metrics=self.train_metrics,
+            label_image=label_image,
         )
 
     def validation_step(
@@ -412,11 +433,31 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
             target=binary_masks,
         )
 
+
+        label_image: PILImage | None = None
+        prediction_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = plot_instance_segmentation_labels(
+                batch=batch,
+                included_classes=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+            )
+            prediction_image = plot_instance_segmentation_predictions(
+                batch=batch,
+                predictions=predictions,
+                included_classes=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+            )
         return TaskStepResult(
             loss=loss,
             log_dict={},
             metrics=self.val_metrics,
+            label_image=label_image,
+            prediction_image=prediction_image,
         )
+
 
     def mask_annealing(
         self,

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
@@ -358,7 +358,7 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_semantic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -452,7 +452,7 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
         if step < 3 and fabric.global_rank == 0:
             label_image = plot_semantic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -461,7 +461,7 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
                 prediction_image = plot_semantic_segmentation_predictions(
                     batch=batch,
                     logits=pred_logits,
-                    included_classes=self.model.included_classes,
+                    class_names=self.model.included_classes,
                     image_normalize=self.model.image_normalize,
                     max_images=self.viz_max_images,
                     alpha=self.viz_alpha,

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
@@ -54,10 +54,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.semantic_segmentation import (
-    plot_semantic_segmentation_labels,
-    plot_semantic_segmentation_predictions,
-)
+from lightly_train._visualize import semantic_segmentation
 from lightly_train.types import MaskSemanticSegmentationBatch, PathLike
 
 logger = logging.getLogger(__name__)
@@ -356,7 +353,7 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
 
         label_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_semantic_segmentation_labels(
+            label_image = semantic_segmentation.plot_semantic_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -450,7 +447,7 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_semantic_segmentation_labels(
+            label_image = semantic_segmentation.plot_semantic_segmentation_labels(
                 batch=batch,
                 class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
@@ -458,13 +455,15 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
                 alpha=self.viz_alpha,
             )
             if pred_logits is not None:
-                prediction_image = plot_semantic_segmentation_predictions(
-                    batch=batch,
-                    logits=pred_logits,
-                    class_names=self.model.included_classes,
-                    image_normalize=self.model.image_normalize,
-                    max_images=self.viz_max_images,
-                    alpha=self.viz_alpha,
+                prediction_image = (
+                    semantic_segmentation.plot_semantic_segmentation_predictions(
+                        batch=batch,
+                        logits=pred_logits,
+                        class_names=self.model.included_classes,
+                        image_normalize=self.model.image_normalize,
+                        max_images=self.viz_max_images,
+                        alpha=self.viz_alpha,
+                    )
                 )
 
         return TaskStepResult(

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -333,7 +333,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             )
             label_image = plot_object_detection_labels(
                 batch=batch,
-                included_classes=self.data_args.included_classes,
+                class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 max_images=self.viz_max_images,
@@ -425,7 +425,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             )
             label_image = plot_object_detection_labels(
                 batch=batch,
-                included_classes=self.data_args.included_classes,
+                class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 max_images=self.viz_max_images,
@@ -433,7 +433,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             prediction_image = plot_object_detection_predictions(
                 batch=batch,
                 results=results,
-                included_classes=self.data_args.included_classes,
+                class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 score_threshold=self.viz_score_threshold,

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/train_model.py
@@ -63,10 +63,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.object_detection import (
-    plot_object_detection_labels,
-    plot_object_detection_predictions,
-)
+from lightly_train._visualize import object_detection
 from lightly_train.types import ObjectDetectionBatch, PathLike
 
 
@@ -331,7 +328,7 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             normalize_std = (
                 tuple(self._normalize.std) if self._normalize is not None else None
             )
-            label_image = plot_object_detection_labels(
+            label_image = object_detection.plot_object_detection_labels(
                 batch=batch,
                 class_names=self.data_args.included_classes,
                 mean=normalize_mean,
@@ -423,14 +420,14 @@ class DINOv3LTDETRObjectDetectionTrain(TrainModel):
             normalize_std = (
                 tuple(self._normalize.std) if self._normalize is not None else None
             )
-            label_image = plot_object_detection_labels(
+            label_image = object_detection.plot_object_detection_labels(
                 batch=batch,
                 class_names=self.data_args.included_classes,
                 mean=normalize_mean,
                 std=normalize_std,
                 max_images=self.viz_max_images,
             )
-            prediction_image = plot_object_detection_predictions(
+            prediction_image = object_detection.plot_object_detection_predictions(
                 batch=batch,
                 results=results,
                 class_names=self.data_args.included_classes,

--- a/src/lightly_train/_visualize/image_classification.py
+++ b/src/lightly_train/_visualize/image_classification.py
@@ -14,11 +14,7 @@ from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
-from lightly_train._visualize.utils import (
-    _denormalize_image,
-    _draw_class_legend,
-    _render_grid,
-)
+from lightly_train._visualize import utils
 from lightly_train.types import ImageClassificationBatch
 
 
@@ -50,7 +46,7 @@ def plot_image_classification_labels(
     for i in range(n):
         image_tensor = images[i].clone().to(dtype=torch.float32)
         if image_normalize is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=image_normalize["mean"],
                 std=image_normalize["std"],
@@ -61,11 +57,11 @@ def plot_image_classification_labels(
         labels = [
             included_classes.get(int(cid), f"Class {int(cid)}") for cid in gt_classes[i]
         ]
-        img = _draw_class_legend(image=img, labels=labels, colors=None)
+        img = utils._draw_class_legend(image=img, labels=labels, colors=None)
 
         pil_images.append(img)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)
 
 
 def plot_image_classification_predictions(
@@ -116,7 +112,7 @@ def plot_image_classification_predictions(
     for i in range(n):
         image_tensor = images[i].clone().to(dtype=torch.float32)
         if image_normalize is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=image_normalize["mean"],
                 std=image_normalize["std"],
@@ -134,8 +130,8 @@ def plot_image_classification_predictions(
             score = float(top_scores[i, rank].item())
             class_name = included_classes.get(class_id, f"Class {class_id}")
             labels.append(f"{class_name}: {score:.2f}")
-        img = _draw_class_legend(image=img, labels=labels, colors=None)
+        img = utils._draw_class_legend(image=img, labels=labels, colors=None)
 
         pil_images.append(img)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)

--- a/src/lightly_train/_visualize/instance_segmentation.py
+++ b/src/lightly_train/_visualize/instance_segmentation.py
@@ -12,14 +12,7 @@ from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
-from lightly_train._visualize.utils import (
-    _bboxes_from_masks,
-    _build_instance_mask_overlay,
-    _cxcywh_to_xyxy,
-    _denormalize_image,
-    _draw_labeled_boxes,
-    _render_grid,
-)
+from lightly_train._visualize import utils
 from lightly_train.types import InstanceSegmentationBatch
 
 
@@ -63,7 +56,7 @@ def plot_instance_segmentation_labels(
     for i in range(n):
         image_tensor = gt_images[i].clone()
         if image_normalize is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=image_normalize["mean"],
                 std=image_normalize["std"],
@@ -74,12 +67,14 @@ def plot_instance_segmentation_labels(
         labels = binary_masks_list[i]["labels"].cpu()
         bboxes_norm = bboxes_list[i].cpu()
 
-        overlay = _build_instance_mask_overlay(
+        overlay = utils._build_instance_mask_overlay(
             masks=masks, labels=labels, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
-        bboxes_xyxy = _cxcywh_to_xyxy(boxes=bboxes_norm, w=img.size[0], h=img.size[1])
-        _draw_labeled_boxes(
+        bboxes_xyxy = utils._cxcywh_to_xyxy(
+            boxes=bboxes_norm, w=img.size[0], h=img.size[1]
+        )
+        utils._draw_labeled_boxes(
             image=blended,
             bboxes_xyxy=bboxes_xyxy,
             labels=labels,
@@ -88,7 +83,7 @@ def plot_instance_segmentation_labels(
         )
         pil_images.append(blended)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)
 
 
 def plot_instance_segmentation_predictions(
@@ -135,7 +130,7 @@ def plot_instance_segmentation_predictions(
     for i in range(n):
         image_tensor = gt_images[i].clone()
         if image_normalize is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=image_normalize["mean"],
                 std=image_normalize["std"],
@@ -151,13 +146,13 @@ def plot_instance_segmentation_predictions(
         labels = labels[keep_scores]
         scores = scores[keep_scores]
 
-        overlay = _build_instance_mask_overlay(
+        overlay = utils._build_instance_mask_overlay(
             masks=masks, labels=labels, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
 
-        bboxes_xyxy, keep = _bboxes_from_masks(masks=masks)
-        _draw_labeled_boxes(
+        bboxes_xyxy, keep = utils._bboxes_from_masks(masks=masks)
+        utils._draw_labeled_boxes(
             image=blended,
             bboxes_xyxy=bboxes_xyxy,
             labels=labels[keep],
@@ -166,4 +161,4 @@ def plot_instance_segmentation_predictions(
         )
         pil_images.append(blended)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)

--- a/src/lightly_train/_visualize/instance_segmentation.py
+++ b/src/lightly_train/_visualize/instance_segmentation.py
@@ -29,7 +29,7 @@ def plot_instance_segmentation_labels(
     included_classes: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
-    alpha: float = 0.6,
+    alpha: float = 0.3,
 ) -> PILImage:
     """Render a grid of images annotated with ground truth instance segmentation masks.
 
@@ -91,9 +91,7 @@ def plot_instance_segmentation_labels(
             for box, class_id in zip(bboxes_xyxy, labels):
                 x1, y1, x2, y2 = box.tolist()
                 class_id_int = int(class_id)
-                class_name = included_classes.get(
-                    class_id_int, f"Class {class_id_int}"
-                )
+                class_name = included_classes.get(class_id_int, f"Class {class_id_int}")
                 color = _get_class_color(class_id_int)
                 draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
                 _draw_bbox_label(
@@ -115,9 +113,9 @@ def plot_instance_segmentation_predictions(
     included_classes: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
-    score_threshold: float = 0.5,
+    score_threshold: float = 0.1,
     max_predictions: int = 100,
-    alpha: float = 0.6,
+    alpha: float = 0.3,
 ) -> PILImage:
     """Render a grid of images annotated with predicted instance segmentation masks.
 
@@ -197,9 +195,7 @@ def plot_instance_segmentation_predictions(
                 x2 = int(xs.max())
                 y2 = int(ys.max())
                 class_id_int = int(class_id)
-                class_name = included_classes.get(
-                    class_id_int, f"Class {class_id_int}"
-                )
+                class_name = included_classes.get(class_id_int, f"Class {class_id_int}")
                 color = _get_class_color(class_id_int)
                 draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
                 _draw_bbox_label(

--- a/src/lightly_train/_visualize/instance_segmentation.py
+++ b/src/lightly_train/_visualize/instance_segmentation.py
@@ -1,0 +1,287 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import torch
+from PIL import Image
+from PIL.Image import Image as PILImage
+from PIL.ImageDraw import ImageDraw as PILDraw
+from torch import Tensor
+from torchvision.transforms import functional as torchvision_functional
+
+from lightly_train._visualize.utils import (
+    _cxcywh_to_xyxy,
+    _denormalize_image,
+    _draw_bbox_label,
+    _get_class_color,
+    _render_grid,
+)
+from lightly_train.types import InstanceSegmentationBatch
+
+
+def plot_instance_segmentation_labels(
+    batch: InstanceSegmentationBatch,
+    included_classes: dict[int, str],
+    max_images: int,
+    image_normalize: dict[str, tuple[float, ...]] | None,
+    alpha: float = 0.6,
+) -> PILImage:
+    """Render a grid of images annotated with ground truth instance segmentation masks.
+
+    Each instance is overlaid in the color of its class and outlined with a thin
+    contour that separates it from the background and from neighboring instances
+    of the same class. The class name is rendered as a label at the top-left
+    corner of each instance's bounding box.
+
+    Args:
+        batch: Instance segmentation batch with images, per-image binary masks
+            (one mask per instance) and bboxes (cxcywh normalized). Mask labels
+            are internal contiguous class indices.
+        included_classes: A dict mapping internal class IDs to class names.
+        max_images: Maximum number of images to include in the grid.
+        image_normalize: Optional dict with "mean" and "std" tuples used to
+            denormalize images before rendering. If None, images pass through
+            unchanged.
+        alpha: Blending factor for the mask overlay in [0, 1]. 0 shows only the
+            image, 1 shows only the mask.
+
+    Returns:
+        A single PIL image containing up to max_images annotated images arranged
+        in a grid.
+    """
+    images = batch["image"]
+    binary_masks_list = batch["binary_masks"]
+    bboxes_list = batch["bboxes"]
+    gt_images = (
+        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+    )
+    n = min(max_images, len(gt_images))
+
+    pil_images: list[PILImage] = []
+    for i in range(n):
+        image_tensor = gt_images[i].clone()
+        if image_normalize is not None:
+            image_tensor = _denormalize_image(
+                image=image_tensor,
+                mean=image_normalize["mean"],
+                std=image_normalize["std"],
+            )
+        img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
+        masks = binary_masks_list[i]["masks"].cpu()
+        labels = binary_masks_list[i]["labels"].cpu()
+        bboxes = bboxes_list[i].cpu()
+
+        class_mask, instance_id_mask = _build_class_and_instance_id_masks(
+            masks=masks, labels=labels
+        )
+        overlay = _build_class_overlay(
+            class_mask=class_mask, size=img.size, class_names=included_classes
+        )
+        blended = Image.blend(img, overlay, alpha=alpha)
+
+        if len(bboxes) > 0:
+            img_width, img_height = blended.size
+            bboxes_xyxy = _cxcywh_to_xyxy(boxes=bboxes, w=img_width, h=img_height)
+            draw = PILDraw(blended)
+            for box, class_id in zip(bboxes_xyxy, labels):
+                x1, y1, x2, y2 = box.tolist()
+                class_id_int = int(class_id)
+                class_name = included_classes.get(
+                    class_id_int, f"Class {class_id_int}"
+                )
+                color = _get_class_color(class_id_int)
+                draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
+                _draw_bbox_label(
+                    draw=draw,
+                    x1=x1,
+                    y1=y1,
+                    text=class_name,
+                    color=color,
+                )
+
+        pil_images.append(blended)
+
+    return _render_grid(pil_images)
+
+
+def plot_instance_segmentation_predictions(
+    batch: InstanceSegmentationBatch,
+    predictions: list[dict[str, Tensor]],
+    included_classes: dict[int, str],
+    max_images: int,
+    image_normalize: dict[str, tuple[float, ...]] | None,
+    score_threshold: float = 0.5,
+    max_predictions: int = 100,
+    alpha: float = 0.6,
+) -> PILImage:
+    """Render a grid of images annotated with predicted instance segmentation masks.
+
+    Predictions are filtered by score_threshold and capped at max_predictions per
+    image, keeping the highest-confidence instances. Each kept instance is
+    overlaid in the color of its class and outlined with a bounding box derived
+    from the mask. The class name and score are rendered as a label at the
+    top-left corner of each instance's bounding box.
+
+    Args:
+        batch: Instance segmentation batch with images.
+        predictions: A list of per-image dicts with "labels" of shape (Q,),
+            "masks" of shape (Q, H, W) and "scores" of shape (Q,). Labels are
+            internal contiguous class indices.
+        included_classes: A dict mapping internal class IDs to class names.
+        max_images: Maximum number of images to include in the grid.
+        image_normalize: Optional dict with "mean" and "std" tuples used to
+            denormalize images before rendering. If None, images pass through
+            unchanged.
+        score_threshold: Minimum score for a predicted instance to be shown.
+        max_predictions: Maximum number of predicted instances to show per image.
+        alpha: Blending factor for the mask overlay in [0, 1]. 0 shows only the
+            image, 1 shows only the mask.
+
+    Returns:
+        A single PIL image containing up to max_images annotated images arranged
+        in a grid.
+    """
+    images = batch["image"]
+    gt_images = (
+        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+    )
+    n = min(max_images, len(gt_images))
+
+    pil_images: list[PILImage] = []
+    for i in range(n):
+        image_tensor = gt_images[i].clone()
+        if image_normalize is not None:
+            image_tensor = _denormalize_image(
+                image=image_tensor,
+                mean=image_normalize["mean"],
+                std=image_normalize["std"],
+            )
+        img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
+
+        pred = predictions[i]
+        masks = pred["masks"].cpu()
+        labels = pred["labels"].cpu()
+        scores = pred["scores"].cpu()
+
+        keep = scores >= score_threshold
+        masks = masks[keep]
+        labels = labels[keep]
+        scores = scores[keep]
+        if scores.numel() > max_predictions:
+            order = torch.argsort(scores, descending=True)[:max_predictions]
+            masks = masks[order]
+            labels = labels[order]
+            scores = scores[order]
+
+        class_mask, _ = _build_class_and_instance_id_masks(
+            masks=masks.bool(), labels=labels
+        )
+        overlay = _build_class_overlay(
+            class_mask=class_mask, size=img.size, class_names=included_classes
+        )
+        blended = Image.blend(img, overlay, alpha=alpha)
+
+        if masks.shape[0] > 0:
+            draw = PILDraw(blended)
+            for mask, class_id, score in zip(masks, labels, scores):
+                ys, xs = torch.where(mask)
+                if ys.numel() == 0:
+                    continue
+                x1 = int(xs.min())
+                y1 = int(ys.min())
+                x2 = int(xs.max())
+                y2 = int(ys.max())
+                class_id_int = int(class_id)
+                class_name = included_classes.get(
+                    class_id_int, f"Class {class_id_int}"
+                )
+                color = _get_class_color(class_id_int)
+                draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
+                _draw_bbox_label(
+                    draw=draw,
+                    x1=x1,
+                    y1=y1,
+                    text=f"{class_name} {float(score):.2f}",
+                    color=color,
+                )
+
+        pil_images.append(blended)
+
+    return _render_grid(pil_images)
+
+
+def _build_class_and_instance_id_masks(
+    masks: Tensor,
+    labels: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Build 2D class id and instance id masks from per-instance binary masks.
+
+    Larger instances are painted first so that smaller, nested instances remain
+    visible on top. Background pixels keep a sentinel value of -1 in both
+    masks; this value is never a valid class id or instance index, so it stays
+    transparent in the overlay and produces clean boundaries against any
+    foreground.
+
+    Args:
+        masks: Boolean tensor of shape (n_instances, H, W).
+        labels: Tensor of shape (n_instances,) with internal class ids.
+
+    Returns:
+        A (class_mask, instance_id_mask) tuple, each a tensor of shape (H, W).
+    """
+    h, w = masks.shape[-2:]
+    class_mask = torch.full((h, w), -1, dtype=torch.long)
+    instance_id_mask = torch.full((h, w), -1, dtype=torch.long)
+    if masks.shape[0] == 0:
+        return class_mask, instance_id_mask
+
+    areas = masks.flatten(1).sum(dim=1)
+    order = torch.argsort(areas, descending=True)
+    for idx in order.tolist():
+        mask = masks[idx]
+        class_mask[mask] = int(labels[idx])
+        instance_id_mask[mask] = idx
+    return class_mask, instance_id_mask
+
+
+def _build_class_overlay(
+    class_mask: Tensor,
+    size: tuple[int, int],
+    class_names: dict[int, str],
+) -> PILImage:
+    """Build an RGB overlay image where each pixel is colored by its class id.
+
+    Only ids that appear as keys of ``class_names`` are colored; other ids are
+    left black.
+
+    Args:
+        class_mask: Tensor of shape (H, W) with internal class ids and -1 for
+            background.
+        size: Target (width, height) of the overlay.
+        class_names: Mapping from class id to class name.
+
+    Returns:
+        RGB PIL image of the requested size.
+    """
+    h, w = class_mask.shape[-2:]
+    overlay = torch.zeros((3, h, w), dtype=torch.uint8)
+    for class_id in torch.unique(class_mask).tolist():
+        class_id = int(class_id)
+        if class_id not in class_names:
+            continue
+        color = _get_class_color(class_id)
+        class_pixels = class_mask == class_id
+        for c in range(3):
+            overlay[c][class_pixels] = color[c]
+
+    overlay_img: PILImage = Image.fromarray(overlay.permute(1, 2, 0).numpy()).convert(
+        "RGB"
+    )
+    if overlay_img.size != size:
+        overlay_img = overlay_img.resize(size, resample=Image.Resampling.NEAREST)
+    return overlay_img

--- a/src/lightly_train/_visualize/instance_segmentation.py
+++ b/src/lightly_train/_visualize/instance_segmentation.py
@@ -7,18 +7,17 @@
 #
 from __future__ import annotations
 
-import torch
 from PIL import Image
 from PIL.Image import Image as PILImage
-from PIL.ImageDraw import ImageDraw as PILDraw
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
 from lightly_train._visualize.utils import (
+    _bboxes_from_masks,
+    _build_instance_mask_overlay,
     _cxcywh_to_xyxy,
     _denormalize_image,
-    _draw_bbox_label,
-    _get_class_color,
+    _draw_labeled_boxes,
     _render_grid,
 )
 from lightly_train.types import InstanceSegmentationBatch
@@ -26,23 +25,21 @@ from lightly_train.types import InstanceSegmentationBatch
 
 def plot_instance_segmentation_labels(
     batch: InstanceSegmentationBatch,
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
-    alpha: float = 0.3,
+    alpha: float,
 ) -> PILImage:
     """Render a grid of images annotated with ground truth instance segmentation masks.
 
-    Each instance is overlaid in the color of its class and outlined with a thin
-    contour that separates it from the background and from neighboring instances
-    of the same class. The class name is rendered as a label at the top-left
-    corner of each instance's bounding box.
+    Each instance is overlaid in the color of its class.
+    The class name is rendered as a label at the top-left corner of each instance's bounding box.
 
     Args:
         batch: Instance segmentation batch with images, per-image binary masks
             (one mask per instance) and bboxes (cxcywh normalized). Mask labels
             are internal contiguous class indices.
-        included_classes: A dict mapping internal class IDs to class names.
+        class_names: A dict mapping internal class IDs to class names.
         max_images: Maximum number of images to include in the grid.
         image_normalize: Optional dict with "mean" and "std" tuples used to
             denormalize images before rendering. If None, images pass through
@@ -72,36 +69,23 @@ def plot_instance_segmentation_labels(
                 std=image_normalize["std"],
             )
         img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
-        masks = binary_masks_list[i]["masks"].cpu()
-        labels = binary_masks_list[i]["labels"].cpu()
-        bboxes = bboxes_list[i].cpu()
 
-        class_mask, instance_id_mask = _build_class_and_instance_id_masks(
-            masks=masks, labels=labels
-        )
-        overlay = _build_class_overlay(
-            class_mask=class_mask, size=img.size, class_names=included_classes
+        masks = binary_masks_list[i]["masks"].cpu().bool()
+        labels = binary_masks_list[i]["labels"].cpu()
+        bboxes_norm = bboxes_list[i].cpu()
+
+        overlay = _build_instance_mask_overlay(
+            masks=masks, labels=labels, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
-
-        if len(bboxes) > 0:
-            img_width, img_height = blended.size
-            bboxes_xyxy = _cxcywh_to_xyxy(boxes=bboxes, w=img_width, h=img_height)
-            draw = PILDraw(blended)
-            for box, class_id in zip(bboxes_xyxy, labels):
-                x1, y1, x2, y2 = box.tolist()
-                class_id_int = int(class_id)
-                class_name = included_classes.get(class_id_int, f"Class {class_id_int}")
-                color = _get_class_color(class_id_int)
-                draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
-                _draw_bbox_label(
-                    draw=draw,
-                    x1=x1,
-                    y1=y1,
-                    text=class_name,
-                    color=color,
-                )
-
+        bboxes_xyxy = _cxcywh_to_xyxy(boxes=bboxes_norm, w=img.size[0], h=img.size[1])
+        _draw_labeled_boxes(
+            image=blended,
+            bboxes_xyxy=bboxes_xyxy,
+            labels=labels,
+            scores=None,
+            class_names=class_names,
+        )
         pil_images.append(blended)
 
     return _render_grid(pil_images)
@@ -110,35 +94,32 @@ def plot_instance_segmentation_labels(
 def plot_instance_segmentation_predictions(
     batch: InstanceSegmentationBatch,
     predictions: list[dict[str, Tensor]],
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
-    score_threshold: float = 0.1,
-    max_predictions: int = 100,
-    alpha: float = 0.3,
+    alpha: float,
+    score_threshold: float,
 ) -> PILImage:
     """Render a grid of images annotated with predicted instance segmentation masks.
 
-    Predictions are filtered by score_threshold and capped at max_predictions per
-    image, keeping the highest-confidence instances. Each kept instance is
-    overlaid in the color of its class and outlined with a bounding box derived
-    from the mask. The class name and score are rendered as a label at the
-    top-left corner of each instance's bounding box.
+    Each instance is overlaid in the color of its class. The class name and score
+    are rendered as a label at the top-left corner of each instance's bounding box,
+    where the bounding box is derived from the predicted mask. Predictions with a
+    score below score_threshold are filtered out.
 
     Args:
         batch: Instance segmentation batch with images.
         predictions: A list of per-image dicts with "labels" of shape (Q,),
             "masks" of shape (Q, H, W) and "scores" of shape (Q,). Labels are
             internal contiguous class indices.
-        included_classes: A dict mapping internal class IDs to class names.
+        class_names: A dict mapping internal class IDs to class names.
         max_images: Maximum number of images to include in the grid.
         image_normalize: Optional dict with "mean" and "std" tuples used to
             denormalize images before rendering. If None, images pass through
             unchanged.
-        score_threshold: Minimum score for a predicted instance to be shown.
-        max_predictions: Maximum number of predicted instances to show per image.
         alpha: Blending factor for the mask overlay in [0, 1]. 0 shows only the
             image, 1 shows only the mask.
+        score_threshold: Minimum score for a predicted instance to be shown.
 
     Returns:
         A single PIL image containing up to max_images annotated images arranged
@@ -161,123 +142,28 @@ def plot_instance_segmentation_predictions(
             )
         img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
 
-        pred = predictions[i]
-        masks = pred["masks"].cpu()
-        labels = pred["labels"].cpu()
-        scores = pred["scores"].cpu()
+        masks = predictions[i]["masks"].cpu().bool()
+        labels = predictions[i]["labels"].cpu()
+        scores = predictions[i]["scores"].cpu()
 
-        keep = scores >= score_threshold
-        masks = masks[keep]
-        labels = labels[keep]
-        scores = scores[keep]
-        if scores.numel() > max_predictions:
-            order = torch.argsort(scores, descending=True)[:max_predictions]
-            masks = masks[order]
-            labels = labels[order]
-            scores = scores[order]
+        keep_scores = scores >= score_threshold
+        masks = masks[keep_scores]
+        labels = labels[keep_scores]
+        scores = scores[keep_scores]
 
-        class_mask, _ = _build_class_and_instance_id_masks(
-            masks=masks.bool(), labels=labels
-        )
-        overlay = _build_class_overlay(
-            class_mask=class_mask, size=img.size, class_names=included_classes
+        overlay = _build_instance_mask_overlay(
+            masks=masks, labels=labels, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
 
-        if masks.shape[0] > 0:
-            draw = PILDraw(blended)
-            for mask, class_id, score in zip(masks, labels, scores):
-                ys, xs = torch.where(mask)
-                if ys.numel() == 0:
-                    continue
-                x1 = int(xs.min())
-                y1 = int(ys.min())
-                x2 = int(xs.max())
-                y2 = int(ys.max())
-                class_id_int = int(class_id)
-                class_name = included_classes.get(class_id_int, f"Class {class_id_int}")
-                color = _get_class_color(class_id_int)
-                draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
-                _draw_bbox_label(
-                    draw=draw,
-                    x1=x1,
-                    y1=y1,
-                    text=f"{class_name} {float(score):.2f}",
-                    color=color,
-                )
-
+        bboxes_xyxy, keep = _bboxes_from_masks(masks=masks)
+        _draw_labeled_boxes(
+            image=blended,
+            bboxes_xyxy=bboxes_xyxy,
+            labels=labels[keep],
+            scores=scores[keep],
+            class_names=class_names,
+        )
         pil_images.append(blended)
 
     return _render_grid(pil_images)
-
-
-def _build_class_and_instance_id_masks(
-    masks: Tensor,
-    labels: Tensor,
-) -> tuple[Tensor, Tensor]:
-    """Build 2D class id and instance id masks from per-instance binary masks.
-
-    Larger instances are painted first so that smaller, nested instances remain
-    visible on top. Background pixels keep a sentinel value of -1 in both
-    masks; this value is never a valid class id or instance index, so it stays
-    transparent in the overlay and produces clean boundaries against any
-    foreground.
-
-    Args:
-        masks: Boolean tensor of shape (n_instances, H, W).
-        labels: Tensor of shape (n_instances,) with internal class ids.
-
-    Returns:
-        A (class_mask, instance_id_mask) tuple, each a tensor of shape (H, W).
-    """
-    h, w = masks.shape[-2:]
-    class_mask = torch.full((h, w), -1, dtype=torch.long)
-    instance_id_mask = torch.full((h, w), -1, dtype=torch.long)
-    if masks.shape[0] == 0:
-        return class_mask, instance_id_mask
-
-    areas = masks.flatten(1).sum(dim=1)
-    order = torch.argsort(areas, descending=True)
-    for idx in order.tolist():
-        mask = masks[idx]
-        class_mask[mask] = int(labels[idx])
-        instance_id_mask[mask] = idx
-    return class_mask, instance_id_mask
-
-
-def _build_class_overlay(
-    class_mask: Tensor,
-    size: tuple[int, int],
-    class_names: dict[int, str],
-) -> PILImage:
-    """Build an RGB overlay image where each pixel is colored by its class id.
-
-    Only ids that appear as keys of ``class_names`` are colored; other ids are
-    left black.
-
-    Args:
-        class_mask: Tensor of shape (H, W) with internal class ids and -1 for
-            background.
-        size: Target (width, height) of the overlay.
-        class_names: Mapping from class id to class name.
-
-    Returns:
-        RGB PIL image of the requested size.
-    """
-    h, w = class_mask.shape[-2:]
-    overlay = torch.zeros((3, h, w), dtype=torch.uint8)
-    for class_id in torch.unique(class_mask).tolist():
-        class_id = int(class_id)
-        if class_id not in class_names:
-            continue
-        color = _get_class_color(class_id)
-        class_pixels = class_mask == class_id
-        for c in range(3):
-            overlay[c][class_pixels] = color[c]
-
-    overlay_img: PILImage = Image.fromarray(overlay.permute(1, 2, 0).numpy()).convert(
-        "RGB"
-    )
-    if overlay_img.size != size:
-        overlay_img = overlay_img.resize(size, resample=Image.Resampling.NEAREST)
-    return overlay_img

--- a/src/lightly_train/_visualize/object_detection.py
+++ b/src/lightly_train/_visualize/object_detection.py
@@ -9,15 +9,13 @@ from __future__ import annotations
 
 import torch
 from PIL.Image import Image as PILImage
-from PIL.ImageDraw import ImageDraw as PILDraw
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
 from lightly_train._visualize.utils import (
     _cxcywh_to_xyxy,
     _denormalize_image,
-    _draw_bbox_label,
-    _get_class_color,
+    _draw_labeled_boxes,
     _render_grid,
 )
 from lightly_train.types import ObjectDetectionBatch
@@ -25,7 +23,7 @@ from lightly_train.types import ObjectDetectionBatch
 
 def plot_object_detection_labels(
     batch: ObjectDetectionBatch,
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     mean: tuple[float, ...] | None = None,
     std: tuple[float, ...] | None = None,
@@ -35,7 +33,7 @@ def plot_object_detection_labels(
     Args:
         batch: Object detection batch with images, bboxes (cxcywh normalized), and
             classes.
-        included_classes: Mapping from class ID to class name.
+        class_names: Mapping from class ID to class name.
         mean: Per-channel mean used for image normalization (for denormalization).
         std: Per-channel std used for image normalization (for denormalization).
         max_images: Maximum number of images to include in the grid.
@@ -57,26 +55,17 @@ def plot_object_detection_labels(
 
         _, img_height, img_width = image_tensor.shape
         img = torchvision_functional.to_pil_image(image_tensor)
-        draw = PILDraw(img)
 
         boxes = gt_bboxes[i]
         class_ids = gt_classes[i]
-        if len(boxes) > 0:
-            boxes_xyxy = _cxcywh_to_xyxy(boxes=boxes, w=img_width, h=img_height)
-            for box, class_id in zip(boxes_xyxy, class_ids):
-                x1, y1, x2, y2 = box.tolist()
-                class_name = included_classes.get(
-                    int(class_id), f"Class {int(class_id)}"
-                )
-                color = _get_class_color(int(class_id))
-                draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
-                _draw_bbox_label(
-                    draw=draw,
-                    x1=x1,
-                    y1=y1,
-                    text=class_name,
-                    color=color,
-                )
+        boxes_xyxy = _cxcywh_to_xyxy(boxes=boxes, w=img_width, h=img_height)
+        _draw_labeled_boxes(
+            image=img,
+            bboxes_xyxy=boxes_xyxy,
+            labels=class_ids,
+            scores=None,
+            class_names=class_names,
+        )
         pil_images.append(img)
 
     return _render_grid(pil_images)
@@ -85,7 +74,7 @@ def plot_object_detection_labels(
 def plot_object_detection_predictions(
     batch: ObjectDetectionBatch,
     results: list[dict[str, Tensor]],
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     score_threshold: float,
     max_pred_boxes: int,
@@ -101,7 +90,7 @@ def plot_object_detection_predictions(
         batch: Object detection batch with images and original_size.
         results: Postprocessor outputs, each a dict with 'boxes' (xyxy in original
             image coordinates), 'labels', and 'scores'.
-        included_classes: Mapping from class ID to class name.
+        class_names: Mapping from class ID to class name.
         score_threshold: Minimum score for a predicted box to be shown.
         max_pred_boxes: Maximum number of predicted boxes to show per image.
         mean: Per-channel mean used for image normalization (for denormalization).
@@ -132,7 +121,6 @@ def plot_object_detection_predictions(
             )
 
         img = torchvision_functional.to_pil_image(image_tensor)
-        draw = PILDraw(img)
 
         result = results[i]
         boxes = result["boxes"]
@@ -159,20 +147,13 @@ def plot_object_detection_predictions(
                 class_ids = class_ids[order]
                 scores = scores[order]
 
-                for box, class_id, score in zip(boxes, class_ids, scores):
-                    x1, y1, x2, y2 = box.tolist()
-                    class_name = included_classes.get(
-                        int(class_id), f"Class {int(class_id)}"
-                    )
-                    color = _get_class_color(int(class_id))
-                    draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
-                    _draw_bbox_label(
-                        draw=draw,
-                        x1=x1,
-                        y1=y1,
-                        text=f"{class_name} {score:.2f}",
-                        color=color,
-                    )
+                _draw_labeled_boxes(
+                    image=img,
+                    bboxes_xyxy=boxes,
+                    labels=class_ids,
+                    scores=scores,
+                    class_names=class_names,
+                )
         pil_images.append(img)
 
     return _render_grid(pil_images)

--- a/src/lightly_train/_visualize/object_detection.py
+++ b/src/lightly_train/_visualize/object_detection.py
@@ -12,12 +12,7 @@ from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
-from lightly_train._visualize.utils import (
-    _cxcywh_to_xyxy,
-    _denormalize_image,
-    _draw_labeled_boxes,
-    _render_grid,
-)
+from lightly_train._visualize import utils
 from lightly_train.types import ObjectDetectionBatch
 
 
@@ -51,15 +46,17 @@ def plot_object_detection_labels(
     for i in range(n):
         image_tensor = gt_images[i].clone().to(dtype=torch.float32)
         if mean is not None and std is not None:
-            image_tensor = _denormalize_image(image=image_tensor, mean=mean, std=std)
+            image_tensor = utils._denormalize_image(
+                image=image_tensor, mean=mean, std=std
+            )
 
         _, img_height, img_width = image_tensor.shape
         img = torchvision_functional.to_pil_image(image_tensor)
 
         boxes = gt_bboxes[i]
         class_ids = gt_classes[i]
-        boxes_xyxy = _cxcywh_to_xyxy(boxes=boxes, w=img_width, h=img_height)
-        _draw_labeled_boxes(
+        boxes_xyxy = utils._cxcywh_to_xyxy(boxes=boxes, w=img_width, h=img_height)
+        utils._draw_labeled_boxes(
             image=img,
             bboxes_xyxy=boxes_xyxy,
             labels=class_ids,
@@ -68,7 +65,7 @@ def plot_object_detection_labels(
         )
         pil_images.append(img)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)
 
 
 def plot_object_detection_predictions(
@@ -114,7 +111,7 @@ def plot_object_detection_predictions(
     for i in range(n):
         image_tensor = gt_images[i].clone().to(dtype=torch.float32)
         if mean is not None and std is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=mean,
                 std=std,
@@ -147,7 +144,7 @@ def plot_object_detection_predictions(
                 class_ids = class_ids[order]
                 scores = scores[order]
 
-                _draw_labeled_boxes(
+                utils._draw_labeled_boxes(
                     image=img,
                     bboxes_xyxy=boxes,
                     labels=class_ids,
@@ -156,4 +153,4 @@ def plot_object_detection_predictions(
                 )
         pil_images.append(img)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)

--- a/src/lightly_train/_visualize/semantic_segmentation.py
+++ b/src/lightly_train/_visualize/semantic_segmentation.py
@@ -14,7 +14,7 @@ from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
 from lightly_train._visualize.utils import (
-    _build_mask_overlay,
+    _build_semantic_mask_overlay,
     _denormalize_image,
     _draw_class_legend,
     _draw_mask_contours,
@@ -26,7 +26,7 @@ from lightly_train.types import MaskSemanticSegmentationBatch
 
 def plot_semantic_segmentation_labels(
     batch: MaskSemanticSegmentationBatch,
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
     alpha: float,
@@ -38,7 +38,7 @@ def plot_semantic_segmentation_labels(
             are internal contiguous class indices, not original class ids. Masks
             may also contain the raw class_ignore_index value (e.g. -100), which
             is not a contiguous internal class id.
-        included_classes: A dict mapping internal class IDs to class names. May
+        class_names: A dict mapping internal class IDs to class names. May
             also contain class_ignore_index mapped to "ignored" when masks
             include ignored pixels.
         max_images: Maximum number of images to include in the grid.
@@ -72,15 +72,13 @@ def plot_semantic_segmentation_labels(
         img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
         mask = gt_masks[i]
 
-        overlay = _build_mask_overlay(
-            mask=mask, size=img.size, class_names=included_classes
+        overlay = _build_semantic_mask_overlay(
+            mask=mask, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
         blended = _draw_mask_contours(image=blended, mask=mask)
 
-        labels, colors = _legend_entries_for_mask(
-            mask=mask, class_names=included_classes
-        )
+        labels, colors = _legend_entries_for_mask(mask=mask, class_names=class_names)
         blended = _draw_class_legend(image=blended, labels=labels, colors=colors)
 
         pil_images.append(blended)
@@ -91,7 +89,7 @@ def plot_semantic_segmentation_labels(
 def plot_semantic_segmentation_predictions(
     batch: MaskSemanticSegmentationBatch,
     logits: list[Tensor],
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
     alpha: float,
@@ -101,7 +99,7 @@ def plot_semantic_segmentation_predictions(
     Args:
         batch: Semantic segmentation batch with images.
         logits: List of per-image logit tensors of shape (C, H, W).
-        included_classes: A dict mapping internal class IDs to class names.
+        class_names: A dict mapping internal class IDs to class names.
         max_images: Maximum number of images to include in the grid.
         image_normalize: Optional dict with "mean" and "std" tuples used to
             denormalize images before rendering. If None, images pass through
@@ -133,14 +131,14 @@ def plot_semantic_segmentation_predictions(
         logits_i = logits[i].cpu()
         pred_mask = torch.argmax(logits_i, dim=0)
 
-        overlay = _build_mask_overlay(
-            mask=pred_mask, size=img.size, class_names=included_classes
+        overlay = _build_semantic_mask_overlay(
+            mask=pred_mask, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
         blended = _draw_mask_contours(image=blended, mask=pred_mask)
 
         labels, colors = _legend_entries_for_mask(
-            mask=pred_mask, class_names=included_classes
+            mask=pred_mask, class_names=class_names
         )
         blended = _draw_class_legend(image=blended, labels=labels, colors=colors)
 

--- a/src/lightly_train/_visualize/semantic_segmentation.py
+++ b/src/lightly_train/_visualize/semantic_segmentation.py
@@ -13,14 +13,7 @@ from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
-from lightly_train._visualize.utils import (
-    _build_semantic_mask_overlay,
-    _denormalize_image,
-    _draw_class_legend,
-    _draw_mask_contours,
-    _legend_entries_for_mask,
-    _render_grid,
-)
+from lightly_train._visualize import utils
 from lightly_train.types import MaskSemanticSegmentationBatch
 
 
@@ -64,7 +57,7 @@ def plot_semantic_segmentation_labels(
     for i in range(n):
         image_tensor = gt_images[i].clone()
         if image_normalize is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=image_normalize["mean"],
                 std=image_normalize["std"],
@@ -72,18 +65,20 @@ def plot_semantic_segmentation_labels(
         img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
         mask = gt_masks[i]
 
-        overlay = _build_semantic_mask_overlay(
+        overlay = utils._build_semantic_mask_overlay(
             mask=mask, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
-        blended = _draw_mask_contours(image=blended, mask=mask)
+        blended = utils._draw_mask_contours(image=blended, mask=mask)
 
-        labels, colors = _legend_entries_for_mask(mask=mask, class_names=class_names)
-        blended = _draw_class_legend(image=blended, labels=labels, colors=colors)
+        labels, colors = utils._legend_entries_for_mask(
+            mask=mask, class_names=class_names
+        )
+        blended = utils._draw_class_legend(image=blended, labels=labels, colors=colors)
 
         pil_images.append(blended)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)
 
 
 def plot_semantic_segmentation_predictions(
@@ -121,7 +116,7 @@ def plot_semantic_segmentation_predictions(
     for i in range(n):
         image_tensor = gt_images[i].clone()
         if image_normalize is not None:
-            image_tensor = _denormalize_image(
+            image_tensor = utils._denormalize_image(
                 image=image_tensor,
                 mean=image_normalize["mean"],
                 std=image_normalize["std"],
@@ -131,17 +126,17 @@ def plot_semantic_segmentation_predictions(
         logits_i = logits[i].cpu()
         pred_mask = torch.argmax(logits_i, dim=0)
 
-        overlay = _build_semantic_mask_overlay(
+        overlay = utils._build_semantic_mask_overlay(
             mask=pred_mask, size=img.size, class_names=class_names
         )
         blended = Image.blend(img, overlay, alpha=alpha)
-        blended = _draw_mask_contours(image=blended, mask=pred_mask)
+        blended = utils._draw_mask_contours(image=blended, mask=pred_mask)
 
-        labels, colors = _legend_entries_for_mask(
+        labels, colors = utils._legend_entries_for_mask(
             mask=pred_mask, class_names=class_names
         )
-        blended = _draw_class_legend(image=blended, labels=labels, colors=colors)
+        blended = utils._draw_class_legend(image=blended, labels=labels, colors=colors)
 
         pil_images.append(blended)
 
-    return _render_grid(pil_images)
+    return utils._render_grid(pil_images)

--- a/src/lightly_train/_visualize/utils.py
+++ b/src/lightly_train/_visualize/utils.py
@@ -232,20 +232,53 @@ def _render_grid(pil_images: list[PILImage]) -> PILImage:
     return grid
 
 
-def _build_mask_overlay(
+def _build_instance_mask_overlay(
+    masks: Tensor,
+    labels: Tensor,
+    size: tuple[int, int],
+    class_names: dict[int, str],
+) -> PILImage:
+    """Build an RGB overlay image colored by class id from per-instance binary masks.
+
+    Instances may overlap; later instances overwrite earlier ones. Only ids that
+    appear as keys of ``class_names`` are colored; pixels with any other id are
+    left black.
+
+    Args:
+        masks: Boolean tensor of shape (n_instances, H, W).
+        labels: Tensor of shape (n_instances,) with internal class ids.
+        size: Target (width, height) of the overlay.
+        class_names: Mapping from class id to class name. Only ids that appear
+            as keys are colored; other ids are left black.
+
+    Returns:
+        RGB PIL image of the requested size.
+    """
+    h, w = masks.shape[-2:]
+    overlay = torch.zeros((3, h, w), dtype=torch.uint8)
+    for idx in range(masks.shape[0]):
+        class_id = int(labels[idx])
+        if class_id not in class_names:
+            continue
+        color = _get_class_color(class_id)
+        for c in range(3):
+            overlay[c][masks[idx]] = color[c]
+
+    return _overlay_to_pil(overlay=overlay, size=size)
+
+
+def _build_semantic_mask_overlay(
     mask: Tensor,
     size: tuple[int, int],
     class_names: dict[int, str],
 ) -> PILImage:
-    """Build an RGB overlay image where each pixel is colored by its class id.
+    """Build an RGB overlay image colored by class id from a 2D class mask.
 
     Only ids that appear as keys of ``class_names`` are colored; pixels with
-    any other id are left black. Note that the ignore index is colored when
-    callers include it as a key in ``class_names`` (e.g. mapped to
-    ``"ignored"``) and left black otherwise.
+    any other id are left black.
 
     Args:
-        mask: Tensor of shape (H, W) with internal contiguous class indices.
+        mask: Tensor of shape (H, W) with internal class ids per pixel.
         size: Target (width, height) of the overlay.
         class_names: Mapping from class id to class name. Only ids that appear
             as keys are colored; other ids are left black.
@@ -260,10 +293,15 @@ def _build_mask_overlay(
         if class_id not in class_names:
             continue
         color = _get_class_color(class_id)
-        class_pixels = mask == class_id
+        pixels = mask == class_id
         for c in range(3):
-            overlay[c][class_pixels] = color[c]
+            overlay[c][pixels] = color[c]
 
+    return _overlay_to_pil(overlay=overlay, size=size)
+
+
+def _overlay_to_pil(overlay: Tensor, size: tuple[int, int]) -> PILImage:
+    """Convert a (3, H, W) uint8 overlay tensor to a resized RGB PIL image."""
     overlay_img: PILImage = Image.fromarray(overlay.permute(1, 2, 0).numpy()).convert(
         "RGB"
     )
@@ -348,3 +386,63 @@ def _cxcywh_to_xyxy(boxes: Tensor, w: int, h: int) -> Tensor:
     boxes_xyxy[:, 2] = (cx + bw / 2) * w
     boxes_xyxy[:, 3] = (cy + bh / 2) * h
     return boxes_xyxy
+
+
+def _bboxes_from_masks(masks: Tensor) -> tuple[Tensor, Tensor]:
+    """Derive xyxy bounding boxes from per-instance binary masks.
+
+    Empty masks (no foreground pixels) are skipped: their entries do not appear
+    in the returned boxes and the corresponding entry in the keep tensor is
+    False. Callers should use the keep tensor to filter parallel arrays such as
+    labels and scores.
+
+    Args:
+        masks: Boolean tensor of shape (n_instances, H, W).
+
+    Returns:
+        A tuple (boxes, keep) where boxes has shape (n_kept, 4) in xyxy pixel
+        coordinates and keep is a boolean tensor of shape (n_instances,).
+    """
+    n = masks.shape[0]
+    boxes = torch.zeros((n, 4), dtype=torch.float32)
+    keep = torch.zeros((n,), dtype=torch.bool)
+    for i in range(n):
+        ys, xs = torch.where(masks[i])
+        if ys.numel() == 0:
+            continue
+        boxes[i, 0] = float(xs.min())
+        boxes[i, 1] = float(ys.min())
+        boxes[i, 2] = float(xs.max())
+        boxes[i, 3] = float(ys.max())
+        keep[i] = True
+    return boxes[keep], keep
+
+
+def _draw_labeled_boxes(
+    image: PILImage,
+    bboxes_xyxy: Tensor,
+    labels: Tensor,
+    scores: Tensor | None,
+    class_names: dict[int, str],
+) -> None:
+    """Draw a colored bounding box and class label per box, in place.
+
+    Args:
+        image: RGB PIL image to draw onto.
+        bboxes_xyxy: Tensor of shape (n_boxes, 4) in xyxy pixel coordinates.
+        labels: Tensor of shape (n_boxes,) with internal class ids.
+        scores: Optional tensor of shape (n_boxes,) with per-box scores. When
+            provided, scores are appended to each label.
+        class_names: A dict mapping internal class IDs to class names.
+    """
+    if bboxes_xyxy.shape[0] == 0:
+        return
+    draw = PILDraw(image)
+    for i in range(bboxes_xyxy.shape[0]):
+        x1, y1, x2, y2 = bboxes_xyxy[i].tolist()
+        class_id = int(labels[i])
+        class_name = class_names.get(class_id, f"Class {class_id}")
+        color = _get_class_color(class_id)
+        text = class_name if scores is None else f"{class_name} {float(scores[i]):.2f}"
+        draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
+        _draw_bbox_label(draw=draw, x1=x1, y1=y1, text=text, color=color)

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -306,7 +306,6 @@ def test_train_instance_segmentation(
     assert (image_examples_dir / "val_predictions_0.jpg").exists()
 
 
-
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
 @pytest.mark.skipif(
     is_self_hosted_docker_runner,

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -298,6 +298,14 @@ def test_train_instance_segmentation(
     assert results["masks"].shape[-2:] == dummy_input.shape[1:]
     assert results["scores"].ndim == 1
 
+    # Check that example images were logged for training and validation.
+    image_examples_dir = out / "image_examples"
+    assert image_examples_dir.exists()
+    assert (image_examples_dir / "train_labels_0.jpg").exists()
+    assert (image_examples_dir / "val_labels_0.jpg").exists()
+    assert (image_examples_dir / "val_predictions_0.jpg").exists()
+
+
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
 @pytest.mark.skipif(

--- a/tests/_visualize/test_instance_segmentation.py
+++ b/tests/_visualize/test_instance_segmentation.py
@@ -161,8 +161,8 @@ def test_plot_instance_segmentation_predictions__score_threshold_filters_low_sco
     None
 ):
     # Two predictions on a 128x128 black canvas:
-    #   instance 0: class 0, mask in rows/cols 0..63, score 0.9 → kept.
-    #   instance 1: class 1, mask in rows/cols 64..127, score 0.2 → dropped.
+    #   instance 0: class 0, mask in rows/cols 0..63, score 0.9 -> kept.
+    #   instance 1: class 1, mask in rows/cols 64..127, score 0.2 -> dropped.
     # The dropped instance must produce no overlay AND no bbox, so its bbox
     # corners must remain black. A bug that filters only the overlay but still
     # draws the box (or vice versa) would fail at these probes.
@@ -190,7 +190,7 @@ def test_plot_instance_segmentation_predictions__score_threshold_filters_low_sco
         alpha=1.0,
         score_threshold=0.5,
     )
-    # Kept instance: bbox is derived from mask extent → xyxy [0, 0, 63, 63].
+    # Kept instance: bbox is derived from mask extent -> xyxy [0, 0, 63, 63].
     # All four corners are painted in class 0's color.
     _assert_bbox_corners_have_color(
         image=result, xyxy=(0, 0, 63, 63), color=utils._get_class_color(0)

--- a/tests/_visualize/test_instance_segmentation.py
+++ b/tests/_visualize/test_instance_segmentation.py
@@ -1,0 +1,254 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import torch
+from PIL.Image import Image as PILImage
+from torch import Tensor
+
+from lightly_train._visualize import instance_segmentation, utils
+from lightly_train.types import BinaryMasksDict, InstanceSegmentationBatch
+
+_BACKGROUND_COLOR: float = 0.0
+_WHITE_COLOR: float = 1.0
+_BLACK_PIXEL: tuple[int, int, int] = (0, 0, 0)
+_WHITE_PIXEL: tuple[int, int, int] = (255, 255, 255)
+
+
+def _assert_bbox_corners_have_color(
+    *,
+    image: PILImage,
+    xyxy: tuple[int, int, int, int],
+    color: tuple[int, int, int],
+) -> None:
+    x1, y1, x2, y2 = xyxy
+    assert image.getpixel((x1, y1)) == color
+    assert image.getpixel((x2, y1)) == color
+    assert image.getpixel((x1, y2)) == color
+    assert image.getpixel((x2, y2)) == color
+
+
+def _make_batch(
+    *,
+    image: Tensor,
+    binary_masks: list[BinaryMasksDict],
+    bboxes: list[Tensor],
+) -> InstanceSegmentationBatch:
+    batch_size = image.shape[0]
+    classes = [bm["labels"] for bm in binary_masks]
+    return InstanceSegmentationBatch(
+        image_path=[f"img_{i}.png" for i in range(batch_size)],
+        image=image,
+        binary_masks=binary_masks,
+        bboxes=bboxes,
+        classes=classes,
+    )
+
+
+def _binary_masks_block(
+    *,
+    height: int,
+    width: int,
+    label: int,
+    y0: int,
+    x0: int,
+    y1: int,
+    x1: int,
+) -> BinaryMasksDict:
+    """Build a single-instance BinaryMasksDict whose mask covers [y0:y1, x0:x1]."""
+    masks = torch.zeros(1, height, width, dtype=torch.bool)
+    masks[0, y0:y1, x0:x1] = True
+    return BinaryMasksDict(masks=masks, labels=torch.tensor([label], dtype=torch.long))
+
+
+def _empty_binary_masks(*, height: int, width: int) -> BinaryMasksDict:
+    return BinaryMasksDict(
+        masks=torch.zeros(0, height, width, dtype=torch.bool),
+        labels=torch.zeros(0, dtype=torch.long),
+    )
+
+
+def test_plot_instance_segmentation_labels__overlay_and_bbox_use_class_color() -> None:
+    # 128x128 black canvas. Class 1 mask covers the top-left 64x64 region (rows
+    # and cols 0..63). cxcywh [0.25, 0.25, 0.5, 0.5] maps to xyxy [0, 0, 64, 64],
+    # tight around the mask. y1=0 is below label_height, so the label rectangle
+    # is drawn below the bbox top edge inside the box, near (0, 0). The probe
+    # (32, 32) sits below the label rect (~27 px tall) and away from the outline.
+    binary_masks = _binary_masks_block(
+        height=128, width=128, label=1, y0=0, x0=0, y1=64, x1=64
+    )
+    bboxes = [torch.tensor([[0.25, 0.25, 0.5, 0.5]])]
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _BACKGROUND_COLOR),
+        binary_masks=[binary_masks],
+        bboxes=bboxes,
+    )
+    result = instance_segmentation.plot_instance_segmentation_labels(
+        batch=batch,
+        class_names={1: "dog"},
+        max_images=1,
+        image_normalize=None,
+        alpha=1.0,
+    )
+    # All four bbox corners are painted in class 1's color.
+    _assert_bbox_corners_have_color(
+        image=result, xyxy=(0, 0, 64, 64), color=utils._get_class_color(1)
+    )
+    # Mask interior, below the label rect and off the bbox outline: at alpha=1
+    # the overlay alone determines the pixel, so it must be class 1's color.
+    # A buggy implementation that skips the overlay would leave this pixel black.
+    assert result.getpixel((32, 32)) == utils._get_class_color(1)
+    # Pixel far outside both mask and bbox: overlay is black there, and at
+    # alpha=1 the blended image equals the overlay, so the pixel stays black.
+    assert result.getpixel((100, 100)) == _BLACK_PIXEL
+
+
+def test_plot_instance_segmentation_labels__alpha_zero_keeps_image_in_mask_region() -> (
+    None
+):
+    # alpha=0 disables the overlay, so even pixels covered by the mask must
+    # retain the original image color. The bbox is still drawn afterwards, so
+    # we probe inside the bbox but well away from the outline and below the
+    # label rectangle.
+    binary_masks = _binary_masks_block(
+        height=128, width=128, label=1, y0=0, x0=0, y1=64, x1=64
+    )
+    bboxes = [torch.tensor([[0.25, 0.25, 0.5, 0.5]])]
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _WHITE_COLOR),
+        binary_masks=[binary_masks],
+        bboxes=bboxes,
+    )
+    result = instance_segmentation.plot_instance_segmentation_labels(
+        batch=batch,
+        class_names={1: "dog"},
+        max_images=1,
+        image_normalize=None,
+        alpha=0.0,
+    )
+    assert result.getpixel((32, 32)) == _WHITE_PIXEL
+
+
+def test_plot_instance_segmentation_labels__image_normalize_denormalizes() -> None:
+    # mean=std=0.5 maps a 0.0 tensor to 0.5 -> pixel 127. Without
+    # denormalization the input would render as black. The probe pixel is
+    # outside the mask and outside the bbox so it isn't overwritten.
+    binary_masks = _binary_masks_block(
+        height=64, width=64, label=1, y0=0, x0=0, y1=16, x1=16
+    )
+    bboxes = [torch.tensor([[0.125, 0.125, 0.25, 0.25]])]
+    batch = _make_batch(
+        image=torch.zeros(1, 3, 64, 64),
+        binary_masks=[binary_masks],
+        bboxes=bboxes,
+    )
+    result = instance_segmentation.plot_instance_segmentation_labels(
+        batch=batch,
+        class_names={1: "dog"},
+        max_images=1,
+        image_normalize={"mean": (0.5, 0.5, 0.5), "std": (0.5, 0.5, 0.5)},
+        alpha=0.0,
+    )
+    assert result.getpixel((63, 63)) == (127, 127, 127)
+
+
+def test_plot_instance_segmentation_predictions__score_threshold_filters_low_scores() -> (
+    None
+):
+    # Two predictions on a 128x128 black canvas:
+    #   instance 0: class 0, mask in rows/cols 0..63, score 0.9 → kept.
+    #   instance 1: class 1, mask in rows/cols 64..127, score 0.2 → dropped.
+    # The dropped instance must produce no overlay AND no bbox, so its bbox
+    # corners must remain black. A bug that filters only the overlay but still
+    # draws the box (or vice versa) would fail at these probes.
+    masks = torch.zeros(2, 128, 128, dtype=torch.bool)
+    masks[0, 0:64, 0:64] = True
+    masks[1, 64:128, 64:128] = True
+    predictions = [
+        {
+            "masks": masks,
+            "labels": torch.tensor([0, 1], dtype=torch.long),
+            "scores": torch.tensor([0.9, 0.2]),
+        }
+    ]
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _BACKGROUND_COLOR),
+        binary_masks=[_empty_binary_masks(height=128, width=128)],
+        bboxes=[torch.zeros(0, 4)],
+    )
+    result = instance_segmentation.plot_instance_segmentation_predictions(
+        batch=batch,
+        predictions=predictions,
+        class_names={0: "cat", 1: "dog"},
+        max_images=1,
+        image_normalize=None,
+        alpha=1.0,
+        score_threshold=0.5,
+    )
+    # Kept instance: bbox is derived from mask extent → xyxy [0, 0, 63, 63].
+    # All four corners are painted in class 0's color.
+    _assert_bbox_corners_have_color(
+        image=result, xyxy=(0, 0, 63, 63), color=utils._get_class_color(0)
+    )
+    # Mask interior of the kept instance: overlay paints class 0's color.
+    # Probe well below the label rect and off the bbox outline.
+    assert result.getpixel((32, 40)) == utils._get_class_color(0)
+    # Dropped instance region: no overlay (class 1 never got painted) and no
+    # bbox (filtered before _bboxes_from_masks). All four would-be corners
+    # stay black.
+    _assert_bbox_corners_have_color(
+        image=result, xyxy=(64, 64, 127, 127), color=_BLACK_PIXEL
+    )
+
+
+def test_plot_instance_segmentation_predictions__bbox_derived_from_mask_extent() -> (
+    None
+):
+    # The mask is a 32x32 block at rows/cols 16..47 on a 128x128 canvas.
+    # _bboxes_from_masks uses inclusive max coords (xs.max() / ys.max()),
+    # so the derived bbox is xyxy [16, 16, 47, 47]. alpha=0 disables the
+    # overlay so only the bbox is drawn — that isolates the bbox geometry.
+    # The mask sits in the canvas interior (not at origin) so a buggy
+    # implementation that always uses a fixed bbox (e.g. the full image, or
+    # the top-left corner) would mispaint the canvas corners.
+    masks = torch.zeros(1, 128, 128, dtype=torch.bool)
+    masks[0, 16:48, 16:48] = True
+    predictions = [
+        {
+            "masks": masks,
+            "labels": torch.tensor([0], dtype=torch.long),
+            "scores": torch.tensor([0.9]),
+        }
+    ]
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _BACKGROUND_COLOR),
+        binary_masks=[_empty_binary_masks(height=128, width=128)],
+        bboxes=[torch.zeros(0, 4)],
+    )
+    result = instance_segmentation.plot_instance_segmentation_predictions(
+        batch=batch,
+        predictions=predictions,
+        class_names={0: "cat"},
+        max_images=1,
+        image_normalize=None,
+        alpha=0.0,
+        score_threshold=0.5,
+    )
+    # Bbox corners are at exactly the mask extent. y1=16 is below
+    # label_height (~22), so the label is drawn below the box and its glyphs
+    # don't overlap the bottom corners we probe here.
+    _assert_bbox_corners_have_color(
+        image=result, xyxy=(16, 16, 47, 47), color=utils._get_class_color(0)
+    )
+    # Canvas corners far outside the mask remain background — a bbox spanning
+    # the full image would have painted these.
+    assert result.getpixel((0, 0)) == _BLACK_PIXEL
+    assert result.getpixel((127, 127)) == _BLACK_PIXEL
+    # Just outside the bbox stays untouched — proves the bbox is tight, not
+    # padded by some constant.
+    assert result.getpixel((48, 48)) == _BLACK_PIXEL

--- a/tests/_visualize/test_object_detection.py
+++ b/tests/_visualize/test_object_detection.py
@@ -91,7 +91,7 @@ class TestPlotObjectDetectionLabels:
     def test_plot_object_detection_labels_grid_caps_at_max_images(self) -> None:
         batch = _make_batch(batch_size=4, height=16, width=16)
         result = object_detection.plot_object_detection_labels(
-            batch=batch, included_classes={}, max_images=2
+            batch=batch, class_names={}, max_images=2
         )
         assert result.size == (32, 16)
 
@@ -107,7 +107,7 @@ class TestPlotObjectDetectionLabels:
             classes=classes,
         )
         result = object_detection.plot_object_detection_labels(
-            batch=batch, included_classes={1: "dog"}, max_images=1
+            batch=batch, class_names={1: "dog"}, max_images=1
         )
         # All four corners of the bbox outline must be painted with class 1's color.
         _assert_bbox_corners_have_color(
@@ -131,7 +131,7 @@ class TestPlotObjectDetectionLabels:
             classes=classes,
         )
         result = object_detection.plot_object_detection_labels(
-            batch=batch, included_classes={}, max_images=1
+            batch=batch, class_names={}, max_images=1
         )
         # Unknown class IDs still get a deterministic color from `_get_class_color`.
         _assert_bbox_corners_have_color(
@@ -169,7 +169,7 @@ class TestPlotObjectDetectionLabels:
         batch = _make_batch_from_image(image=torch.full((1, 3, 32, 32), image_value))
         result = object_detection.plot_object_detection_labels(
             batch=batch,
-            included_classes={},
+            class_names={},
             max_images=1,
             mean=mean,
             std=std,
@@ -185,7 +185,7 @@ class TestPlotObjectDetectionLabels:
         # Uniform 0.4 -> 102.
         batch = _make_batch_from_image(image=torch.full((1, 3, 32, 32), 0.4))
         result = object_detection.plot_object_detection_labels(
-            batch=batch, included_classes={}, max_images=1
+            batch=batch, class_names={}, max_images=1
         )
         assert result.getpixel((0, 0)) == (102, 102, 102)
         assert result.getpixel((31, 31)) == (102, 102, 102)
@@ -206,7 +206,7 @@ class TestPlotObjectDetectionLabels:
             classes=classes,
         )
         result = object_detection.plot_object_detection_labels(
-            batch=batch, included_classes={0: "cat"}, max_images=2
+            batch=batch, class_names={0: "cat"}, max_images=2
         )
         # Grid is 2×1 (128 wide, 64 tall): image 0 at x=0..63, image 1 at x=64..127.
         _assert_bbox_corners_have_color(
@@ -224,7 +224,7 @@ class TestPlotObjectDetectionPredictions:
         result = object_detection.plot_object_detection_predictions(
             batch=batch,
             results=results,
-            included_classes={},
+            class_names={},
             max_images=2,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -240,7 +240,7 @@ class TestPlotObjectDetectionPredictions:
         result = object_detection.plot_object_detection_predictions(
             batch=batch,
             results=_make_empty_results(batch_size=1),
-            included_classes={},
+            class_names={},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -270,7 +270,7 @@ class TestPlotObjectDetectionPredictions:
         result = object_detection.plot_object_detection_predictions(
             batch=batch,
             results=results,
-            included_classes={0: "cat"},
+            class_names={0: "cat"},
             max_images=2,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -299,7 +299,7 @@ class TestPlotObjectDetectionPredictions:
                     "scores": torch.tensor([score]),
                 }
             ],
-            included_classes={0: "cat"},
+            class_names={0: "cat"},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -347,7 +347,7 @@ class TestPlotObjectDetectionPredictions:
                     "scores": torch.tensor([0.60, 0.95, 0.55, 0.85, 0.75]),
                 }
             ],
-            included_classes={i: f"c{i}" for i in range(5)},
+            class_names={i: f"c{i}" for i in range(5)},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=3,
@@ -386,7 +386,7 @@ class TestPlotObjectDetectionPredictions:
                     "scores": torch.tensor([0.9]),
                 }
             ],
-            included_classes={},
+            class_names={},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -423,7 +423,7 @@ class TestPlotObjectDetectionPredictions:
         result = object_detection.plot_object_detection_predictions(
             batch=batch,
             results=_make_empty_results(batch_size=1),
-            included_classes={},
+            class_names={},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -444,7 +444,7 @@ class TestPlotObjectDetectionPredictions:
         result = object_detection.plot_object_detection_predictions(
             batch=batch,
             results=_make_empty_results(batch_size=1),
-            included_classes={},
+            class_names={},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -471,7 +471,7 @@ class TestPlotObjectDetectionPredictions:
                     "scores": torch.tensor([0.9]),
                 }
             ],
-            included_classes={0: "obj"},
+            class_names={0: "obj"},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,
@@ -503,7 +503,7 @@ class TestPlotObjectDetectionPredictions:
                     "scores": torch.tensor([0.9]),
                 }
             ],
-            included_classes={0: "obj"},
+            class_names={0: "obj"},
             max_images=1,
             score_threshold=0.5,
             max_pred_boxes=10,

--- a/tests/_visualize/test_semantic_segmentation.py
+++ b/tests/_visualize/test_semantic_segmentation.py
@@ -67,7 +67,7 @@ def test_plot_semantic_segmentation_labels__grid_caps_at_max_images() -> None:
     batch = _make_batch(batch_size=4, height=16, width=16)
     result = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={0: "_"},
+        class_names={0: "_"},
         max_images=2,
         image_normalize=None,
         alpha=0.0,
@@ -87,7 +87,7 @@ def test_plot_semantic_segmentation_labels__no_image_normalize_skips_denormaliza
     )
     result = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={},
+        class_names={},
         max_images=1,
         image_normalize=None,
         alpha=0.0,
@@ -105,7 +105,7 @@ def test_plot_semantic_segmentation_labels__image_normalize_denormalizes() -> No
     )
     result = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={},
+        class_names={},
         max_images=1,
         image_normalize={"mean": (0.5, 0.5, 0.5), "std": (0.5, 0.5, 0.5)},
         alpha=0.0,
@@ -126,7 +126,7 @@ def test_plot_semantic_segmentation_labels__alpha_one_replaces_image_with_mask_c
     )
     result = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={0: "cat"},
+        class_names={0: "cat"},
         max_images=1,
         image_normalize=None,
         alpha=1.0,
@@ -147,7 +147,7 @@ def test_plot_semantic_segmentation_labels__contours_drawn_at_class_boundary() -
     )
     result = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={0: "cat", 1: "dog"},
+        class_names={0: "cat", 1: "dog"},
         max_images=1,
         image_normalize=None,
         alpha=1.0,
@@ -173,14 +173,14 @@ def test_plot_semantic_segmentation_labels__legend_skips_class_not_in_included_c
     )
     with_known_class = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={0: "cat"},
+        class_names={0: "cat"},
         max_images=1,
         image_normalize=None,
         alpha=0.0,
     )
     with_unknown_class = semantic_segmentation.plot_semantic_segmentation_labels(
         batch=batch,
-        included_classes={1: "dog"},
+        class_names={1: "dog"},
         max_images=1,
         image_normalize=None,
         alpha=0.0,
@@ -209,7 +209,7 @@ def test_plot_semantic_segmentation_predictions__overlay_matches_argmax_class() 
     result = semantic_segmentation.plot_semantic_segmentation_predictions(
         batch=batch,
         logits=[logits],
-        included_classes={0: "cat", 1: "dog"},
+        class_names={0: "cat", 1: "dog"},
         max_images=1,
         image_normalize=None,
         alpha=1.0,

--- a/tests/_visualize/test_utils.py
+++ b/tests/_visualize/test_utils.py
@@ -141,8 +141,8 @@ def test__draw_class_legend__mismatched_colors_and_labels_raises() -> None:
 def test__build_semantic_mask_overlay__colors_known_classes_skips_unknown_and_resizes() -> (
     None
 ):
-    # Top half is class 0 (in class_names → colored). Bottom half is class 5
-    # (not in class_names → stays black). Output size differs from mask, so
+    # Top half is class 0 (in class_names -> colored). Bottom half is class 5
+    # (not in class_names -> stays black). Output size differs from mask, so
     # nearest-neighbor resize is exercised.
     mask = torch.zeros(4, 4, dtype=torch.long)
     mask[2:, :] = 5
@@ -157,9 +157,9 @@ def test__build_semantic_mask_overlay__colors_known_classes_skips_unknown_and_re
 
 def test__bboxes_from_masks__tight_bounds_and_skips_empty() -> None:
     # Three instances on an 8x8 canvas:
-    #   0: rows 1-3, cols 2-5 → tight box [2, 1, 5, 3].
-    #   1: empty (no foreground pixels) → skipped.
-    #   2: a single pixel at (col=6, row=7) → degenerate box [6, 7, 6, 7].
+    #   0: rows 1-3, cols 2-5 -> tight box [2, 1, 5, 3].
+    #   1: empty (no foreground pixels) -> skipped.
+    #   2: a single pixel at (col=6, row=7) -> degenerate box [6, 7, 6, 7].
     # Note: bboxes use inclusive max coords (xs.max() / ys.max(), no +1).
     masks = torch.zeros(3, 8, 8, dtype=torch.bool)
     masks[0, 1:4, 2:6] = True
@@ -216,7 +216,7 @@ def test__draw_mask_contours__paints_boundary_keeps_interior() -> None:
 
 
 def test__legend_entries_for_mask__returns_sorted_filtered_entries() -> None:
-    # Mask contains classes 0, 1 and 5. Class 5 is not in class_names → skipped.
+    # Mask contains classes 0, 1 and 5. Class 5 is not in class_names -> skipped.
     # Class 1 appears before class 0 in the mask, so output must be sorted by id.
     mask = torch.tensor([[1, 5], [0, 1]], dtype=torch.long)
     labels, colors = utils._legend_entries_for_mask(

--- a/tests/_visualize/test_utils.py
+++ b/tests/_visualize/test_utils.py
@@ -138,17 +138,67 @@ def test__draw_class_legend__mismatched_colors_and_labels_raises() -> None:
         utils._draw_class_legend(image=image, labels=["a", "b"], colors=[(255, 0, 0)])
 
 
-def test__build_mask_overlay__colors_known_classes_skips_unknown_and_resizes() -> None:
+def test__build_semantic_mask_overlay__colors_known_classes_skips_unknown_and_resizes() -> (
+    None
+):
     # Top half is class 0 (in class_names → colored). Bottom half is class 5
     # (not in class_names → stays black). Output size differs from mask, so
     # nearest-neighbor resize is exercised.
     mask = torch.zeros(4, 4, dtype=torch.long)
     mask[2:, :] = 5
-    result = utils._build_mask_overlay(mask=mask, size=(8, 8), class_names={0: "a"})
+    result = utils._build_semantic_mask_overlay(
+        mask=mask, size=(8, 8), class_names={0: "a"}
+    )
     assert result.mode == "RGB"
     assert result.size == (8, 8)
     assert result.getpixel((0, 0)) == _CLASS_0_COLOR
     assert result.getpixel((0, 7)) == _BACKGROUND_PIXEL
+
+
+def test__bboxes_from_masks__tight_bounds_and_skips_empty() -> None:
+    # Three instances on an 8x8 canvas:
+    #   0: rows 1-3, cols 2-5 → tight box [2, 1, 5, 3].
+    #   1: empty (no foreground pixels) → skipped.
+    #   2: a single pixel at (col=6, row=7) → degenerate box [6, 7, 6, 7].
+    # Note: bboxes use inclusive max coords (xs.max() / ys.max(), no +1).
+    masks = torch.zeros(3, 8, 8, dtype=torch.bool)
+    masks[0, 1:4, 2:6] = True
+    masks[2, 7, 6] = True
+    boxes, keep = utils._bboxes_from_masks(masks=masks)
+    # The keep tensor preserves the original instance order so callers can use
+    # it to filter parallel arrays (labels, scores) — index 1 must be False.
+    assert keep.tolist() == [True, False, True]
+    assert boxes.shape == (2, 4)
+    assert boxes[0].tolist() == [2.0, 1.0, 5.0, 3.0]
+    assert boxes[1].tolist() == [6.0, 7.0, 6.0, 7.0]
+
+
+def test__draw_labeled_boxes__draws_outline_and_label_in_class_color() -> None:
+    # Single 64x64 box at (32, 32) on a 128x128 canvas. y1=32 leaves room for
+    # the label above the box, so the label rectangle is drawn above and is
+    # filled with the class color.
+    image = Image.new("RGB", (128, 128), color=_BACKGROUND_PIXEL)
+    bboxes = torch.tensor([[32.0, 32.0, 96.0, 96.0]])
+    labels = torch.tensor([1], dtype=torch.long)
+    utils._draw_labeled_boxes(
+        image=image,
+        bboxes_xyxy=bboxes,
+        labels=labels,
+        scores=None,
+        class_names={1: "dog"},
+    )
+    # Each of the four corners is painted in class 1's color — catches a
+    # regression where the bbox is drawn in the wrong color (e.g. a hard-coded
+    # color or class 0's color regardless of label).
+    assert image.getpixel((32, 32)) == _CLASS_1_COLOR
+    assert image.getpixel((96, 32)) == _CLASS_1_COLOR
+    assert image.getpixel((32, 96)) == _CLASS_1_COLOR
+    assert image.getpixel((96, 96)) == _CLASS_1_COLOR
+    # Box interior remains background (only the outline is drawn).
+    assert image.getpixel((64, 64)) == _BACKGROUND_PIXEL
+    # The label rectangle sits above the box and is filled with class 1's
+    # color, so a pixel just above the box at x=34 lands inside the label.
+    assert image.getpixel((34, 30)) == _CLASS_1_COLOR
 
 
 def test__draw_mask_contours__paints_boundary_keeps_interior() -> None:


### PR DESCRIPTION
## What has changed and why?

Implements logging instance segmentation example images during training, matching the existing flow for semantic segmentation and object detection.

- New `_visualize/instance_segmentation.py` with `plot_instance_segmentation_labels` and `plot_instance_segmentation_predictions` (mask overlay + class-labeled bboxes; predictions are score-thresholded).
- Wired into `dinov3_eomt_instance_segmentation/train_model.py`: training/validation steps now emit `label_image` / `prediction_image` for the first 3 steps on rank 0.
- Refactored `_visualize/utils.py`: split `_build_mask_overlay` into semantic/instance variants, added `_bboxes_from_masks` and shared `_draw_labeled_boxes` (also adopted by object detection).
- Renamed plot-function parameter `included_classes` -> `class_names` for consistency.


Example of predictions:

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/c4ba620a-0f30-44e3-86bd-6e4354afcb3c" />

Note that the model does not produce bounding boxes directly; the boxes were extracted from the predicted masks.

## How has it been tested?

- Added `tests/_visualize/test_instance_segmentation.py` covering both plot functions, score thresholding, and empty-mask handling.
- Updated `tests/_visualize/test_utils.py`, `test_object_detection.py`, `test_semantic_segmentation.py` for the refactor and rename.
- Extended `tests/_commands/test_train_task.py` to assert `train_labels_0.jpg`, `val_labels_0.jpg`, `val_predictions_0.jpg` are written to `out/image_examples/`.


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)

