### PR TITLE
chore: add Ruff pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,31 @@
 repos:
- - repo: https://github.com/kynan/nbstripout.git
-   rev: 0.9.0
-   hooks:
-    - id: nbstripout
-      description: "Strips outputs from Jupyter notebooks."
- - repo: https://github.com/pre-commit/pre-commit-hooks
-   rev: v6.0.0
-   hooks:
-    - id: check-added-large-files
-      description: "Avoid committing large files."
-      args: ["--maxkb=2000", "--enforce-all"]
- - repo: https://github.com/fastai/nbdev
-   rev: 3.0.14
-   hooks:
-    - id: nbdev-clean
-      args: [--fname=examples]
+  - repo: https://github.com/kynan/nbstripout.git
+    rev: 0.9.0
+    hooks:
+      - id: nbstripout
+        description: "Strips outputs from Jupyter notebooks."
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        description: "Avoid committing large files."
+        args: ["--maxkb=2000", "--enforce-all"]
+  - repo: https://github.com/fastai/nbdev
+    rev: 3.0.14
+    hooks:
+      - id: nbdev-clean
+        args: [--fname=examples]
+  - repo: local
+    hooks:
+      - id: ruff-format-check
+        name: ruff format (check)
+        entry: ruff format --check
+        language: system
+        types_or: [python]
+        description: "Ensure Python files are formatted with Ruff."
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check
+        language: system
+        types_or: [python]
+        description: "Run Ruff lint checks."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,17 +15,8 @@ repos:
     hooks:
       - id: nbdev-clean
         args: [--fname=examples]
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: ruff-format-check
-        name: ruff format (check)
-        entry: ruff format --check
-        language: system
-        types_or: [python]
-        description: "Ensure Python files are formatted with Ruff."
+      - id: ruff-format
       - id: ruff-check
-        name: ruff check
-        entry: ruff check
-        language: system
-        types_or: [python]
-        description: "Run Ruff lint checks."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,11 @@ Make sure the environment is activated before running the following commands.
 
 ### Running Checks and Tests
 
-Before committing code, make sure all tests and checks pass:
+Before committing code, make sure the checks pass. The common file-level checks are
+handled by pre-commit, which `make install-dev` installs for you:
 
 ```
+pre-commit run --all-files
 make format
 make static-checks
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,16 +19,23 @@ Make sure the environment is activated before running the following commands.
 
 ### Running Checks and Tests
 
-Before committing code, make sure the checks pass. The common file-level checks are
-handled by pre-commit, which `make install-dev` installs for you:
+Before committing code, make sure the checks pass. A typical workflow is:
 
 ```
-pre-commit run --all-files
 make format
 make static-checks
 ```
 
-and if you want to run all the tests:
+`make format` fixes formatting and lint issues, and `make static-checks` validates
+formatting, linting, markdown formatting, and type checking.
+
+If you only want the hook-based file checks, run:
+
+```
+pre-commit run --all-files
+```
+
+To run all the tests:
 
 ```
 make test

--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,12 @@ format: add-header
 # run format check
 .PHONY: format-check
 format-check:
-	# Check code formatting
-	ruff format --check .
-	# Check linting issues
-	ruff check .
+	# Run pre-commit hooks
+	pre-commit run --all-files
 	# Check markdown formatting
 	mdformat --check ${MDFORMAT_FILES}
 	# Check code in markdown files
 	pytest docs/format_code.py::test_format_check_code_in_docs
-	# Run pre-commit hooks
-	pre-commit run --all-files
 
 # run type check
 .PHONY: type-check


### PR DESCRIPTION
## What has changed and why?

Added the existing Ruff checks to pre-commit so contributors can run the same Python
checks locally with one command.

Updated `make format-check` to use pre-commit and refreshed `CONTRIBUTING.md` to point
to the new workflow.

## How has it been tested?

- `pre-commit run --all-files`
- `make format-check`
- Manual hook proof with a temporary bad Python file:
  - `ruff-format-check` failed on bad formatting, passed after fixing
  - `ruff-check` failed on lint errors, passed after fixing

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
