### PR TITLE
Add Predict Batch Method to Instance Segmentation

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -268,56 +268,10 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
         if self.training:
             self.eval()
 
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        x = transforms_functional.normalize(
-            x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-        )
-
-        x, (crop_h, crop_w) = self.resize_and_pad(x)
-        x = x.unsqueeze(0)  # (1, C, H', W')
-
-        # (1, Q, H', W'), (1, Q, K+1), Q = num_queries, K = len(self.classes)
-        mask_logits, class_logits = self.forward_backend(x)
-
-        # Interpolate to original image size.
-        mask_logits = mask_logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
-        # (1, Q, H, W)
-        mask_logits = F.interpolate(
-            mask_logits, size=(image_h, image_w), mode="bilinear"
-        )
-
-        # (1, Q), (1, Q, H, W), (1, Q)
-        labels, masks, scores = self.get_labels_masks_scores(
-            mask_logits=mask_logits, class_logits=class_logits
-        )
-
-        # Map internal class IDs to class IDs.
-        labels = self.internal_class_to_class[labels]  # (1, Q)
-
-        # Remove batch dimension.
-        labels = labels.squeeze(0)
-        masks = masks.squeeze(0)
-        scores = scores.squeeze(0)
-
-        # Apply threshold.
-        keep = scores >= threshold
-        labels = labels[keep]
-        masks = masks[keep]
-        scores = scores[keep]
-
-        return {
-            "labels": labels,
-            "masks": masks,
-            "scores": scores,
-        }
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch(x.unsqueeze(0))
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata], threshold=threshold)[0]
 
     def preprocess_image(
         self, image: PathLike | PILImage | Tensor

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import logging
 import math
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -284,7 +285,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
         x = x.unsqueeze(0)  # (1, C, H', W')
 
         # (1, Q, H', W'), (1, Q, K+1), Q = num_queries, K = len(self.classes)
-        mask_logits, class_logits = self._forward_logits(x)
+        mask_logits, class_logits = self.forward_backend(x)
 
         # Interpolate to original image size.
         mask_logits = mask_logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
@@ -318,10 +319,128 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
             "scores": scores,
         }
 
