### PR TITLE
Add image logging for panoptic segmentation training

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
@@ -134,7 +134,10 @@ class DINOv2EoMTPanopticSegmentation(TaskModel):
             class_id: internal_id
             for internal_id, class_id in enumerate(internal_class_to_class[:-1])
         }
-
+        self.included_classes: dict[int, str] = {
+            internal_class_id: class_name
+            for internal_class_id, class_name in enumerate(self.classes.values())
+        }
         # Boolean mask indicating which internal classes are stuff classes.
         self.is_stuff_class: Tensor
         self.register_buffer(

--- a/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/train_model.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, Literal
 import torch
 import torch.nn.functional as F
 from lightning_fabric import Fabric
+from PIL.Image import Image as PILImage
 from torch import Tensor
 from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import LRScheduler
@@ -50,6 +51,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
+from lightly_train._visualize import panoptic_segmentation
 from lightly_train.types import (
     MaskPanopticSegmentationBatch,
     PathLike,
@@ -268,6 +270,12 @@ class DINOv2EoMTPanopticSegmentationTrain(TrainModel):
             self, hooks.criterion_empty_weight_reinit_hook
         )
 
+        # TODO(Nauryz, 04/2026): These visualization thresholds are currently
+        # hardcoded, but we may want to make them configurable in the future
+        # (with logger_args).
+        self.viz_max_images = 4
+        self.viz_alpha = 0.5
+
     def get_task_model(self) -> DINOv2EoMTPanopticSegmentation:
         return self.model
 
@@ -348,10 +356,20 @@ class DINOv2EoMTPanopticSegmentationTrain(TrainModel):
                 final_iter=no_auto(self.model_args.attn_mask_annealing_steps_end)[i],
             )
 
+        label_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = panoptic_segmentation.plot_panoptic_segmentation_labels(
+                batch=batch,
+                class_names=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
+            )
         return TaskStepResult(
             loss=loss,
             log_dict=mask_prob_dict,
             metrics=self.train_metrics,
+            label_image=label_image,
         )
 
     def validation_step(
@@ -422,6 +440,7 @@ class DINOv2EoMTPanopticSegmentationTrain(TrainModel):
         resized_mask_logits_last_layer = resized_mask_logits_per_layer[-1]
         class_logits_last_layer = class_logits_per_layer[-1]
         # Revert resize and pad for mask logits.
+        pred_masks: list[Tensor] = []
         for logits, class_logits, target_masks, target_binary_mask, (crop_h, crop_w), (
             image_h,
             image_w,
@@ -449,6 +468,7 @@ class DINOv2EoMTPanopticSegmentationTrain(TrainModel):
                 mask_threshold=self.model_args.mask_threshold,
                 mask_overlap_threshold=self.model_args.mask_overlap_threshold,
             )
+            pred_masks.append(masks)
             _mark_ignore_regions(
                 target_masks=target_masks,
                 ignore_class_id=self.model.internal_ignore_class_id,
@@ -459,10 +479,33 @@ class DINOv2EoMTPanopticSegmentationTrain(TrainModel):
                 target=target_masks.unsqueeze(0),  # (1, H, W, 2)
             )
 
+        label_image: PILImage | None = None
+        prediction_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = panoptic_segmentation.plot_panoptic_segmentation_labels(
+                batch=batch,
+                class_names=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
+            )
+            prediction_image = (
+                panoptic_segmentation.plot_panoptic_segmentation_predictions(
+                    batch=batch,
+                    pred_masks=pred_masks,
+                    class_names=self.model.included_classes,
+                    image_normalize=self.model.image_normalize,
+                    max_images=self.viz_max_images,
+                    alpha=self.viz_alpha,
+                )
+            )
+
         return TaskStepResult(
             loss=loss,
             log_dict={},
             metrics=self.val_metrics,
+            label_image=label_image,
+            prediction_image=prediction_image,
         )
 
     def mask_annealing(

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
@@ -135,6 +135,10 @@ class DINOv3EoMTPanopticSegmentation(TaskModel):
             class_id: internal_id
             for internal_id, class_id in enumerate(internal_class_to_class[:-1])
         }
+        self.included_classes: dict[int, str] = {
+            internal_class_id: class_name
+            for internal_class_id, class_name in enumerate(self.classes.values())
+        }
 
         # Boolean mask indicating which internal classes are stuff classes.
         self.is_stuff_class: Tensor

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/train_model.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, Literal
 import torch
 import torch.nn.functional as F
 from lightning_fabric import Fabric
+from PIL.Image import Image as PILImage
 from torch import Tensor
 from torch.optim.adamw import AdamW
 from torch.optim.lr_scheduler import LRScheduler
@@ -50,6 +51,10 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
+from lightly_train._visualize.panoptic_segmentation import (
+    plot_panoptic_segmentation_labels,
+    plot_panoptic_segmentation_predictions,
+)
 from lightly_train.types import (
     MaskPanopticSegmentationBatch,
     PathLike,
@@ -279,6 +284,12 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
             self, hooks.criterion_empty_weight_reinit_hook
         )
 
+        # TODO(Nauryz, 04/2026): These visualization thresholds are currently
+        # hardcoded, but we may want to make them configurable in the future
+        # (with logger_args).
+        self.viz_max_images = 4
+        self.viz_alpha = 0.5
+
     def get_task_model(self) -> DINOv3EoMTPanopticSegmentation:
         return self.model
 
@@ -359,10 +370,21 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
                 final_iter=no_auto(self.model_args.attn_mask_annealing_steps_end)[i],
             )
 
