### PR TITLE
Fix failing ONNX exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+Fix ONNX export for `dinov3_eomt_instance_segmentation`,
+`dinov3_eomt_panoptic_segmentation` and `dinov3_eomt_semantic_segmentation`.
+
 ### Security
 
 ## [0.15.0] - 2026-04-16

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -26,6 +26,7 @@ from lightly_train._models import package_helpers
 from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.layers.attention import (
     SelfAttention,
+    rope_apply,
 )
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
@@ -550,23 +551,54 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
         mask: Tensor | None,
     ) -> Tensor:
         # This mirrors DINOv3 Attention forward but with mask support.
+        # Uses unflatten/flatten and negative indexing for ONNX compatibility:
+        # the ONNX tracer can produce wrong constants from shape extraction
+        # (B, N, _ = tensor.shape) when the same method is called with
+        # different sequence lengths.
         qkv = module.qkv(x)
-        B, N, _ = qkv.shape
         C = module.qkv.in_features
 
-        qkv = qkv.reshape(B, N, 3, module.num_heads, C // module.num_heads)
+        qkv = qkv.unflatten(-1, (3, module.num_heads, C // module.num_heads))
         q, k, v = torch.unbind(qkv, 2)
         q, k, v = [t.transpose(1, 2) for t in [q, k, v]]
         if rope is not None:
-            q, k = module.apply_rope(q, k, rope)
+            assert isinstance(rope, tuple)
+            q, k = self._apply_rope(q, k, rope)
         if mask is not None:
             mask = mask[:, None, ...].expand(-1, module.num_heads, -1, -1)
         x = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask)
         x = x.transpose(1, 2)
-        x = x.reshape([B, N, C])
+        x = x.flatten(2)
         x = module.proj(x)
         x = module.proj_drop(x)
         return x
+
+    @staticmethod
+    def _apply_rope(
+        q: Tensor, k: Tensor, rope: tuple[Tensor, Tensor]
+    ) -> tuple[Tensor, Tensor]:
+        sin, cos = rope
+        rope_dtype = sin.dtype
+        patch_count = sin.shape[-2]
+        q_dtype = q.dtype
+        k_dtype = k.dtype
+        q = q.to(dtype=rope_dtype)
+        k = k.to(dtype=rope_dtype)
+        q = torch.cat(
+            (
+                q[:, :, :-patch_count, :],
+                rope_apply(q[:, :, -patch_count:, :], sin, cos),
+            ),
+            dim=-2,
+        )
+        k = torch.cat(
+            (
+                k[:, :, :-patch_count, :],
+                rope_apply(k[:, :, -patch_count:, :], sin, cos),
+            ),
+            dim=-2,
+        )
+        return q.to(dtype=q_dtype), k.to(dtype=k_dtype)
 
     def load_train_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Load the state dict from a training checkpoint."""

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
@@ -27,6 +27,7 @@ from lightly_train._models import package_helpers
 from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.layers.attention import (
     SelfAttention,
+    rope_apply,
 )
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
@@ -814,23 +815,54 @@ class DINOv3EoMTPanopticSegmentation(TaskModel):
         mask: Tensor | None,
     ) -> Tensor:
         # This mirrors DINOv3 Attention forward but with mask support.
+        # Uses unflatten/flatten and negative indexing for ONNX compatibility:
+        # the ONNX tracer can produce wrong constants from shape extraction
+        # (B, N, _ = tensor.shape) when the same method is called with
+        # different sequence lengths.
         qkv = module.qkv(x)
-        B, N, _ = qkv.shape
         C = module.qkv.in_features
 
-        qkv = qkv.reshape(B, N, 3, module.num_heads, C // module.num_heads)
+        qkv = qkv.unflatten(-1, (3, module.num_heads, C // module.num_heads))
         q, k, v = torch.unbind(qkv, 2)
         q, k, v = [t.transpose(1, 2) for t in [q, k, v]]
         if rope is not None:
-            q, k = module.apply_rope(q, k, rope)
+            assert isinstance(rope, tuple)
+            q, k = self._apply_rope(q, k, rope)
         if mask is not None:
             mask = mask[:, None, ...].expand(-1, module.num_heads, -1, -1)
         x = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask)
         x = x.transpose(1, 2)
-        x = x.reshape([B, N, C])
+        x = x.flatten(2)
         x = module.proj(x)
         x = module.proj_drop(x)
         return x
+
+    @staticmethod
+    def _apply_rope(
+        q: Tensor, k: Tensor, rope: tuple[Tensor, Tensor]
+    ) -> tuple[Tensor, Tensor]:
+        sin, cos = rope
+        rope_dtype = sin.dtype
+        patch_count = sin.shape[-2]
+        q_dtype = q.dtype
+        k_dtype = k.dtype
+        q = q.to(dtype=rope_dtype)
+        k = k.to(dtype=rope_dtype)
+        q = torch.cat(
+            (
+                q[:, :, :-patch_count, :],
+                rope_apply(q[:, :, -patch_count:, :], sin, cos),
+            ),
+            dim=-2,
+        )
+        k = torch.cat(
+            (
+                k[:, :, :-patch_count, :],
+                rope_apply(k[:, :, -patch_count:, :], sin, cos),
+            ),
+            dim=-2,
+        )
+        return q.to(dtype=q_dtype), k.to(dtype=k_dtype)
 
     def load_train_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Load the state dict from a training checkpoint."""

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -26,6 +26,7 @@ from lightly_train._models import package_helpers
 from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.layers.attention import (
     SelfAttention,
+    rope_apply,
 )
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
@@ -595,23 +596,54 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         mask: Tensor | None,
     ) -> Tensor:
         # This mirrors DINOv3 Attention forward but with mask support.
+        # Uses unflatten/flatten and negative indexing for ONNX compatibility:
+        # the ONNX tracer can produce wrong constants from shape extraction
+        # (B, N, _ = tensor.shape) when the same method is called with
+        # different sequence lengths.
         qkv = module.qkv(x)
-        B, N, _ = qkv.shape
         C = module.qkv.in_features
 
-        qkv = qkv.reshape(B, N, 3, module.num_heads, C // module.num_heads)
+        qkv = qkv.unflatten(-1, (3, module.num_heads, C // module.num_heads))
         q, k, v = torch.unbind(qkv, 2)
         q, k, v = [t.transpose(1, 2) for t in [q, k, v]]
         if rope is not None:
-            q, k = module.apply_rope(q, k, rope)
+            assert isinstance(rope, tuple)
+            q, k = self._apply_rope(q, k, rope)
         if mask is not None:
             mask = mask[:, None, ...].expand(-1, module.num_heads, -1, -1)
         x = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask)
         x = x.transpose(1, 2)
-        x = x.reshape([B, N, C])
+        x = x.flatten(2)
         x = module.proj(x)
         x = module.proj_drop(x)
         return x
+
+    @staticmethod
+    def _apply_rope(
+        q: Tensor, k: Tensor, rope: tuple[Tensor, Tensor]
+    ) -> tuple[Tensor, Tensor]:
+        sin, cos = rope
+        rope_dtype = sin.dtype
+        patch_count = sin.shape[-2]
+        q_dtype = q.dtype
+        k_dtype = k.dtype
+        q = q.to(dtype=rope_dtype)
+        k = k.to(dtype=rope_dtype)
+        q = torch.cat(
+            (
+                q[:, :, :-patch_count, :],
+                rope_apply(q[:, :, -patch_count:, :], sin, cos),
+            ),
+            dim=-2,
+        )
+        k = torch.cat(
+            (
+                k[:, :, :-patch_count, :],
+                rope_apply(k[:, :, -patch_count:, :], sin, cos),
+            ),
+            dim=-2,
+        )
+        return q.to(dtype=q_dtype), k.to(dtype=k_dtype)
 
     def load_train_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Load the state dict from a training checkpoint."""

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -67,9 +67,6 @@ def test_export_onnx__dynamic_batch_size(
             assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
-@pytest.mark.xfail(
-    strict=True, reason="dinov3 ONNX export shape mismatch with static batch size"
-)
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"

--- a/tests/_task_models/dinov3_eomt_panoptic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_panoptic_segmentation/test_task_model.py
@@ -31,7 +31,6 @@ def model() -> DINOv3EoMTPanopticSegmentation:
     )
 
 
-@pytest.mark.xfail(strict=True, reason="dinov3 ONNX export shape mismatch")
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
@@ -41,7 +40,6 @@ def test_export_onnx(model: DINOv3EoMTPanopticSegmentation, tmp_path: Path) -> N
     model.export_onnx(out=out, simplify=False, verify=True)
 
 
-@pytest.mark.xfail(strict=True, reason="dinov3 ONNX export shape mismatch")
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -68,9 +68,6 @@ def test_export_onnx__dynamic_batch_size(
             assert (onnx_tensor == torch_out).float().mean() > 0.95
 
 
-@pytest.mark.xfail(
-    strict=True, reason="dinov3 ONNX export shape mismatch with static batch size"
-)
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
@@ -80,11 +77,15 @@ def test_export_onnx__static_batch_size(
 ) -> None:
     out = tmp_path / "model.onnx"
     model.export_onnx(
-        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+        out=out,
+        batch_size=3,
+        dynamic_batch_size=False,
+        simplify=False,
+        verify=True,
+        opset_version=20,
     )
 
 
-@pytest.mark.xfail(strict=True, reason="dinov3 ONNX export shape mismatch")
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"


### PR DESCRIPTION
## What has changed and why?

This PR fixes the failing ONNX exports for the models
- `dinov3_eomt_instance_segmentation`
- `dinov3_eomt_panoptic_segmentation`
- `dinov3_eomt_semantic_segmentation`

There was an issue with shape inference, probably related to this issue https://github.com/onnx/onnx/issues/6664

Another option would to try the export with `dynamo=True`.

## How has it been tested?

Tests previously marked as `xfail` pass now.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