+    def preprocess_image(
+        self, image: PathLike | PILImage | Tensor
+    ) -> tuple[Tensor, dict[str, Any]]:
+        first_param = next(self.parameters())
+        device, dtype = first_param.device, first_param.dtype
+
+        x = file_helpers.as_image_tensor(image).to(device)
+        image_h, image_w = x.shape[-2:]
+
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        # Normalize before resize_and_pad so the zero padding inserted by
+        # resize_and_pad is identical to the per-image `predict` path.
+        x = transforms_functional.normalize(
+            x,
+            mean=list(self.image_normalize["mean"]),
+            std=list(self.image_normalize["std"]),
+        )
+        x, (crop_h, crop_w) = self.resize_and_pad(x)
+        return x, {
+            "orig_h": image_h,
+            "orig_w": image_w,
+            "crop_h": crop_h,
+            "crop_w": crop_w,
+        }
+
+    def preprocess_batch(self, batch: Tensor) -> Tensor:
+        return batch
+
+    def forward_backend(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """Forward pass that returns the logits of the last layer. Intended for
+        inference."""
+        # x is a batch of images with shape (B, C, H, W).
+        H, W = x.shape[-2:]
+
+        # Forward pass.
+        # Only the logits of the last layer are returned.
+        mask_logits_per_layer, class_logits_per_layer = self.forward_train(
+            x, return_logits_per_layer=False
+        )
+        mask_logits = mask_logits_per_layer[-1]
+        class_logits = class_logits_per_layer[-1]
+
+        # Interpolate.
+        mask_logits = F.interpolate(mask_logits, (H, W), mode="bilinear")
+        return mask_logits, class_logits
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: tuple[Tensor, Tensor],
+        metadata: Sequence[dict[str, Any]],
+        threshold: float,
+    ) -> list[dict[str, Tensor]]:
+        mask_logits_batch, class_logits_batch = raw_outputs
+        out: list[dict[str, Tensor]] = []
+        for i, meta in enumerate(metadata):
+            crop_h, crop_w = meta["crop_h"], meta["crop_w"]
+            orig_h, orig_w = meta["orig_h"], meta["orig_w"]
+            # (1, Q, crop_h, crop_w)
+            mask_logits = mask_logits_batch[i : i + 1, ..., :crop_h, :crop_w]
+            # (1, Q, orig_h, orig_w)
+            mask_logits = F.interpolate(
+                mask_logits, size=(orig_h, orig_w), mode="bilinear"
+            )
+            class_logits = class_logits_batch[i : i + 1]
+            labels, masks, scores = self.get_labels_masks_scores(
+                mask_logits=mask_logits, class_logits=class_logits
+            )
+            labels = self.internal_class_to_class[labels]
+            labels = labels.squeeze(0)
+            masks = masks.squeeze(0)
+            scores = scores.squeeze(0)
+            keep = scores >= threshold
+            out.append(
+                {
+                    "labels": labels[keep],
+                    "masks": masks[keep],
+                    "scores": scores[keep],
+                }
+            )
+        return out
+
+    @torch.no_grad()
+    def predict_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+        threshold: float = 0.8,
+    ) -> list[dict[str, Tensor]]:
+        """Run inference on a batch of images and return per-image predictions.
+
+        Args:
+            images:
+                Sequence of input images. Each can be a path, a PIL image, or a
+                tensor of shape (C, H, W).
+            threshold:
+                The confidence threshold for the predicted masks. Only masks with a
+                confidence score above this threshold are returned.
+
+        Returns:
+            A list with one dict per input image. Each dict contains:
+                - "labels": Tensor of shape (N,) with predicted class indices.
+                - "masks": Tensor of shape (N, H, W) with predicted masks at the
+                  original image resolution.
+                - "scores": Tensor of shape (N,) with confidence scores.
+        """
+        self._track_inference()
+        if self.training:
+            self.eval()
+        tensors: list[Tensor] = []
+        metadata: list[dict[str, Any]] = []
+        for image in images:
+            x, meta = self.preprocess_image(image)
+            tensors.append(x)
+            metadata.append(meta)
+        batch = torch.stack(tensors, dim=0)
+        batch = self.preprocess_batch(batch)
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, metadata, threshold=threshold)
+
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
         # Function used for ONNX export
         # (1, Q, H, W), (1, Q, K+1), Q = num_queries, K = len(self.classes)
-        mask_logits, class_logits = self._forward_logits(x)
+        mask_logits, class_logits = self.forward_backend(x)
         labels, masks, scores = self.get_labels_masks_scores(
             mask_logits=mask_logits, class_logits=class_logits
         )
@@ -427,24 +546,6 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
             mask_logits_per_layer,
             class_logits_per_layer,
         )
-
-    def _forward_logits(self, x: Tensor) -> tuple[Tensor, Tensor]:
-        """Forward pass that returns the logits of the last layer. Intended for
-        inference."""
-        # x is a batch of images with shape (B, C, H, W).
-        H, W = x.shape[-2:]
-
-        # Forward pass.
-        # Only the logits of the last layer are returned.
-        mask_logits_per_layer, class_logits_per_layer = self.forward_train(
-            x, return_logits_per_layer=False
-        )
-        mask_logits = mask_logits_per_layer[-1]
-        class_logits = class_logits_per_layer[-1]
-
-        # Interpolate.
-        mask_logits = F.interpolate(mask_logits, (H, W), mode="bilinear")
-        return mask_logits, class_logits
 
     def _predict(self, x: Tensor, grid_size: tuple[int, int]) -> tuple[Tensor, Tensor]:
         # TODO(Guarin, 08/25): Investigate if having different norms for queries and

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -282,7 +282,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
         x = x.unsqueeze(0)  # (1, C, H', W')
 
         # (1, Q, H', W'), (1, Q, K+1), Q = num_queries, K = len(self.classes)
