### PR TITLE
Add gemma4_vit_ architecture support to TIMM model prefixes

### DIFF
--- a/src/lightly_train/_models/timm/timm.py
+++ b/src/lightly_train/_models/timm/timm.py
@@ -49,6 +49,7 @@ _TIMM_ARCH_NAME_PREFIXES: list[tuple[str, ArchitectureInfo]] = [
     ("sequencer2d_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("aimv2_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("convit_", {"model_type": "transformer", "norm_type": "layernorm"}),
+    ("gemma4_vit_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("gmixer_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("gmlp_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("hiera_", {"model_type": "transformer", "norm_type": "layernorm"}),

--- a/src/lightly_train/_models/timm/timm.py
+++ b/src/lightly_train/_models/timm/timm.py
@@ -49,6 +49,8 @@ _TIMM_ARCH_NAME_PREFIXES: list[tuple[str, ArchitectureInfo]] = [
     ("sequencer2d_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("aimv2_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("convit_", {"model_type": "transformer", "norm_type": "layernorm"}),
+    # gemma4_vit_* uses RmsNorm throughout, but norm_type is a training-recipe
+    # tag (non-batchnorm) so "layernorm" is the correct bucket here.
     ("gemma4_vit_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("gmixer_", {"model_type": "transformer", "norm_type": "layernorm"}),
     ("gmlp_", {"model_type": "transformer", "norm_type": "layernorm"}),


### PR DESCRIPTION
## What has changed and why?

`test_architecture_info__all_timm_model_names_match_prefix` validates that every model returned by `timm.list_models()` matches a prefix in `_TIMM_ARCH_NAME_PREFIXES`. Since `gemma4_vit_` was missing, the test started failing.

## How has it been tested?

NA

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