+        label_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = plot_panoptic_segmentation_labels(
+                batch=batch,
+                included_classes=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
+            )
+
         return TaskStepResult(
             loss=loss,
             log_dict=mask_prob_dict,
             metrics=self.train_metrics,
+            label_image=label_image,
         )
 
     def validation_step(
@@ -433,6 +455,7 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
         resized_mask_logits_last_layer = resized_mask_logits_per_layer[-1]
         class_logits_last_layer = class_logits_per_layer[-1]
         # Revert resize and pad for mask logits.
+        pred_masks: list[Tensor] = []
         for logits, class_logits, target_masks, target_binary_mask, (crop_h, crop_w), (
             image_h,
             image_w,
@@ -460,6 +483,7 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
                 mask_threshold=self.model_args.mask_threshold,
                 mask_overlap_threshold=self.model_args.mask_overlap_threshold,
             )
+            pred_masks.append(masks)
             _mark_ignore_regions(
                 target_masks=target_masks,
                 ignore_class_id=self.model.internal_ignore_class_id,
@@ -470,10 +494,31 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
                 target=target_masks.unsqueeze(0),  # (1, H, W, 2)
             )
 
+        label_image: PILImage | None = None
+        prediction_image: PILImage | None = None
+        if step < 3 and fabric.global_rank == 0:
+            label_image = plot_panoptic_segmentation_labels(
+                batch=batch,
+                included_classes=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
+            )
+            prediction_image = plot_panoptic_segmentation_predictions(
+                batch=batch,
+                pred_masks=pred_masks,
+                included_classes=self.model.included_classes,
+                image_normalize=self.model.image_normalize,
+                max_images=self.viz_max_images,
+                alpha=self.viz_alpha,
+            )
+
         return TaskStepResult(
             loss=loss,
             log_dict={},
             metrics=self.val_metrics,
+            label_image=label_image,
+            prediction_image=prediction_image,
         )
 
     def mask_annealing(

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/train_model.py
@@ -51,10 +51,7 @@ from lightly_train._task_models.train_model import (
     TrainModelArgs,
 )
 from lightly_train._torch_compile import TorchCompileArgs
-from lightly_train._visualize.panoptic_segmentation import (
-    plot_panoptic_segmentation_labels,
-    plot_panoptic_segmentation_predictions,
-)
+from lightly_train._visualize import panoptic_segmentation
 from lightly_train.types import (
     MaskPanopticSegmentationBatch,
     PathLike,
@@ -372,9 +369,9 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
 
         label_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_panoptic_segmentation_labels(
+            label_image = panoptic_segmentation.plot_panoptic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
@@ -497,20 +494,22 @@ class DINOv3EoMTPanopticSegmentationTrain(TrainModel):
         label_image: PILImage | None = None
         prediction_image: PILImage | None = None
         if step < 3 and fabric.global_rank == 0:
-            label_image = plot_panoptic_segmentation_labels(
+            label_image = panoptic_segmentation.plot_panoptic_segmentation_labels(
                 batch=batch,
-                included_classes=self.model.included_classes,
+                class_names=self.model.included_classes,
                 image_normalize=self.model.image_normalize,
                 max_images=self.viz_max_images,
                 alpha=self.viz_alpha,
             )
-            prediction_image = plot_panoptic_segmentation_predictions(
-                batch=batch,
-                pred_masks=pred_masks,
-                included_classes=self.model.included_classes,
-                image_normalize=self.model.image_normalize,
-                max_images=self.viz_max_images,
-                alpha=self.viz_alpha,
+            prediction_image = (
+                panoptic_segmentation.plot_panoptic_segmentation_predictions(
+                    batch=batch,
+                    pred_masks=pred_masks,
+                    class_names=self.model.included_classes,
+                    image_normalize=self.model.image_normalize,
+                    max_images=self.viz_max_images,
+                    alpha=self.viz_alpha,
+                )
             )
 
         return TaskStepResult(

--- a/src/lightly_train/_visualize/image_classification.py
+++ b/src/lightly_train/_visualize/image_classification.py
@@ -38,7 +38,7 @@ def plot_image_classification_labels(
         A single PIL image containing up to max_images annotated images arranged
         in a grid.
     """
-    images = batch["image"].cpu()
+    images = batch["image"].float().cpu()
     gt_classes = [c.cpu() for c in batch["classes"]]
     n = min(max_images, images.shape[0])
 

--- a/src/lightly_train/_visualize/instance_segmentation.py
+++ b/src/lightly_train/_visualize/instance_segmentation.py
@@ -48,7 +48,9 @@ def plot_instance_segmentation_labels(
     binary_masks_list = batch["binary_masks"]
     bboxes_list = batch["bboxes"]
     gt_images = (
-        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+        [img.float().cpu() for img in images]
+        if isinstance(images, list)
+        else images.float().cpu()
     )
     n = min(max_images, len(gt_images))
 
@@ -122,7 +124,9 @@ def plot_instance_segmentation_predictions(
     """
     images = batch["image"]
     gt_images = (
-        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+        [img.float().cpu() for img in images]
+        if isinstance(images, list)
+        else images.float().cpu()
     )
     n = min(max_images, len(gt_images))
 

--- a/src/lightly_train/_visualize/panoptic_segmentation.py
+++ b/src/lightly_train/_visualize/panoptic_segmentation.py
@@ -7,36 +7,27 @@
 #
 from __future__ import annotations
 
-import io
 from collections.abc import Sequence
 
-import matplotlib.patches as mpatches
-import torch
-from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.figure import Figure
 from PIL import Image
 from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision.transforms import functional as torchvision_functional
 
-from lightly_train._visualize.utils import (
-    _denormalize_image,
-    _get_class_color,
-    _render_grid,
-)
+from lightly_train._visualize import utils
 from lightly_train.types import MaskPanopticSegmentationBatch
 
 
 def plot_panoptic_segmentation_labels(
     batch: MaskPanopticSegmentationBatch,
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
     alpha: float,
 ) -> PILImage:
     """Render a grid of images annotated with ground truth panoptic segmentation masks.
 
-    The class label channel of each mask is colorized using ``included_classes``,
+    The class label channel of each mask is colorized using ``class_names``,
     and contours are drawn along segment boundaries so that distinct instances
     of the same class remain visually separated.
 
@@ -44,7 +35,7 @@ def plot_panoptic_segmentation_labels(
         batch: Panoptic segmentation batch with images and (H, W, 2) masks where
             channel 0 holds internal class labels and channel 1 holds segment
             ids (segment id -1 indicates unassigned pixels).
-        included_classes: A dict mapping internal class IDs to class names. May
+        class_names: A dict mapping internal class IDs to class names. May
             also contain the internal ignore class id mapped to "ignored" when
             masks include ignored pixels.
         max_images: Maximum number of images to include in the grid.
@@ -66,23 +57,45 @@ def plot_panoptic_segmentation_labels(
     gt_masks = [m.cpu() for m in masks] if isinstance(masks, list) else masks.cpu()
     n = min(max_images, len(gt_images))
 
-    pil_images = [
-        _render_panoptic_image(
-            image=gt_images[i],
-            mask=gt_masks[i],
-            included_classes=included_classes,
-            image_normalize=image_normalize,
-            alpha=alpha,
+    pil_images: list[PILImage] = []
+    for i in range(n):
+        image_tensor = gt_images[i].clone()
+        if image_normalize is not None:
+            image_tensor = utils._denormalize_image(
+                image=image_tensor,
+                mean=image_normalize["mean"],
+                std=image_normalize["std"],
+            )
+        img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
+        # (H, W, 2): channel 0 is the class label, channel 1 is the segment id.
+        label_mask = gt_masks[i][..., 0]
+        segment_mask = gt_masks[i][..., 1]
+
+        overlay = utils._build_panoptic_mask_overlay(
+            label_mask=label_mask,
+            segment_mask=segment_mask,
+            size=img.size,
+            class_names=class_names,
         )
-        for i in range(n)
-    ]
-    return _render_grid(pil_images)
+        blended = Image.blend(img, overlay, alpha=alpha)
+        # Use segment id boundaries so different instances of the same class
+        # remain visually separated.
+        blended = utils._draw_mask_contours(image=blended, mask=segment_mask)
+
+        labels, colors = utils._legend_entries_for_mask(
+            mask=label_mask, class_names=class_names
+        )
+        blended = utils._draw_class_legend(image=blended, labels=labels, colors=colors)
+
+        pil_images.append(blended)
+
+    return utils._render_grid(pil_images)
 
 
 def plot_panoptic_segmentation_predictions(
     batch: MaskPanopticSegmentationBatch,
     pred_masks: Sequence[Tensor],
-    included_classes: dict[int, str],
+    class_names: dict[int, str],
     max_images: int,
     image_normalize: dict[str, tuple[float, ...]] | None,
     alpha: float,
@@ -95,7 +108,7 @@ def plot_panoptic_segmentation_predictions(
             internal class labels and channel 1 holds segment ids. Each mask
             must have the same spatial size as its corresponding image in
             ``batch["image"]``.
-        included_classes: A dict mapping internal class IDs to class names.
+        class_names: A dict mapping internal class IDs to class names.
         max_images: Maximum number of images to include in the grid.
         image_normalize: Optional dict with "mean" and "std" tuples used to
             denormalize images before rendering. If None, images pass through
@@ -113,234 +126,37 @@ def plot_panoptic_segmentation_predictions(
     )
     n = min(max_images, len(gt_images), len(pred_masks))
 
-    pil_images = [
-        _render_panoptic_image(
-            image=gt_images[i],
-            mask=pred_masks[i].cpu(),
-            included_classes=included_classes,
-            image_normalize=image_normalize,
-            alpha=alpha,
+    pil_images: list[PILImage] = []
+    for i in range(n):
+        image_tensor = gt_images[i].clone()
+        if image_normalize is not None:
+            image_tensor = utils._denormalize_image(
+                image=image_tensor,
+                mean=image_normalize["mean"],
+                std=image_normalize["std"],
+            )
+        img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
+        pred_mask = pred_masks[i].cpu()
+        # (H, W, 2): channel 0 is the class label, channel 1 is the segment id.
+        label_mask = pred_mask[..., 0]
+        segment_mask = pred_mask[..., 1]
+
+        overlay = utils._build_panoptic_mask_overlay(
+            label_mask=label_mask,
+            segment_mask=segment_mask,
+            size=img.size,
+            class_names=class_names,
         )
-        for i in range(n)
-    ]
-    return _render_grid(pil_images)
+        blended = Image.blend(img, overlay, alpha=alpha)
+        # Use segment id boundaries so different instances of the same class
+        # remain visually separated.
+        blended = utils._draw_mask_contours(image=blended, mask=segment_mask)
 
-
-def _render_panoptic_image(
-    image: Tensor,
-    mask: Tensor,
-    included_classes: dict[int, str],
-    image_normalize: dict[str, tuple[float, ...]] | None,
-    alpha: float,
-) -> PILImage:
-    """Render a single image with its panoptic mask overlay, contours, and legend."""
-    image_tensor = image.clone()
-    if image_normalize is not None:
-        image_tensor = _denormalize_image(
-            image=image_tensor,
-            mean=image_normalize["mean"],
-            std=image_normalize["std"],
+        labels, colors = utils._legend_entries_for_mask(
+            mask=label_mask, class_names=class_names
         )
-    img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
-    # (H, W, 2): channel 0 is the class label, channel 1 is the segment id.
-    label_mask = mask[..., 0]
-    segment_mask = mask[..., 1]
+        blended = utils._draw_class_legend(image=blended, labels=labels, colors=colors)
 
-    overlay = _build_mask_overlay(
-        label_mask=label_mask,
-        segment_mask=segment_mask,
-        size=img.size,
-        class_names=included_classes,
-    )
-    blended = Image.blend(img, overlay, alpha=alpha)
-    # Use segment id boundaries so different instances of the same class
-    # remain visually separated.
-    blended = _draw_mask_contours(image=blended, mask=segment_mask)
+        pil_images.append(blended)
 
-    labels, colors = _legend_entries_for_mask(
-        mask=label_mask, class_names=included_classes
-    )
-    return _draw_class_legend(image=blended, labels=labels, colors=colors)
-
-
-def _build_mask_overlay(
-    label_mask: Tensor,
-    segment_mask: Tensor,
-    size: tuple[int, int],
-    class_names: dict[int, str],
-) -> PILImage:
-    """Build an RGB overlay image where each segment is colored.
-
-    Different instances of the same class are given visually-close but distinct
-    colors by passing ``class_id + small_offset`` to ``_get_class_color``. The
-    first instance of each class uses the base class color so that the legend
-    color matches.
-
-    Only class ids that appear as keys of ``class_names`` are colored; pixels
-    with any other id are left black. The ignore index is colored when callers
-    include it as a key in ``class_names`` (e.g. mapped to ``"ignored"``) and
-    left black otherwise.
-
-    Args:
-        label_mask: Tensor of shape (H, W) with internal contiguous class
-            indices.
-        segment_mask: Tensor of shape (H, W) with per-pixel segment ids.
-            Different segment ids within the same class are treated as
-            different instances and rendered with different colors.
-        size: Target (width, height) of the overlay.
-        class_names: Mapping from class id to class name. Only ids that appear
-            as keys are colored; other ids are left black.
-
-    Returns:
-        RGB PIL image of the requested size.
-    """
-    h, w = label_mask.shape[-2:]
-    overlay = torch.zeros((3, h, w), dtype=torch.uint8)
-    instance_hue_step = 0.01
-    for class_id in torch.unique(label_mask).tolist():
-        class_id = int(class_id)
-        if class_id not in class_names:
-            continue
-        class_pixels = label_mask == class_id
-        segment_ids = sorted(
-            int(s) for s in torch.unique(segment_mask[class_pixels]).tolist()
-        )
-        for instance_idx, seg_id in enumerate(segment_ids):
-            color = _get_class_color(class_id + instance_hue_step * instance_idx)
-            seg_pixels = class_pixels & (segment_mask == seg_id)
-            for c in range(3):
-                overlay[c][seg_pixels] = color[c]
-
-    overlay_img: PILImage = Image.fromarray(overlay.permute(1, 2, 0).numpy()).convert(
-        "RGB"
-    )
-    if overlay_img.size != size:
-        overlay_img = overlay_img.resize(size, resample=Image.Resampling.NEAREST)
-    return overlay_img
-
-
-def _draw_mask_contours(
-    image: PILImage,
-    mask: Tensor,
-) -> PILImage:
-    """Overlay thin black contours along boundaries of ``mask`` onto ``image``.
-
-    Boundary pixels are pixels whose value differs from any 4-connected
-    neighbor. The contours are drawn after blending so that they remain solid
-    black and are not faded by the overlay alpha.
-
-    Args:
-        image: RGB PIL image to draw contours on.
-        mask: Tensor of shape (H, W) used to detect boundaries.
-
-    Returns:
-        A new RGB PIL image with boundaries marked in black.
-    """
-    h, w = mask.shape[-2:]
-    boundary = torch.zeros((h, w), dtype=torch.bool)
-    diff_v = mask[:-1, :] != mask[1:, :]
-    boundary[:-1, :] |= diff_v
-    boundary[1:, :] |= diff_v
-    diff_h = mask[:, :-1] != mask[:, 1:]
-    boundary[:, :-1] |= diff_h
-    boundary[:, 1:] |= diff_h
-
-    boundary_img = Image.fromarray((boundary.to(torch.uint8) * 255).numpy())
-    if boundary_img.size != image.size:
-        boundary_img = boundary_img.resize(
-            image.size, resample=Image.Resampling.NEAREST
-        )
-
-    result = image.copy()
-    black = Image.new("RGB", image.size, (0, 0, 0))
-    result.paste(black, mask=boundary_img)
-    return result
-
-
-def _legend_entries_for_mask(
-    mask: Tensor,
-    class_names: dict[int, str],
-) -> tuple[list[str], list[tuple[int, int, int]]]:
-    """Build legend labels and colors for the unique classes present in ``mask``.
-
-    Entries are sorted by class id and skip classes that are not in
-    ``class_names``.
-    """
-    labels: list[str] = []
-    colors: list[tuple[int, int, int]] = []
-    for class_id in sorted(int(c) for c in torch.unique(mask).tolist()):
-        class_name = class_names.get(class_id)
-        if class_name is None:
-            continue
-        labels.append(str(class_name))
-        colors.append(_get_class_color(class_id))
-    return labels, colors
-
-
-def _draw_class_legend(
-    image: PILImage,
-    labels: Sequence[str],
-    colors: Sequence[tuple[int, int, int]],
-) -> PILImage:
-    """Composite a colored-patch legend onto the upper-left of ``image``.
-
-    The legend is rendered on a transparent canvas via matplotlib's headless
-    Agg backend and composited onto the image, so pixels outside the legend
-    area are preserved unchanged. Returns the image unchanged when ``labels``
-    is empty.
-
-    Args:
-        image: Base PIL image to render on.
-        labels: Legend lines to display, in order.
-        colors: Per-label RGB colors in [0, 255]; must have the same length as
-            ``labels``.
-
-    Returns:
-        A new RGB PIL image with the legend baked in (or the input image when
-        ``labels`` is empty).
-    """
-    if not labels:
-        return image
-    if len(colors) != len(labels):
-        raise ValueError(
-            f"colors and labels must have the same length, got "
-            f"{len(colors)} and {len(labels)}."
-        )
-
-    handles = [
-        mpatches.Patch(
-            color=(r / 255, g / 255, b / 255),
-            label=label,
-        )
-        for label, (r, g, b) in zip(labels, colors)
-    ]
-
-    img_width, img_height = image.size
-    dpi = 100
-    fig = Figure(figsize=(img_width / dpi, img_height / dpi), dpi=dpi)
-    fig.patch.set_alpha(0)
-    FigureCanvasAgg(fig)
-    ax = fig.add_axes((0, 0, 1, 1))
-    ax.set_axis_off()
-    ax.patch.set_alpha(0)
-    ax.legend(
-        handles=handles,
-        loc="upper left",
-        framealpha=0.7,
-        fontsize=10,
-        borderpad=0.4,
-        labelspacing=0.3,
-    )
-
-    buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=dpi, transparent=True, pad_inches=0)
-    buf.seek(0)
-    overlay = Image.open(buf).convert("RGBA")
-    if overlay.size != (img_width, img_height):
-        overlay = overlay.resize(
-            (img_width, img_height), resample=Image.Resampling.BILINEAR
-        )
-
-    base = image.convert("RGBA")
-    base.alpha_composite(overlay)
-    return base.convert("RGB")
+    return utils._render_grid(pil_images)

--- a/src/lightly_train/_visualize/panoptic_segmentation.py
+++ b/src/lightly_train/_visualize/panoptic_segmentation.py
@@ -1,0 +1,346 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import io
+from collections.abc import Sequence
+
+import matplotlib.patches as mpatches
+import torch
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+from PIL import Image
+from PIL.Image import Image as PILImage
+from torch import Tensor
+from torchvision.transforms import functional as torchvision_functional
+
+from lightly_train._visualize.utils import (
+    _denormalize_image,
+    _get_class_color,
+    _render_grid,
+)
+from lightly_train.types import MaskPanopticSegmentationBatch
+
+
+def plot_panoptic_segmentation_labels(
+    batch: MaskPanopticSegmentationBatch,
+    included_classes: dict[int, str],
+    max_images: int,
+    image_normalize: dict[str, tuple[float, ...]] | None,
+    alpha: float,
+) -> PILImage:
+    """Render a grid of images annotated with ground truth panoptic segmentation masks.
+
+    The class label channel of each mask is colorized using ``included_classes``,
+    and contours are drawn along segment boundaries so that distinct instances
+    of the same class remain visually separated.
+
+    Args:
+        batch: Panoptic segmentation batch with images and (H, W, 2) masks where
+            channel 0 holds internal class labels and channel 1 holds segment
+            ids (segment id -1 indicates unassigned pixels).
+        included_classes: A dict mapping internal class IDs to class names. May
+            also contain the internal ignore class id mapped to "ignored" when
+            masks include ignored pixels.
+        max_images: Maximum number of images to include in the grid.
+        image_normalize: Optional dict with "mean" and "std" tuples used to
+            denormalize images before rendering. If None, images pass through
+            unchanged.
+        alpha: Blending factor for the mask overlay in [0, 1]. 0 shows only the
+            image, 1 shows only the mask.
+
+    Returns:
+        A single PIL image containing up to max_images annotated images arranged
+        in a grid.
+    """
+    images = batch["image"]
+    masks = batch["masks"]
+    gt_images = (
+        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+    )
+    gt_masks = [m.cpu() for m in masks] if isinstance(masks, list) else masks.cpu()
+    n = min(max_images, len(gt_images))
+
+    pil_images = [
+        _render_panoptic_image(
+            image=gt_images[i],
+            mask=gt_masks[i],
+            included_classes=included_classes,
+            image_normalize=image_normalize,
+            alpha=alpha,
+        )
+        for i in range(n)
+    ]
+    return _render_grid(pil_images)
+
+
+def plot_panoptic_segmentation_predictions(
+    batch: MaskPanopticSegmentationBatch,
+    pred_masks: Sequence[Tensor],
+    included_classes: dict[int, str],
+    max_images: int,
+    image_normalize: dict[str, tuple[float, ...]] | None,
+    alpha: float,
+) -> PILImage:
+    """Render a grid of images annotated with predicted panoptic segmentation masks.
+
+    Args:
+        batch: Panoptic segmentation batch with images.
+        pred_masks: Per-image predicted (H, W, 2) masks where channel 0 holds
+            internal class labels and channel 1 holds segment ids. Each mask
+            must have the same spatial size as its corresponding image in
+            ``batch["image"]``.
+        included_classes: A dict mapping internal class IDs to class names.
+        max_images: Maximum number of images to include in the grid.
+        image_normalize: Optional dict with "mean" and "std" tuples used to
+            denormalize images before rendering. If None, images pass through
+            unchanged.
+        alpha: Blending factor for the mask overlay in [0, 1]. 0 shows only the
+            image, 1 shows only the mask.
+
+    Returns:
+        A single PIL image containing up to max_images annotated images arranged
+        in a grid.
+    """
+    images = batch["image"]
+    gt_images = (
+        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+    )
+    n = min(max_images, len(gt_images), len(pred_masks))
+
+    pil_images = [
+        _render_panoptic_image(
+            image=gt_images[i],
+            mask=pred_masks[i].cpu(),
+            included_classes=included_classes,
+            image_normalize=image_normalize,
+            alpha=alpha,
+        )
+        for i in range(n)
+    ]
+    return _render_grid(pil_images)
+
+
+def _render_panoptic_image(
+    image: Tensor,
+    mask: Tensor,
+    included_classes: dict[int, str],
+    image_normalize: dict[str, tuple[float, ...]] | None,
+    alpha: float,
+) -> PILImage:
+    """Render a single image with its panoptic mask overlay, contours, and legend."""
+    image_tensor = image.clone()
+    if image_normalize is not None:
+        image_tensor = _denormalize_image(
+            image=image_tensor,
+            mean=image_normalize["mean"],
+            std=image_normalize["std"],
+        )
+    img = torchvision_functional.to_pil_image(image_tensor).convert("RGB")
+    # (H, W, 2): channel 0 is the class label, channel 1 is the segment id.
+    label_mask = mask[..., 0]
+    segment_mask = mask[..., 1]
+
+    overlay = _build_mask_overlay(
+        label_mask=label_mask,
+        segment_mask=segment_mask,
+        size=img.size,
+        class_names=included_classes,
+    )
+    blended = Image.blend(img, overlay, alpha=alpha)
+    # Use segment id boundaries so different instances of the same class
+    # remain visually separated.
+    blended = _draw_mask_contours(image=blended, mask=segment_mask)
+
+    labels, colors = _legend_entries_for_mask(
+        mask=label_mask, class_names=included_classes
+    )
+    return _draw_class_legend(image=blended, labels=labels, colors=colors)
+
+
+def _build_mask_overlay(
+    label_mask: Tensor,
+    segment_mask: Tensor,
+    size: tuple[int, int],
+    class_names: dict[int, str],
+) -> PILImage:
+    """Build an RGB overlay image where each segment is colored.
+
+    Different instances of the same class are given visually-close but distinct
+    colors by passing ``class_id + small_offset`` to ``_get_class_color``. The
+    first instance of each class uses the base class color so that the legend
+    color matches.
+
+    Only class ids that appear as keys of ``class_names`` are colored; pixels
+    with any other id are left black. The ignore index is colored when callers
+    include it as a key in ``class_names`` (e.g. mapped to ``"ignored"``) and
+    left black otherwise.
+
+    Args:
+        label_mask: Tensor of shape (H, W) with internal contiguous class
+            indices.
+        segment_mask: Tensor of shape (H, W) with per-pixel segment ids.
+            Different segment ids within the same class are treated as
+            different instances and rendered with different colors.
+        size: Target (width, height) of the overlay.
+        class_names: Mapping from class id to class name. Only ids that appear
+            as keys are colored; other ids are left black.
+
+    Returns:
+        RGB PIL image of the requested size.
+    """
+    h, w = label_mask.shape[-2:]
+    overlay = torch.zeros((3, h, w), dtype=torch.uint8)
+    instance_hue_step = 0.01
+    for class_id in torch.unique(label_mask).tolist():
+        class_id = int(class_id)
+        if class_id not in class_names:
+            continue
+        class_pixels = label_mask == class_id
+        segment_ids = sorted(
+            int(s) for s in torch.unique(segment_mask[class_pixels]).tolist()
+        )
+        for instance_idx, seg_id in enumerate(segment_ids):
+            color = _get_class_color(class_id + instance_hue_step * instance_idx)
+            seg_pixels = class_pixels & (segment_mask == seg_id)
+            for c in range(3):
+                overlay[c][seg_pixels] = color[c]
+
+    overlay_img: PILImage = Image.fromarray(overlay.permute(1, 2, 0).numpy()).convert(
+        "RGB"
+    )
+    if overlay_img.size != size:
+        overlay_img = overlay_img.resize(size, resample=Image.Resampling.NEAREST)
+    return overlay_img
+
+
+def _draw_mask_contours(
+    image: PILImage,
+    mask: Tensor,
+) -> PILImage:
+    """Overlay thin black contours along boundaries of ``mask`` onto ``image``.
+
+    Boundary pixels are pixels whose value differs from any 4-connected
+    neighbor. The contours are drawn after blending so that they remain solid
+    black and are not faded by the overlay alpha.
+
+    Args:
+        image: RGB PIL image to draw contours on.
+        mask: Tensor of shape (H, W) used to detect boundaries.
+
+    Returns:
+        A new RGB PIL image with boundaries marked in black.
+    """
+    h, w = mask.shape[-2:]
+    boundary = torch.zeros((h, w), dtype=torch.bool)
+    diff_v = mask[:-1, :] != mask[1:, :]
+    boundary[:-1, :] |= diff_v
+    boundary[1:, :] |= diff_v
+    diff_h = mask[:, :-1] != mask[:, 1:]
+    boundary[:, :-1] |= diff_h
+    boundary[:, 1:] |= diff_h
+
+    boundary_img = Image.fromarray((boundary.to(torch.uint8) * 255).numpy())
+    if boundary_img.size != image.size:
+        boundary_img = boundary_img.resize(
+            image.size, resample=Image.Resampling.NEAREST
+        )
+
+    result = image.copy()
+    black = Image.new("RGB", image.size, (0, 0, 0))
+    result.paste(black, mask=boundary_img)
+    return result
+
+
+def _legend_entries_for_mask(
+    mask: Tensor,
+    class_names: dict[int, str],
+) -> tuple[list[str], list[tuple[int, int, int]]]:
+    """Build legend labels and colors for the unique classes present in ``mask``.
+
+    Entries are sorted by class id and skip classes that are not in
+    ``class_names``.
+    """
+    labels: list[str] = []
+    colors: list[tuple[int, int, int]] = []
+    for class_id in sorted(int(c) for c in torch.unique(mask).tolist()):
+        class_name = class_names.get(class_id)
+        if class_name is None:
+            continue
+        labels.append(str(class_name))
+        colors.append(_get_class_color(class_id))
+    return labels, colors
+
+
+def _draw_class_legend(
+    image: PILImage,
+    labels: Sequence[str],
+    colors: Sequence[tuple[int, int, int]],
+) -> PILImage:
+    """Composite a colored-patch legend onto the upper-left of ``image``.
+
+    The legend is rendered on a transparent canvas via matplotlib's headless
+    Agg backend and composited onto the image, so pixels outside the legend
+    area are preserved unchanged. Returns the image unchanged when ``labels``
+    is empty.
+
+    Args:
+        image: Base PIL image to render on.
+        labels: Legend lines to display, in order.
+        colors: Per-label RGB colors in [0, 255]; must have the same length as
+            ``labels``.
+
+    Returns:
+        A new RGB PIL image with the legend baked in (or the input image when
+        ``labels`` is empty).
+    """
+    if not labels:
+        return image
+    if len(colors) != len(labels):
+        raise ValueError(
+            f"colors and labels must have the same length, got "
+            f"{len(colors)} and {len(labels)}."
+        )
+
+    handles = [
+        mpatches.Patch(
+            color=(r / 255, g / 255, b / 255),
+            label=label,
+        )
+        for label, (r, g, b) in zip(labels, colors)
+    ]
+
+    img_width, img_height = image.size
+    dpi = 100
+    fig = Figure(figsize=(img_width / dpi, img_height / dpi), dpi=dpi)
+    fig.patch.set_alpha(0)
+    FigureCanvasAgg(fig)
+    ax = fig.add_axes((0, 0, 1, 1))
+    ax.set_axis_off()
+    ax.patch.set_alpha(0)
+    ax.legend(
+        handles=handles,
+        loc="upper left",
+        framealpha=0.7,
+        fontsize=10,
+        borderpad=0.4,
+        labelspacing=0.3,
+    )
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=dpi, transparent=True, pad_inches=0)
+    buf.seek(0)
+    overlay = Image.open(buf).convert("RGBA")
+    if overlay.size != (img_width, img_height):
+        overlay = overlay.resize(
+            (img_width, img_height), resample=Image.Resampling.BILINEAR
+        )
+
+    base = image.convert("RGBA")
+    base.alpha_composite(overlay)
+    return base.convert("RGB")

--- a/src/lightly_train/_visualize/panoptic_segmentation.py
+++ b/src/lightly_train/_visualize/panoptic_segmentation.py
@@ -52,7 +52,9 @@ def plot_panoptic_segmentation_labels(
     images = batch["image"]
     masks = batch["masks"]
     gt_images = (
-        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+        [img.float().cpu() for img in images]
+        if isinstance(images, list)
+        else images.float().cpu()
     )
     gt_masks = [m.cpu() for m in masks] if isinstance(masks, list) else masks.cpu()
     n = min(max_images, len(gt_images))
@@ -122,7 +124,9 @@ def plot_panoptic_segmentation_predictions(
     """
     images = batch["image"]
     gt_images = (
-        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+        [img.float().cpu() for img in images]
+        if isinstance(images, list)
+        else images.float().cpu()
     )
     n = min(max_images, len(gt_images), len(pred_masks))
 

--- a/src/lightly_train/_visualize/semantic_segmentation.py
+++ b/src/lightly_train/_visualize/semantic_segmentation.py
@@ -48,7 +48,9 @@ def plot_semantic_segmentation_labels(
     images = batch["image"]
     masks = batch["mask"]
     gt_images = (
-        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+        [img.float().cpu() for img in images]
+        if isinstance(images, list)
+        else images.float().cpu()
     )
     gt_masks = [m.cpu() for m in masks] if isinstance(masks, list) else masks.cpu()
     n = min(max_images, len(gt_images))
@@ -108,7 +110,9 @@ def plot_semantic_segmentation_predictions(
     """
     images = batch["image"]
     gt_images = (
-        [img.cpu() for img in images] if isinstance(images, list) else images.cpu()
+        [img.float().cpu() for img in images]
+        if isinstance(images, list)
+        else images.float().cpu()
     )
     n = min(max_images, len(gt_images))
 

--- a/src/lightly_train/_visualize/utils.py
+++ b/src/lightly_train/_visualize/utils.py
@@ -157,12 +157,17 @@ def _denormalize_image(
     return denormalized
 
 
-def _get_class_color(class_id: int) -> tuple[int, int, int]:
+def _get_class_color(class_id: float) -> tuple[int, int, int]:
     """Generate a deterministic RGB color for a class ID.
 
-    Uses HSV color space with varying hue to ensure the same class ID always gets
-    the same color, with good visual distinction between different classes.
-    This maintains color consistency throughout the training process.
+    The integer part of ``class_id`` selects a base hue using the golden ratio
+    (so different classes are well-separated). The fractional part adds an
+    amplified hue offset, so callers can pass ``class_id + small_offset`` to
+    derive instance-specific colors that are clearly distinct yet still in the
+    same color region as the base class.
+
+    Integer class IDs reproduce the original per-class colors exactly, so
+    existing callers (e.g. object detection) are unaffected.
 
     Args:
         class_id: The class ID to generate a color for.
@@ -185,8 +190,11 @@ def _get_class_color(class_id: int) -> tuple[int, int, int]:
 def _render_grid(pil_images: list[PILImage]) -> PILImage:
     """Arrange PIL images into a square-ish grid.
 
+    Tiles may have different sizes. The cell size is the maximum width and
+    height across all tiles, and each tile is centered within its cell.
+
     Args:
-        pil_images: List of PIL images, all the same size.
+        pil_images: List of PIL images.
 
     Returns:
         Single PIL image with all inputs tiled into a grid.
@@ -194,12 +202,16 @@ def _render_grid(pil_images: list[PILImage]) -> PILImage:
     n = len(pil_images)
     n_cols = math.ceil(math.sqrt(n))
     n_rows = math.ceil(n / n_cols)
-    w, h = pil_images[0].size
+    w = max(img.size[0] for img in pil_images)
+    h = max(img.size[1] for img in pil_images)
     mode = pil_images[0].mode
     grid = Image.new(mode, (n_cols * w, n_rows * h))
     for idx, img in enumerate(pil_images):
         row, col = divmod(idx, n_cols)
-        grid.paste(img, (col * w, row * h))
+        img_w, img_h = img.size
+        x = col * w + (w - img_w) // 2
+        y = row * h + (h - img_h) // 2
+        grid.paste(img, (x, y))
     return grid
 
 

--- a/src/lightly_train/_visualize/utils.py
+++ b/src/lightly_train/_visualize/utils.py
@@ -182,14 +182,12 @@ def _denormalize_image(
 def _get_class_color(class_id: float) -> tuple[int, int, int]:
     """Generate a deterministic RGB color for a class ID.
 
-    The integer part of ``class_id`` selects a base hue using the golden ratio
-    (so different classes are well-separated). The fractional part adds an
-    amplified hue offset, so callers can pass ``class_id + small_offset`` to
-    derive instance-specific colors that are clearly distinct yet still in the
-    same color region as the base class.
-
-    Integer class IDs reproduce the original per-class colors exactly, so
-    existing callers (e.g. object detection) are unaffected.
+    The hue is computed as ``(class_id * golden_ratio) % 1.0``. Multiplying by
+    the golden ratio spreads consecutive integer class IDs across the hue
+    circle so different classes are well-separated, while a small fractional
+    offset on ``class_id`` produces only a small hue shift. Callers can
+    therefore pass ``class_id + small_offset`` to derive instance-specific
+    colors that remain in the same color region as the base class.
 
     Args:
         class_id: The class ID to generate a color for.

--- a/src/lightly_train/_visualize/utils.py
+++ b/src/lightly_train/_visualize/utils.py
@@ -245,9 +245,8 @@ def _build_instance_mask_overlay(
 ) -> PILImage:
     """Build an RGB overlay image colored by class id from per-instance binary masks.
 
-    Instances may overlap; later instances overwrite earlier ones. Only ids that
-    appear as keys of ``class_names`` are colored; pixels with any other id are
-    left black.
+    Only ids that appear as keys of ``class_names`` are colored; pixels with
+    any other id are left black.
 
     Args:
         masks: Boolean tensor of shape (n_instances, H, W).
@@ -268,6 +267,57 @@ def _build_instance_mask_overlay(
         color = _get_class_color(class_id)
         for c in range(3):
             overlay[c][masks[idx]] = color[c]
+
+    return _overlay_to_pil(overlay=overlay, size=size)
+
+
+def _build_panoptic_mask_overlay(
+    label_mask: Tensor,
+    segment_mask: Tensor,
+    size: tuple[int, int],
+    class_names: dict[int, str],
+) -> PILImage:
+    """Build an RGB overlay image where each segment is colored.
+
+    Different instances of the same class are given visually-close but distinct
+    colors by passing ``class_id + small_offset`` to ``_get_class_color``. The
+    first instance of each class uses the base class color so that the legend
+    color matches.
+
+    Only class ids that appear as keys of ``class_names`` are colored; pixels
+    with any other id are left black. The ignore index is colored when callers
+    include it as a key in ``class_names`` (e.g. mapped to ``"ignored"``) and
+    left black otherwise.
+
+    Args:
+        label_mask: Tensor of shape (H, W) with internal contiguous class
+            indices.
+        segment_mask: Tensor of shape (H, W) with per-pixel segment ids.
+            Different segment ids within the same class are treated as
+            different instances and rendered with different colors.
+        size: Target (width, height) of the overlay.
+        class_names: Mapping from class id to class name. Only ids that appear
+            as keys are colored; other ids are left black.
+
+    Returns:
+        RGB PIL image of the requested size.
+    """
+    h, w = label_mask.shape[-2:]
+    overlay = torch.zeros((3, h, w), dtype=torch.uint8)
+    instance_hue_step = 0.01
+    for class_id in torch.unique(label_mask).tolist():
+        class_id = int(class_id)
+        if class_id not in class_names:
+            continue
+        class_pixels = label_mask == class_id
+        segment_ids = sorted(
+            int(s) for s in torch.unique(segment_mask[class_pixels]).tolist()
+        )
+        for instance_idx, seg_id in enumerate(segment_ids):
+            color = _get_class_color(class_id + instance_hue_step * instance_idx)
+            seg_pixels = class_pixels & (segment_mask == seg_id)
+            for c in range(3):
+                overlay[c][seg_pixels] = color[c]
 
     return _overlay_to_pil(overlay=overlay, size=size)
 

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -358,6 +358,13 @@ def test_train_panoptic_segmentation(
     assert results["segment_ids"].ndim == 1
     assert results["scores"].ndim == 1
 
+    # Check that example images were logged for training and validation.
+    image_examples_dir = out / "image_examples"
+    assert image_examples_dir.exists()
+    assert (image_examples_dir / "train_labels_0.jpg").exists()
+    assert (image_examples_dir / "val_labels_0.jpg").exists()
+    assert (image_examples_dir / "val_predictions_0.jpg").exists()
+
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
 @pytest.mark.skipif(
@@ -411,6 +418,13 @@ def test_train_panoptic_segmentation__dinov2(
     assert results["masks"].shape == (100, 200, 2)
     assert results["segment_ids"].ndim == 1
     assert results["scores"].ndim == 1
+
+    # Check that example images were logged for training and validation.
+    image_examples_dir = out / "image_examples"
+    assert image_examples_dir.exists()
+    assert (image_examples_dir / "train_labels_0.jpg").exists()
+    assert (image_examples_dir / "val_labels_0.jpg").exists()
+    assert (image_examples_dir / "val_predictions_0.jpg").exists()
 
 
 @pytest.mark.skipif(

--- a/tests/_visualize/test_panoptic_segmentation.py
+++ b/tests/_visualize/test_panoptic_segmentation.py
@@ -1,0 +1,249 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import torch
+from PIL import Image, ImageChops
+from PIL.Image import Image as PILImage
+from torch import Tensor
+
+from lightly_train._visualize import panoptic_segmentation
+from lightly_train.types import (
+    MaskPanopticSegmentationBatch,
+    PanopticBinaryMasksDict,
+)
+
+_WHITE_COLOR: float = 1.0
+_WHITE_PIXEL: tuple[int, int, int] = (255, 255, 255)
+_BLACK_PIXEL: tuple[int, int, int] = (0, 0, 0)
+# These come from the deterministic golden-ratio palette in utils._get_class_color.
+_CLASS_0_COLOR: tuple[int, int, int] = (242, 24, 24)
+_CLASS_1_COLOR: tuple[int, int, int] = (24, 87, 242)
+
+
+def _has_legend(image: PILImage) -> bool:
+    """Return True if any pixel differs from pure white (i.e. legend was drawn)."""
+    white = Image.new(image.mode, image.size, _WHITE_PIXEL)
+    return ImageChops.difference(image, white).getbbox() is not None
+
+
+def _empty_panoptic_binary_masks(
+    *, batch_size: int, height: int, width: int
+) -> list[PanopticBinaryMasksDict]:
+    return [
+        PanopticBinaryMasksDict(
+            masks=torch.zeros(0, height, width, dtype=torch.bool),
+            labels=torch.zeros(0, dtype=torch.long),
+            iscrowd=torch.zeros(0, dtype=torch.long),
+        )
+        for _ in range(batch_size)
+    ]
+
+
+def _make_batch(
+    *,
+    batch_size: int = 1,
+    height: int = 32,
+    width: int = 32,
+    image: Tensor | None = None,
+    masks: Tensor | None = None,
+) -> MaskPanopticSegmentationBatch:
+    if image is None:
+        image = torch.rand(batch_size, 3, height, width)
+    if masks is None:
+        masks = torch.zeros(batch_size, height, width, 2, dtype=torch.long)
+    return MaskPanopticSegmentationBatch(
+        image_path=[f"img_{i}.png" for i in range(batch_size)],
+        image=image,
+        masks=masks,
+        binary_masks=_empty_panoptic_binary_masks(
+            batch_size=batch_size, height=height, width=width
+        ),
+    )
+
+
+def test_plot_panoptic_segmentation_labels__grid_caps_at_max_images() -> None:
+    batch = _make_batch(batch_size=4, height=16, width=16)
+    result = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={0: "_"},
+        max_images=2,
+        image_normalize=None,
+        alpha=0.0,
+    )
+    assert result.size == (32, 16)
+
+
+def test_plot_panoptic_segmentation_labels__no_image_normalize_skips_denormalization() -> (
+    None
+):
+    # alpha=0 disables the mask overlay; a uniform mask draws no contours; an
+    # empty included_classes draws no legend. The 0.4 input therefore renders
+    # as uniform (102, 102, 102).
+    batch = _make_batch(
+        image=torch.full((1, 3, 32, 32), 0.4),
+        masks=torch.zeros(1, 32, 32, 2, dtype=torch.long),
+    )
+    result = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={},
+        max_images=1,
+        image_normalize=None,
+        alpha=0.0,
+    )
+    assert result.getpixel((0, 0)) == (102, 102, 102)
+    assert result.getpixel((31, 31)) == (102, 102, 102)
+
+
+def test_plot_panoptic_segmentation_labels__image_normalize_denormalizes() -> None:
+    # Input 0.0 with mean=0.5, std=0.5 -> denormalized to 0.5 -> pixel 127.
+    # Without denormalization, 0.0 would render as black (0).
+    batch = _make_batch(
+        image=torch.zeros(1, 3, 32, 32),
+        masks=torch.zeros(1, 32, 32, 2, dtype=torch.long),
+    )
+    result = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={},
+        max_images=1,
+        image_normalize={"mean": (0.5, 0.5, 0.5), "std": (0.5, 0.5, 0.5)},
+        alpha=0.0,
+    )
+    assert result.getpixel((0, 0)) == (127, 127, 127)
+    assert result.getpixel((31, 31)) == (127, 127, 127)
+
+
+def test_plot_panoptic_segmentation_labels__alpha_one_replaces_image_with_mask_colors() -> (
+    None
+):
+    # alpha=1.0 makes the blended image equal to the overlay, which paints
+    # every class-0 pixel with the class-0 color. The far corner avoids the
+    # upper-left legend region.
+    batch = _make_batch(
+        image=torch.full((1, 3, 64, 64), _WHITE_COLOR),
+        masks=torch.zeros(1, 64, 64, 2, dtype=torch.long),
+    )
+    result = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={0: "cat"},
+        max_images=1,
+        image_normalize=None,
+        alpha=1.0,
+    )
+    assert result.getpixel((63, 63)) == _CLASS_0_COLOR
+
+
+def test_plot_panoptic_segmentation_labels__contours_drawn_at_segment_boundary_within_same_class() -> (
+    None
+):
+    # KEY panoptic feature: the panoptic visualizer draws contours along
+    # *segment* boundaries, not class boundaries. Two adjacent instances of the
+    # SAME class must still be separated by a black contour. Top half: class 0,
+    # segment 0. Bottom half: class 0, segment 1. The semantic visualizer
+    # (which uses class boundaries) would leave this image contour-free.
+    masks = torch.zeros(1, 128, 128, 2, dtype=torch.long)
+    masks[0, 64:, :, 1] = 1
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _WHITE_COLOR),
+        masks=masks,
+    )
+    result = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={0: "cat"},
+        max_images=1,
+        image_normalize=None,
+        alpha=1.0,
+    )
+    # Probe near the right edge to avoid the upper-left legend region. Rows 63
+    # and 64 straddle the segment-id boundary and must both be black.
+    assert result.getpixel((120, 63)) == _BLACK_PIXEL
+    assert result.getpixel((120, 64)) == _BLACK_PIXEL
+
+
+def test_plot_panoptic_segmentation_labels__different_instances_same_class_get_different_colors() -> (
+    None
+):
+    # Top half: class 0, segment 0 -> first instance, must use the base class
+    # color (so the legend swatch matches). Bottom half: class 0, segment 1 ->
+    # second instance, must use a hue-shifted color (otherwise the two
+    # instances are visually indistinguishable). Probe pixels are taken near
+    # the right edge to avoid the upper-left legend, and away from the
+    # boundary contour at row 64.
+    masks = torch.zeros(1, 128, 128, 2, dtype=torch.long)
+    masks[0, 64:, :, 1] = 1
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _WHITE_COLOR),
+        masks=masks,
+    )
+    result = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={0: "cat"},
+        max_images=1,
+        image_normalize=None,
+        alpha=1.0,
+    )
+    top_pixel = result.getpixel((120, 30))
+    bottom_pixel = result.getpixel((120, 100))
+    assert top_pixel == _CLASS_0_COLOR
+    assert bottom_pixel != _CLASS_0_COLOR
+    assert bottom_pixel != _BLACK_PIXEL
+
+
+def test_plot_panoptic_segmentation_labels__legend_skips_class_not_in_included_classes() -> (
+    None
+):
+    # With alpha=0 and a uniform mask there is nothing on the canvas except
+    # the legend. So a class that isn't in included_classes leaves the image
+    # fully white, while a known class adds a legend.
+    batch = _make_batch(
+        image=torch.full((1, 3, 256, 256), _WHITE_COLOR),
+        masks=torch.zeros(1, 256, 256, 2, dtype=torch.long),
+    )
+    with_known_class = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={0: "cat"},
+        max_images=1,
+        image_normalize=None,
+        alpha=0.0,
+    )
+    with_unknown_class = panoptic_segmentation.plot_panoptic_segmentation_labels(
+        batch=batch,
+        class_names={1: "dog"},
+        max_images=1,
+        image_normalize=None,
+        alpha=0.0,
+    )
+    assert _has_legend(with_known_class)
+    assert not _has_legend(with_unknown_class)
+
+
+def test_plot_panoptic_segmentation_predictions__overlay_uses_predicted_class_colors() -> (
+    None
+):
+    # Predicted (H, W, 2) mask with two classes split top/bottom, each with its
+    # own segment id (so each is the first instance of its class and therefore
+    # uses the base class color). The ground-truth batch is unused for color
+    # selection — only pred_masks should drive the overlay. Probe near the
+    # right edge to avoid the legend, and away from the contour at row 64.
+    pred_mask = torch.zeros(128, 128, 2, dtype=torch.long)
+    pred_mask[64:, :, 0] = 1
+    pred_mask[64:, :, 1] = 1
+    batch = _make_batch(
+        image=torch.full((1, 3, 128, 128), _WHITE_COLOR),
+        masks=torch.zeros(1, 128, 128, 2, dtype=torch.long),
+    )
+    result = panoptic_segmentation.plot_panoptic_segmentation_predictions(
+        batch=batch,
+        pred_masks=[pred_mask],
+        class_names={0: "cat", 1: "dog"},
+        max_images=1,
+        image_normalize=None,
+        alpha=1.0,
+    )
+    assert result.getpixel((120, 30)) == _CLASS_0_COLOR
+    assert result.getpixel((120, 100)) == _CLASS_1_COLOR

--- a/tests/_visualize/test_utils.py
+++ b/tests/_visualize/test_utils.py
@@ -138,21 +138,87 @@ def test__draw_class_legend__mismatched_colors_and_labels_raises() -> None:
         utils._draw_class_legend(image=image, labels=["a", "b"], colors=[(255, 0, 0)])
 
 
-def test__build_semantic_mask_overlay__colors_known_classes_skips_unknown_and_resizes() -> (
-    None
-):
-    # Top half is class 0 (in class_names -> colored). Bottom half is class 5
-    # (not in class_names -> stays black). Output size differs from mask, so
-    # nearest-neighbor resize is exercised.
+def test__build_panoptic_mask_overlay__colors_known_segments() -> None:
+    # Two segments with the same class: first uses base class color, second
+    # uses a shifted hue so separate instances are visually distinct.
+    label_mask = torch.zeros(4, 4, dtype=torch.long)
+    segment_mask = torch.zeros(4, 4, dtype=torch.long)
+    segment_mask[2:, :] = 1
+    result = utils._build_panoptic_mask_overlay(
+        label_mask=label_mask,
+        segment_mask=segment_mask,
+        size=(4, 4),
+        class_names={0: "cat"},
+    )
+    assert result.getpixel((0, 0)) == _CLASS_0_COLOR
+    assert result.getpixel((0, 3)) != _CLASS_0_COLOR
+    assert result.getpixel((0, 3)) != _BACKGROUND_PIXEL
+
+
+def test__build_panoptic_mask_overlay__skips_unknown_classes() -> None:
+    label_mask = torch.zeros(4, 4, dtype=torch.long)
+    label_mask[2:, :] = 5
+    segment_mask = torch.zeros(4, 4, dtype=torch.long)
+    result = utils._build_panoptic_mask_overlay(
+        label_mask=label_mask,
+        segment_mask=segment_mask,
+        size=(4, 4),
+        class_names={0: "cat"},
+    )
+    assert result.getpixel((0, 0)) == _CLASS_0_COLOR
+    assert result.getpixel((0, 3)) == _BACKGROUND_PIXEL
+
+
+def test__build_instance_mask_overlay__colors_known_instances() -> None:
+    # Each instance mask should be painted with its class color.
+    masks = torch.zeros(2, 4, 4, dtype=torch.bool)
+    masks[0, :2, :] = True
+    masks[1, 2:, :] = True
+    labels = torch.tensor([0, 1], dtype=torch.long)
+    result = utils._build_instance_mask_overlay(
+        masks=masks,
+        labels=labels,
+        size=(4, 4),
+        class_names={0: "cat", 1: "dog"},
+    )
+    assert result.getpixel((0, 0)) == _CLASS_0_COLOR
+    assert result.getpixel((0, 3)) == _CLASS_1_COLOR
+
+
+def test__build_instance_mask_overlay__skips_unknown_classes() -> None:
+    # Masks whose label is not in class_names should stay black.
+    masks = torch.zeros(2, 4, 4, dtype=torch.bool)
+    masks[0, :2, :] = True
+    masks[1, 2:, :] = True
+    labels = torch.tensor([0, 5], dtype=torch.long)
+    result = utils._build_instance_mask_overlay(
+        masks=masks,
+        labels=labels,
+        size=(4, 4),
+        class_names={0: "cat"},
+    )
+    assert result.getpixel((0, 0)) == _CLASS_0_COLOR
+    assert result.getpixel((0, 3)) == _BACKGROUND_PIXEL
+
+
+def test__build_semantic_mask_overlay__colors_known_classes() -> None:
+    mask = torch.zeros(4, 4, dtype=torch.long)
+    mask[2:, :] = 1
+    result = utils._build_semantic_mask_overlay(
+        mask=mask, size=(4, 4), class_names={0: "cat", 1: "dog"}
+    )
+    assert result.getpixel((0, 0)) == _CLASS_0_COLOR
+    assert result.getpixel((0, 3)) == _CLASS_1_COLOR
+
+
+def test__build_semantic_mask_overlay__skips_unknown_classes() -> None:
     mask = torch.zeros(4, 4, dtype=torch.long)
     mask[2:, :] = 5
     result = utils._build_semantic_mask_overlay(
-        mask=mask, size=(8, 8), class_names={0: "a"}
+        mask=mask, size=(4, 4), class_names={0: "cat"}
     )
-    assert result.mode == "RGB"
-    assert result.size == (8, 8)
     assert result.getpixel((0, 0)) == _CLASS_0_COLOR
-    assert result.getpixel((0, 7)) == _BACKGROUND_PIXEL
+    assert result.getpixel((0, 3)) == _BACKGROUND_PIXEL
 
 
 def test__bboxes_from_masks__tight_bounds_and_skips_empty() -> None:
@@ -174,9 +240,7 @@ def test__bboxes_from_masks__tight_bounds_and_skips_empty() -> None:
 
 
 def test__draw_labeled_boxes__draws_outline_and_label_in_class_color() -> None:
-    # Single 64x64 box at (32, 32) on a 128x128 canvas. y1=32 leaves room for
-    # the label above the box, so the label rectangle is drawn above and is
-    # filled with the class color.
+    # Single box on a 128x128 canvas. y1=32 leaves room for the label above.
     image = Image.new("RGB", (128, 128), color=_BACKGROUND_PIXEL)
     bboxes = torch.tensor([[32.0, 32.0, 96.0, 96.0]])
     labels = torch.tensor([1], dtype=torch.long)
@@ -187,17 +251,11 @@ def test__draw_labeled_boxes__draws_outline_and_label_in_class_color() -> None:
         scores=None,
         class_names={1: "dog"},
     )
-    # Each of the four corners is painted in class 1's color — catches a
-    # regression where the bbox is drawn in the wrong color (e.g. a hard-coded
-    # color or class 0's color regardless of label).
+    # Box corner is painted with class 1's color (outline drawn in class color).
     assert image.getpixel((32, 32)) == _CLASS_1_COLOR
-    assert image.getpixel((96, 32)) == _CLASS_1_COLOR
-    assert image.getpixel((32, 96)) == _CLASS_1_COLOR
-    assert image.getpixel((96, 96)) == _CLASS_1_COLOR
-    # Box interior remains background (only the outline is drawn).
+    # Box interior remains background (only the outline is drawn, not fill).
     assert image.getpixel((64, 64)) == _BACKGROUND_PIXEL
-    # The label rectangle sits above the box and is filled with class 1's
-    # color, so a pixel just above the box at x=34 lands inside the label.
+    # Label rectangle sits above the box, filled with class color.
     assert image.getpixel((34, 30)) == _CLASS_1_COLOR
 
 


### PR DESCRIPTION
## What has changed and why?


Adds example image logging for panoptic segmentation training, mirroring the same feature already shipped for instance segmentation and semantic segmentation.

- Added a new `_visualize/panoptic_segmentation.py` module with two functions:
  - `plot_panoptic_segmentation_labels` - renders ground-truth panoptic masks blended over the input images.
  - `plot_panoptic_segmentation_predictions` - renders predicted panoptic masks blended over the input images.
- Extended `_visualize/utils.py` with a segment-mask overlay utility used by the above functions.
- Wired both functions into the `training_step` (labels only) and `validation_step` (labels + predictions) of both DINOv2 and DINOv3 panoptic segmentation train models. Images are logged for the first 3 steps on rank 0 only.


## How has it been tested?

- Unit tests added in `test_panoptic_segmentation.py` covering both plotting functions across various batch shapes and edge cases.
- `test_utils.py` extended to cover the new overlay utility.
- Integration smoke-test added to `test_train_task.py` to verify logging is wired up correctly end-to-end.



## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)




Example of labels:



<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/daed5b3f-0776-4a20-9d83-b72ef0e2ada0" />