-        mask_logits, class_logits = self._forward_logits(x)
+        mask_logits, class_logits = self.forward_backend(x)
 
         # Interpolate to original image size.
         mask_logits = mask_logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
@@ -345,7 +345,22 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
         return batch
 
     def forward_backend(self, x: Tensor) -> tuple[Tensor, Tensor]:
-        return self._forward_logits(x)
+        """Forward pass that returns the logits of the last layer. Intended for
+        inference."""
+        # x is a batch of images with shape (B, C, H, W).
+        H, W = x.shape[-2:]
+
+        # Forward pass.
+        # Only the logits of the last layer are returned.
+        mask_logits_per_layer, class_logits_per_layer = self.forward_train(
+            x, return_logits_per_layer=False
+        )
+        mask_logits = mask_logits_per_layer[-1]
+        class_logits = class_logits_per_layer[-1]
+
+        # Interpolate.
+        mask_logits = F.interpolate(mask_logits, (H, W), mode="bilinear")
+        return mask_logits, class_logits
 
     def postprocess(  # type: ignore[override]
         self,
@@ -359,12 +374,12 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
             crop_h, crop_w = meta["crop_h"], meta["crop_w"]
             orig_h, orig_w = meta["orig_h"], meta["orig_w"]
             # (1, Q, crop_h, crop_w)
-            mask_logits = mask_logits_batch[i:i+1, ..., :crop_h, :crop_w]
+            mask_logits = mask_logits_batch[i : i + 1, ..., :crop_h, :crop_w]
             # (1, Q, orig_h, orig_w)
             mask_logits = F.interpolate(
                 mask_logits, size=(orig_h, orig_w), mode="bilinear"
             )
-            class_logits = class_logits_batch[i:i+1]
+            class_logits = class_logits_batch[i : i + 1]
             labels, masks, scores = self.get_labels_masks_scores(
                 mask_logits=mask_logits, class_logits=class_logits
             )
@@ -422,7 +437,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
         # Function used for ONNX export
         # (1, Q, H, W), (1, Q, K+1), Q = num_queries, K = len(self.classes)
-        mask_logits, class_logits = self._forward_logits(x)
+        mask_logits, class_logits = self.forward_backend(x)
         labels, masks, scores = self.get_labels_masks_scores(
             mask_logits=mask_logits, class_logits=class_logits
         )
@@ -525,24 +540,6 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
             mask_logits_per_layer,
             class_logits_per_layer,
         )
-
-    def _forward_logits(self, x: Tensor) -> tuple[Tensor, Tensor]:
-        """Forward pass that returns the logits of the last layer. Intended for
-        inference."""
-        # x is a batch of images with shape (B, C, H, W).
-        H, W = x.shape[-2:]
-
-        # Forward pass.
-        # Only the logits of the last layer are returned.
-        mask_logits_per_layer, class_logits_per_layer = self.forward_train(
-            x, return_logits_per_layer=False
-        )
-        mask_logits = mask_logits_per_layer[-1]
-        class_logits = class_logits_per_layer[-1]
-
-        # Interpolate.
-        mask_logits = F.interpolate(mask_logits, (H, W), mode="bilinear")
-        return mask_logits, class_logits
 
     def _predict(self, x: Tensor, grid_size: tuple[int, int]) -> tuple[Tensor, Tensor]:
         # TODO(Guarin, 08/25): Investigate if having different norms for queries and

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -265,56 +265,10 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
         if self.training:
             self.eval()
 
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        x = transforms_functional.normalize(
-            x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-        )
-
-        x, (crop_h, crop_w) = self.resize_and_pad(x)
-        x = x.unsqueeze(0)  # (1, C, H', W')
-
-        # (1, Q, H', W'), (1, Q, K+1), Q = num_queries, K = len(self.classes)
-        mask_logits, class_logits = self.forward_backend(x)
-
-        # Interpolate to original image size.
-        mask_logits = mask_logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
-        # (1, Q, H, W)
-        mask_logits = F.interpolate(
-            mask_logits, size=(image_h, image_w), mode="bilinear"
-        )
-
-        # (1, Q), (1, Q, H, W), (1, Q)
-        labels, masks, scores = self.get_labels_masks_scores(
-            mask_logits=mask_logits, class_logits=class_logits
-        )
-
-        # Map internal class IDs to class IDs.
-        labels = self.internal_class_to_class[labels]  # (1, Q)
-
-        # Remove batch dimension.
-        labels = labels.squeeze(0)
-        masks = masks.squeeze(0)
-        scores = scores.squeeze(0)
-
-        # Apply threshold.
-        keep = scores >= threshold
-        labels = labels[keep]
-        masks = masks[keep]
-        scores = scores[keep]
-
-        return {
-            "labels": labels,
-            "masks": masks,
-            "scores": scores,
-        }
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch(x.unsqueeze(0))
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata], threshold=threshold)[0]
 
     def preprocess_image(
         self, image: PathLike | PILImage | Tensor

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import logging
 import math
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -314,6 +315,109 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
             "masks": masks,
             "scores": scores,
         }
+
+    def preprocess_image(
+        self, image: PathLike | PILImage | Tensor
+    ) -> tuple[Tensor, dict[str, Any]]:
+        first_param = next(self.parameters())
+        device, dtype = first_param.device, first_param.dtype
+
+        x = file_helpers.as_image_tensor(image).to(device)
+        image_h, image_w = x.shape[-2:]
+
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        # Normalize before resize_and_pad so the zero padding inserted by
+        # resize_and_pad is identical to the per-image `predict` path.
+        x = transforms_functional.normalize(
+            x,
+            mean=list(self.image_normalize["mean"]),
+            std=list(self.image_normalize["std"]),
+        )
+        x, (crop_h, crop_w) = self.resize_and_pad(x)
+        return x, {
+            "orig_h": image_h,
+            "orig_w": image_w,
+            "crop_h": crop_h,
+            "crop_w": crop_w,
+        }
+
+    def preprocess_batch(self, batch: Tensor) -> Tensor:
+        return batch
+
+    def forward_backend(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        return self._forward_logits(x)
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: tuple[Tensor, Tensor],
+        metadata: Sequence[dict[str, Any]],
+        threshold: float,
+    ) -> list[dict[str, Tensor]]:
+        mask_logits_batch, class_logits_batch = raw_outputs
+        out: list[dict[str, Tensor]] = []
+        for i, meta in enumerate(metadata):
+            crop_h, crop_w = meta["crop_h"], meta["crop_w"]
+            orig_h, orig_w = meta["orig_h"], meta["orig_w"]
+            # (1, Q, crop_h, crop_w)
+            mask_logits = mask_logits_batch[i:i+1, ..., :crop_h, :crop_w]
+            # (1, Q, orig_h, orig_w)
+            mask_logits = F.interpolate(
+                mask_logits, size=(orig_h, orig_w), mode="bilinear"
+            )
+            class_logits = class_logits_batch[i:i+1]
+            labels, masks, scores = self.get_labels_masks_scores(
+                mask_logits=mask_logits, class_logits=class_logits
+            )
+            labels = self.internal_class_to_class[labels]
+            labels = labels.squeeze(0)
+            masks = masks.squeeze(0)
+            scores = scores.squeeze(0)
+            keep = scores >= threshold
+            out.append(
+                {
+                    "labels": labels[keep],
+                    "masks": masks[keep],
+                    "scores": scores[keep],
+                }
+            )
+        return out
+
+    @torch.no_grad()
+    def predict_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+        threshold: float = 0.8,
+    ) -> list[dict[str, Tensor]]:
+        """Run inference on a batch of images and return per-image predictions.
+
+        Args:
+            images:
+                Sequence of input images. Each can be a path, a PIL image, or a
+                tensor of shape (C, H, W).
+            threshold:
+                The confidence threshold for the predicted masks. Only masks with a
+                confidence score above this threshold are returned.
+
+        Returns:
+            A list with one dict per input image. Each dict contains:
+                - "labels": Tensor of shape (N,) with predicted class indices.
+                - "masks": Tensor of shape (N, H, W) with predicted masks at the
+                  original image resolution.
+                - "scores": Tensor of shape (N,) with confidence scores.
+        """
+        self._track_inference()
+        if self.training:
+            self.eval()
+        tensors: list[Tensor] = []
+        metadata: list[dict[str, Any]] = []
+        for image in images:
+            x, meta = self.preprocess_image(image)
+            tensors.append(x)
+            metadata.append(meta)
+        batch = torch.stack(tensors, dim=0)
+        batch = self.preprocess_batch(batch)
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, metadata, threshold=threshold)
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
         # Function used for ONNX export

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 from lightning_utilities.core.imports import RequirementCache
+from pytest_mock import MockerFixture
 
 from lightly_train._task_models.dinov2_eomt_instance_segmentation.task_model import (
     DINOv2EoMTInstanceSegmentation,
@@ -28,6 +30,40 @@ def model() -> DINOv2EoMTInstanceSegmentation:
         num_joint_blocks=1,
         load_weights=False,
     )
+
+
+def test_predict_batch__composes_stages_in_order(
+    model: DINOv2EoMTInstanceSegmentation, mocker: MockerFixture
+) -> None:
+    preprocess_image_spy = mocker.spy(model, "preprocess_image")
+    preprocess_batch_spy = mocker.spy(model, "preprocess_batch")
+    forward_backend_spy = mocker.spy(model, "forward_backend")
+    postprocess_spy = mocker.spy(model, "postprocess")
+
+    images = [torch.rand(3, 24, 32), torch.rand(3, 40, 24)]
+    result = model.predict_batch(images=images)
+
+    # Each input image goes through preprocess_image once.
+    assert preprocess_image_spy.call_count == 2
+
+    # The stacked batch is preprocessed in a single call with shape (B, C, H, W).
+    assert preprocess_batch_spy.call_count == 1
+    (batch_in,) = preprocess_batch_spy.call_args.args
+    assert batch_in.shape == (2, 3, 14, 14)
+
+    # forward_backend receives the output of preprocess_batch.
+    assert forward_backend_spy.call_count == 1
+    (forward_in,) = forward_backend_spy.call_args.args
+    assert forward_in is preprocess_batch_spy.spy_return
+
+    # postprocess receives forward_backend's output and per-image metadata.
+    assert postprocess_spy.call_count == 1
+    raw_in, metadata = postprocess_spy.call_args.args
+    assert raw_in is forward_backend_spy.spy_return
+    assert len(metadata) == 2
+
+    # predict_batch returns whatever postprocess produced.
+    assert result is postprocess_spy.spy_return
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 from lightning_utilities.core.imports import RequirementCache
+from pytest_mock import MockerFixture
 
 from lightly_train._task_models.dinov3_eomt_instance_segmentation.task_model import (
     DINOv3EoMTInstanceSegmentation,
@@ -29,6 +31,39 @@ def model() -> DINOv3EoMTInstanceSegmentation:
         load_weights=False,
     )
 
+
+def test_predict_batch__composes_stages_in_order(
+    model: DINOv3EoMTInstanceSegmentation, mocker: MockerFixture
+) -> None:
+    preprocess_image_spy = mocker.spy(model, "preprocess_image")
+    preprocess_batch_spy = mocker.spy(model, "preprocess_batch")
+    forward_backend_spy = mocker.spy(model, "forward_backend")
+    postprocess_spy = mocker.spy(model, "postprocess")
+
+    images = [torch.rand(3, 24, 32), torch.rand(3, 40, 24)]
+    result = model.predict_batch(images=images)
+
+    # Each input image goes through preprocess_image once.
+    assert preprocess_image_spy.call_count == 2
+
+    # The stacked batch is preprocessed in a single call with shape (B, C, H, W).
+    assert preprocess_batch_spy.call_count == 1
+    (batch_in,) = preprocess_batch_spy.call_args.args
+    assert batch_in.shape == (2, 3, 16, 16)
+
+    # forward_backend receives the output of preprocess_batch.
+    assert forward_backend_spy.call_count == 1
+    (forward_in,) = forward_backend_spy.call_args.args
+    assert forward_in is preprocess_batch_spy.spy_return
+
+    # postprocess receives forward_backend's output and per-image metadata.
+    assert postprocess_spy.call_count == 1
+    raw_in, metadata = postprocess_spy.call_args.args
+    assert raw_in is forward_backend_spy.spy_return
+    assert len(metadata) == 2
+
+    # predict_batch returns whatever postprocess produced.
+    assert result is postprocess_spy.spy_return
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -65,6 +65,7 @@ def test_predict_batch__composes_stages_in_order(
     # predict_batch returns whatever postprocess produced.
     assert result is postprocess_spy.spy_return
 
+
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"


### PR DESCRIPTION
## What has changed and why?

- Adds `predict_batch()` to `DINOv3EoMTInstanceSegmentation`/`DINOv2EoMTInstanceSegmentation` for batched inference. 
- Mirrors the staged `preprocess_image` / `preprocess_batch` / `forward_backend` / `postprocess` pattern from #738. 
- Renames `_forward_logits` to `forward_backend` (same body, now implements the `TaskModel` protocol directly). 

## How has it been tested?

```python
if __name__ == "__main__":
    images = [
        "/coco128_yolo/images/val2017/000000012120.jpg",
        "/coco128_yolo/images/val2017/000000011760.jpg",
        "/coco128_yolo/images/val2017/000000007888.jpg",
        "/coco128_yolo/images/val2017/000000003661.jpg",
    ]
    model = lightly_train.load_model(
        model="dinov3/vits16-eomt-inst-coco",
        device="cpu",
    )
    results_single = [model.predict(image=img) for img in images]
    results_batch = model.predict_batch(images=images)
    
    for i, (single, batch) in enumerate(zip(results_single, results_batch)):
        name = os.path.basename(images[i])
        n_single = single["labels"].shape[0]
        n_batch = batch["labels"].shape[0]
        if n_single != n_batch:
            print(f"Image {i} ({name}): instance count mismatch — predict={n_single}, predict_batch={n_batch}")
            continue
        labels_match = torch.equal(single["labels"], batch["labels"])
        scores_diff = (single["scores"] - batch["scores"]).abs().max().item()
        scores_close = torch.allclose(single["scores"], batch["scores"], atol=1e-4)
        masks_iou = (
            (single["masks"] & batch["masks"]).flatten(1).sum(dim=1).float()
            / (single["masks"] | batch["masks"]).flatten(1).sum(dim=1).clamp(min=1).float()
        )
        masks_min_iou = masks_iou.min().item()
        masks_match = masks_min_iou > 0.99
        print(
            f"Image {i} ({name}): n={n_single}, labels={labels_match}, "
            f"scores_close={scores_close} (max_diff={scores_diff:.2e}), "
            f"masks_match={masks_match} (min_iou={masks_min_iou:.4f})"
        )
```
Output:
```bash
Image 0 (000000012120.jpg): n=10, labels=True, scores_close=True (max_diff=2.38e-07), masks_match=True (min_iou=1.0000)
Image 1 (000000011760.jpg): n=3, labels=True, scores_close=True (max_diff=5.96e-08), masks_match=True (min_iou=1.0000)
Image 2 (000000007888.jpg): n=2, labels=True, scores_close=True (max_diff=1.19e-07), masks_match=True (min_iou=1.0000)
Image 3 (000000003661.jpg): n=5, labels=True, scores_close=True (max_diff=2.38e-07), masks_match=True (min_iou=1.0000)
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
