### PR TITLE
Add Predict Batch Method to Semantic Segmentation

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -272,38 +272,10 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
         self._track_inference()
         if self.training:
             self.eval()
-
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        x = transforms_functional.normalize(
-            x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-        )
-
-        # Crop size is the short side of the training image size. We resize the image
-        # such that the short side of the image matches the crop size.
-        crop_size = min(self.image_size)
-        # (C, H, W) -> (C, H', W')
-        x = transforms_functional.resize(x, size=[crop_size])
-        x = x.unsqueeze(0)  # (1, C, H', W')
-
-        logits = self._forward_logits(x)  # (1, K+1, H', W'), K = len(self.classes)
-        # Restrict logits to known classes only.
-        logits = logits[:, :-1]  # (1, K, H', W')
-        logits = F.interpolate(
-            logits, size=(image_h, image_w), mode="bilinear"
-        )  # (1, K|K+1, H, W)
-
-        masks = logits.argmax(dim=1)  # (1, H, W)
-        # Map internal class IDs to class IDs.
-        masks = self.internal_class_to_class[masks]  # (1, H, W)
-        return masks[0]
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch([x])
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata])[0]
 
     def preprocess_image(
         self, image: PathLike | PILImage | Tensor
@@ -323,7 +295,7 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
 
         # Crop size is the short side of the training image size. We resize the image
         # such that the short side of the image matches the crop size. The long side
-        # therefore varies per image, so preprocessed tensors are NOT stackable across
+        # therefore varies per image, so preprocessed tensors are not stackable across
         # the batch.
         crop_size = min(self.image_size)
         x = transforms_functional.resize(x, size=[crop_size])

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import logging
 import math
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -303,6 +304,134 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
         # Map internal class IDs to class IDs.
         masks = self.internal_class_to_class[masks]  # (1, H, W)
         return masks[0]
+
+    def preprocess_image(
+        self, image: PathLike | PILImage | Tensor
+    ) -> tuple[Tensor, dict[str, Any]]:
+        first_param = next(self.parameters())
+        device, dtype = first_param.device, first_param.dtype
+
+        x = file_helpers.as_image_tensor(image).to(device)
+        image_h, image_w = x.shape[-2:]
+
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        x = transforms_functional.normalize(
+            x,
+            mean=list(self.image_normalize["mean"]),
+            std=list(self.image_normalize["std"]),
+        )
+
+        # Crop size is the short side of the training image size. We resize the image
+        # such that the short side of the image matches the crop size. The long side
+        # therefore varies per image, so preprocessed tensors are NOT stackable across
+        # the batch.
+        crop_size = min(self.image_size)
+        x = transforms_functional.resize(x, size=[crop_size])
+
+        # Origins describe where each crop sits in the resized image. They are
+        # computed here (image_idx=0) so `postprocess` can untile without
+        # recomputing them.
+        _, origins = self.tile(images=[x])
+        return x, {
+            "orig_h": image_h,
+            "orig_w": image_w,
+            "resized_h": int(x.shape[-2]),
+            "resized_w": int(x.shape[-1]),
+            "origins": origins,
+            "num_crops": len(origins),
+        }
+
+    def preprocess_batch(  # type: ignore[override]
+        self, batch: Sequence[Tensor]
+    ) -> Tensor:
+        # Tile each variable-size image into square crops of size
+        # `min(image_size)` and stack them into a single (B, C, H, W) tensor.
+        crops_list, _ = self.tile(images=list(batch))
+        return torch.stack(crops_list)
+
+    def forward_backend(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """Forward pass that returns the logits of the last layer. Intended for
+        inference."""
+        # x is a batch of square crops with shape (B, C, H, W).
+        H, W = x.shape[-2:]
+
+        # Forward pass.
+        # Only the logits of the last layer are returned.
+        mask_logits_per_layer, class_logits_per_layer = self.forward_train(
+            x, return_logits_per_layer=False
+        )
+        mask_logits = mask_logits_per_layer[-1]
+        class_logits = class_logits_per_layer[-1]
+
+        # Interpolate.
+        mask_logits = F.interpolate(mask_logits, (H, W), mode="bilinear")
+        return mask_logits, class_logits
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: tuple[Tensor, Tensor],
+        metadata: Sequence[dict[str, Any]],
+    ) -> list[Tensor]:
+        mask_logits, class_logits = raw_outputs
+        # (sum N_i, K+1, crop_h, crop_w)
+        crop_logits_all = self.to_per_pixel_logits_semantic(mask_logits, class_logits)
+
+        # Split the batched crop logits back into one chunk per image.
+        crop_logits_per_image = torch.split(
+            crop_logits_all, [meta["num_crops"] for meta in metadata], dim=0
+        )
+
+        out: list[Tensor] = []
+        for image_crops, meta in zip(crop_logits_per_image, metadata):
+            # Untile back to the resized image size.
+            logits = self.untile(
+                crop_logits=image_crops,
+                origins=meta["origins"],
+                image_sizes=[(meta["resized_h"], meta["resized_w"])],
+            )[0]  # (K+1, H', W')
+
+            # Restrict to known classes and interpolate to original image size.
+            logits = logits[:-1].unsqueeze(0)  # (1, K, H', W')
+            logits = F.interpolate(
+                logits, size=(meta["orig_h"], meta["orig_w"]), mode="bilinear"
+            )
+            masks = logits.argmax(dim=1)  # (1, H, W)
+            masks = self.internal_class_to_class[masks]
+            out.append(masks[0])
+
+        return out
+
+    @torch.no_grad()
+    def predict_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+    ) -> list[Tensor]:
+        """Returns the predicted masks for the given batch of images.
+
+        Args:
+            images:
+                Sequence of input images. Each can be a path, URL, PIL image, or
+                tensor of shape (C, H, W).
+
+        Returns:
+            A list of predicted masks, one per input image. Each mask is a tensor
+            of shape (H, W) where the values represent the class IDs as defined in
+            the `classes` argument of your dataset. The model will always predict
+            the pixels as one of the known classes even when your dataset contains
+            ignored classes defined by the `ignore_classes` argument.
+        """
+        self._track_inference()
+        if self.training:
+            self.eval()
+        tensors: list[Tensor] = []
+        metadata: list[dict[str, Any]] = []
+        for image in images:
+            x, meta = self.preprocess_image(image)
+            tensors.append(x)
+            metadata.append(meta)
+        batch = self.preprocess_batch(tensors)
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, metadata)
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         # Function used for ONNX export

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
@@ -210,36 +210,10 @@ class DINOv2LinearSemanticSegmentation(TaskModel):
         self._track_inference()
         if self.training:
             self.eval()
-
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        x = transforms_functional.normalize(
-            x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-        )
-
-        # Crop size is the short side of the training image size. We resize the image
-        # such that the short side of the image matches the crop size.
-        crop_size = min(self.image_size)
-        # (C, H, W) -> (C, H', W')
-        x = transforms_functional.resize(x, size=[crop_size])
-        x = x.unsqueeze(0)  # (1, C, H', W')
-
-        logits = self._forward_logits(x)  # (1, K|K+1, H', W'), K=num_classes
-        if self.class_ignore_index is not None:
-            # Restrict logits to known classes only.
-            logits = logits[:, :-1]  # (1, K, H', W')
-        logits = F.interpolate(logits, size=(image_h, image_w), mode="bilinear")
-
-        masks = logits.argmax(dim=1)  # (1, H, W)
-        masks = self.internal_class_to_class[masks]  # (1, H, W)
-        return masks[0]
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch([x])
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata])[0]
 
     def preprocess_image(
         self, image: PathLike | PILImage | Tensor

--- a/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_linear_semantic_segmentation/task_model.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -239,6 +240,122 @@ class DINOv2LinearSemanticSegmentation(TaskModel):
         masks = logits.argmax(dim=1)  # (1, H, W)
         masks = self.internal_class_to_class[masks]  # (1, H, W)
         return masks[0]
+
+    def preprocess_image(
+        self, image: PathLike | PILImage | Tensor
+    ) -> tuple[Tensor, dict[str, Any]]:
+        first_param = next(self.parameters())
+        device, dtype = first_param.device, first_param.dtype
+
+        x = file_helpers.as_image_tensor(image).to(device)
+        image_h, image_w = x.shape[-2:]
+
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        x = transforms_functional.normalize(
+            x,
+            mean=list(self.image_normalize["mean"]),
+            std=list(self.image_normalize["std"]),
+        )
+
+        # Crop size is the short side of the training image size. We resize the image
+        # such that the short side of the image matches the crop size. The long side
+        # therefore varies per image, so preprocessed tensors are NOT stackable across
+        # the batch.
+        crop_size = min(self.image_size)
+        x = transforms_functional.resize(x, size=[crop_size])
+
+        # Origins describe where each crop sits in the resized image. They are
+        # computed here (image_idx=0) so `postprocess` can untile without
+        # recomputing them.
+        _, origins = self.tile(images=[x])
+        return x, {
+            "orig_h": image_h,
+            "orig_w": image_w,
+            "resized_h": int(x.shape[-2]),
+            "resized_w": int(x.shape[-1]),
+            "origins": origins,
+            "num_crops": len(origins),
+        }
+
+    def preprocess_batch(  # type: ignore[override]
+        self, batch: Sequence[Tensor]
+    ) -> Tensor:
+        # Tile each variable-size image into square crops of size
+        # `min(image_size)` and stack them into a single (B, C, H, W) tensor.
+        crops_list, _ = self.tile(images=list(batch))
+        return torch.stack(crops_list)
+
+    def forward_backend(self, x: Tensor) -> Tensor:
+        """Forward pass that returns per-pixel logits for a batch of crops.
+        Intended for inference."""
+        # x is a batch of square crops with shape (B, C, H, W).
+        # forward_train already upsamples back to (H, W), so no extra interpolate
+        # is needed here.
+        return self.forward_train(x)
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: Tensor,
+        metadata: Sequence[dict[str, Any]],
+    ) -> list[Tensor]:
+        # raw_outputs has shape (sum N_i, K|K+1, crop_h, crop_w).
+        crop_logits_per_image = torch.split(
+            raw_outputs, [meta["num_crops"] for meta in metadata], dim=0
+        )
+
+        out: list[Tensor] = []
+        for image_crops, meta in zip(crop_logits_per_image, metadata):
+            # Untile back to the resized image size.
+            logits = self.untile(
+                crop_logits=image_crops,
+                origins=meta["origins"],
+                image_sizes=[(meta["resized_h"], meta["resized_w"])],
+            )[0]  # (K|K+1, H', W')
+
+            if self.class_ignore_index is not None:
+                # Restrict to known classes only.
+                logits = logits[:-1]
+            logits = logits.unsqueeze(0)  # (1, K, H', W')
+            logits = F.interpolate(
+                logits, size=(meta["orig_h"], meta["orig_w"]), mode="bilinear"
+            )
+            masks = logits.argmax(dim=1)  # (1, H, W)
+            masks = self.internal_class_to_class[masks]
+            out.append(masks[0])
+
+        return out
+
+    @torch.no_grad()
+    def predict_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+    ) -> list[Tensor]:
+        """Returns the predicted masks for the given batch of images.
+
+        Args:
+            images:
+                Sequence of input images. Each can be a path, URL, PIL image, or
+                tensor of shape (C, H, W).
+
+        Returns:
+            A list of predicted masks, one per input image. Each mask is a tensor
+            of shape (H, W) where the values represent the class IDs as defined in
+            the `classes` argument of your dataset. The model will always predict
+            the pixels as one of the known classes even when your dataset contains
+            ignored classes defined by the `ignore_classes` argument.
+        """
+        self._track_inference()
+        if self.training:
+            self.eval()
+        tensors: list[Tensor] = []
+        metadata: list[dict[str, Any]] = []
+        for image in images:
+            x, meta = self.preprocess_image(image)
+            tensors.append(x)
+            metadata.append(meta)
+        batch = self.preprocess_batch(tensors)
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, metadata)
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         # Function used for ONNX export

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -287,38 +287,10 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         self._track_inference()
         if self.training:
             self.eval()
-
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        x = transforms_functional.normalize(
-            x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-        )
-
-        # Crop size is the short side of the training image size. We resize the image
-        # such that the short side of the image matches the crop size.
-        crop_size = min(self.image_size)
-        # (C, H, W) -> (C, H', W')
-        x = transforms_functional.resize(x, size=[crop_size])
-        x = x.unsqueeze(0)  # (1, C, H', W')
-
-        logits = self._forward_logits(x)  # (1, K+1, H', W'), K = len(self.classes)
-        # Restrict logits to known classes only.
-        logits = logits[:, :-1]  # (1, K, H', W')
-        logits = F.interpolate(
-            logits, size=(image_h, image_w), mode="bilinear"
-        )  # (1, K|K+1, H, W)
-
-        masks = logits.argmax(dim=1)  # (1, H, W)
-        # Map internal class IDs to class IDs.
-        masks = self.internal_class_to_class[masks]  # (1, H, W)
-        return masks[0]
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch([x])
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata])[0]
 
     def preprocess_image(
         self, image: PathLike | PILImage | Tensor

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import logging
 import math
+from collections.abc import Sequence
 from typing import Any, Literal
 
 import torch
@@ -318,6 +319,134 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         # Map internal class IDs to class IDs.
         masks = self.internal_class_to_class[masks]  # (1, H, W)
         return masks[0]
+
+    def preprocess_image(
+        self, image: PathLike | PILImage | Tensor
+    ) -> tuple[Tensor, dict[str, Any]]:
+        first_param = next(self.parameters())
+        device, dtype = first_param.device, first_param.dtype
+
+        x = file_helpers.as_image_tensor(image).to(device)
+        image_h, image_w = x.shape[-2:]
+
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        x = transforms_functional.normalize(
+            x,
+            mean=list(self.image_normalize["mean"]),
+            std=list(self.image_normalize["std"]),
+        )
+
+        # Crop size is the short side of the training image size. We resize the image
+        # such that the short side of the image matches the crop size. The long side
+        # therefore varies per image, so preprocessed tensors are NOT stackable across
+        # the batch.
+        crop_size = min(self.image_size)
+        x = transforms_functional.resize(x, size=[crop_size])
+
+        # Origins describe where each crop sits in the resized image. They are
+        # computed here (image_idx=0) so `postprocess` can untile without
+        # recomputing them.
+        _, origins = self.tile(images=[x])
+        return x, {
+            "orig_h": image_h,
+            "orig_w": image_w,
+            "resized_h": int(x.shape[-2]),
+            "resized_w": int(x.shape[-1]),
+            "origins": origins,
+            "num_crops": len(origins),
+        }
+
+    def preprocess_batch(  # type: ignore[override]
+        self, batch: Sequence[Tensor]
+    ) -> Tensor:
+        # Tile each variable-size image into square crops of size
+        # `min(image_size)` and stack them into a single (B, C, H, W) tensor.
+        crops_list, _ = self.tile(images=list(batch))
+        return torch.stack(crops_list)
+
+    def forward_backend(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """Forward pass that returns the logits of the last layer. Intended for
+        inference."""
+        # x is a batch of square crops with shape (B, C, H, W).
+        H, W = x.shape[-2:]
+
+        # Forward pass.
+        # Only the logits of the last layer are returned.
+        mask_logits_per_layer, class_logits_per_layer = self.forward_train(
+            x, return_logits_per_layer=False
+        )
+        mask_logits = mask_logits_per_layer[-1]
+        class_logits = class_logits_per_layer[-1]
+
+        # Interpolate.
+        mask_logits = F.interpolate(mask_logits, (H, W), mode="bilinear")
+        return mask_logits, class_logits
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: tuple[Tensor, Tensor],
+        metadata: Sequence[dict[str, Any]],
+    ) -> list[Tensor]:
+        mask_logits, class_logits = raw_outputs
+        # (sum N_i, K+1, crop_h, crop_w)
+        crop_logits_all = self.to_per_pixel_logits_semantic(mask_logits, class_logits)
+
+        # Split the batched crop logits back into one chunk per image.
+        crop_logits_per_image = torch.split(
+            crop_logits_all, [meta["num_crops"] for meta in metadata], dim=0
+        )
+
+        out: list[Tensor] = []
+        for image_crops, meta in zip(crop_logits_per_image, metadata):
+            # Untile back to the resized image size.
+            logits = self.untile(
+                crop_logits=image_crops,
+                origins=meta["origins"],
+                image_sizes=[(meta["resized_h"], meta["resized_w"])],
+            )[0]  # (K+1, H', W')
+
+            # Restrict to known classes and interpolate to original image size.
+            logits = logits[:-1].unsqueeze(0)  # (1, K, H', W')
+            logits = F.interpolate(
+                logits, size=(meta["orig_h"], meta["orig_w"]), mode="bilinear"
+            )
+            masks = logits.argmax(dim=1)  # (1, H, W)
+            masks = self.internal_class_to_class[masks]
+            out.append(masks[0])
+
+        return out
+
+    @torch.no_grad()
+    def predict_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+    ) -> list[Tensor]:
+        """Returns the predicted masks for the given batch of images.
+
+        Args:
+            images:
+                Sequence of input images. Each can be a path, URL, PIL image, or
+                tensor of shape (C, H, W).
+
+        Returns:
+            A list of predicted masks, one per input image. Each mask is a tensor
+            of shape (H, W) where the values represent the class IDs as defined in
+            the `classes` argument of your dataset. The model will always predict
+            the pixels as one of the known classes even when your dataset contains
+            ignored classes defined by the `ignore_classes` argument.
+        """
+        self._track_inference()
+        if self.training:
+            self.eval()
+        tensors: list[Tensor] = []
+        metadata: list[dict[str, Any]] = []
+        for image in images:
+            x, meta = self.preprocess_image(image)
+            tensors.append(x)
+            metadata.append(meta)
+        batch = self.preprocess_batch(tensors)
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, metadata)
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         # Function used for ONNX export

--- a/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 from lightning_utilities.core.imports import RequirementCache
+from pytest_mock import MockerFixture
 
 from lightly_train._task_models.dinov2_eomt_semantic_segmentation.task_model import (
     DINOv2EoMTSemanticSegmentation,
@@ -29,6 +31,43 @@ def model() -> DINOv2EoMTSemanticSegmentation:
         num_joint_blocks=1,
         load_weights=False,
     )
+
+
+def test_predict_batch__composes_stages_in_order(
+    model: DINOv2EoMTSemanticSegmentation, mocker: MockerFixture
+) -> None:
+    preprocess_image_spy = mocker.spy(model, "preprocess_image")
+    preprocess_batch_spy = mocker.spy(model, "preprocess_batch")
+    forward_backend_spy = mocker.spy(model, "forward_backend")
+    postprocess_spy = mocker.spy(model, "postprocess")
+
+    images = [torch.rand(3, 21, 28), torch.rand(3, 35, 21)]
+    result = model.predict_batch(images=images)
+
+    # Each input image goes through preprocess_image once.
+    assert preprocess_image_spy.call_count == 2
+
+    # preprocess_batch receives a sequence of per-image tensors with the same
+    # short side (= min(image_size)) but different long sides.
+    assert preprocess_batch_spy.call_count == 1
+    (batch_in,) = preprocess_batch_spy.call_args.args
+    assert len(batch_in) == 2
+    assert all(t.shape[0] == 3 for t in batch_in)
+    assert all(min(t.shape[-2:]) == min(model.image_size) for t in batch_in)
+
+    # forward_backend receives the output of preprocess_batch.
+    assert forward_backend_spy.call_count == 1
+    (forward_in,) = forward_backend_spy.call_args.args
+    assert forward_in is preprocess_batch_spy.spy_return
+
+    # postprocess receives forward_backend's output and per-image metadata.
+    assert postprocess_spy.call_count == 1
+    raw_in, metadata = postprocess_spy.call_args.args
+    assert raw_in is forward_backend_spy.spy_return
+    assert len(metadata) == 2
+
+    # predict_batch returns whatever postprocess produced.
+    assert result is postprocess_spy.spy_return
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -69,6 +69,7 @@ def test_predict_batch__composes_stages_in_order(
     # predict_batch returns whatever postprocess produced.
     assert result is postprocess_spy.spy_return
 
+
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 from lightning_utilities.core.imports import RequirementCache
+from pytest_mock import MockerFixture
 
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model import (
     DINOv3EoMTSemanticSegmentation,
@@ -30,6 +32,42 @@ def model() -> DINOv3EoMTSemanticSegmentation:
         load_weights=False,
     )
 
+
+def test_predict_batch__composes_stages_in_order(
+    model: DINOv3EoMTSemanticSegmentation, mocker: MockerFixture
+) -> None:
+    preprocess_image_spy = mocker.spy(model, "preprocess_image")
+    preprocess_batch_spy = mocker.spy(model, "preprocess_batch")
+    forward_backend_spy = mocker.spy(model, "forward_backend")
+    postprocess_spy = mocker.spy(model, "postprocess")
+
+    images = [torch.rand(3, 24, 32), torch.rand(3, 40, 24)]
+    result = model.predict_batch(images=images)
+
+    # Each input image goes through preprocess_image once.
+    assert preprocess_image_spy.call_count == 2
+
+    # preprocess_batch receives a sequence of per-image tensors with the same
+    # short side (= min(image_size)) but different long sides.
+    assert preprocess_batch_spy.call_count == 1
+    (batch_in,) = preprocess_batch_spy.call_args.args
+    assert len(batch_in) == 2
+    assert all(t.shape[0] == 3 for t in batch_in)
+    assert all(min(t.shape[-2:]) == min(model.image_size) for t in batch_in)
+
+    # forward_backend receives the output of preprocess_batch.
+    assert forward_backend_spy.call_count == 1
+    (forward_in,) = forward_backend_spy.call_args.args
+    assert forward_in is preprocess_batch_spy.spy_return
+
+    # postprocess receives forward_backend's output and per-image metadata.
+    assert postprocess_spy.call_count == 1
+    raw_in, metadata = postprocess_spy.call_args.args
+    assert raw_in is forward_backend_spy.spy_return
+    assert len(metadata) == 2
+
+    # predict_batch returns whatever postprocess produced.
+    assert result is postprocess_spy.spy_return
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
 @pytest.mark.skipif(


### PR DESCRIPTION

## What has changed and why?

- Adds `predict_batch()` to `DINOv2EoMTSemanticSegmentation`/ `DINOv3EoMTSemanticSegmentation` for batched inference.
- Mirrors the staged `preprocess_image` / `preprocess_batch` / `forward_backend` / `postprocess` pattern from #738 and #741.
- Semantic segmentation images are **variable-size**, so `preprocess_image` resizes each image so its short side matches the crop size, then tiles it into square crops. `preprocess_batch` stacks all crops into a single forward pass, and `postprocess` untiles, interpolates back to the original size, and maps internal class indices to dataset class IDs.


## How has it been tested?

- Unit tests added for both DINOv2 and DINOv3 variants (`test_predict_batch__composes_stages_in_order`): spies verify that each pipeline stage is called exactly once in the correct order, receives the right inputs, and that the output comes from `postprocess`.

Manually tested the correctness of `predict_batch` with `predict` functions.
```python
import lightly_train
import torch
import os

if __name__ == "__main__":
    images = [
        "/coco128_yolo/images/val2017/000000012120.jpg",
        "/coco128_yolo/images/val2017/000000011760.jpg",
        "/coco128_yolo/images/val2017/000000007888.jpg",
        "/coco128_yolo/images/val2017/000000003661.jpg",
    ]
    model = lightly_train.load_model(
        model="dinov3/vitt32-eomt-coco",
        device="cpu",
    )
    results_single = [model.predict(image=img) for img in images]
    results_batch = model.predict_batch(images=images)

    for i, (single, batch) in enumerate(zip(results_single, results_batch)):
        name = os.path.basename(images[i])
        if single.shape != batch.shape:
            print(f"Image {i} ({name}): shape mismatch — predict={tuple(single.shape)}, predict_batch={tuple(batch.shape)}")
            continue
        pixel_match = (single == batch).float().mean().item()
        classes = torch.unique(torch.cat([single.flatten(), batch.flatten()]))
        ious = []
        for c in classes.tolist():
            inter = ((single == c) & (batch == c)).sum().item()
            union = ((single == c) | (batch == c)).sum().item()
            if union > 0:
                ious.append(inter / union)
        min_iou = min(ious) if ious else 1.0
        mean_iou = sum(ious) / len(ious) if ious else 1.0
        masks_match = min_iou > 0.99
        print(
            f"Image {i} ({name}): pixel_acc={pixel_match:.4f}, "
            f"masks_match={masks_match} (min_iou={min_iou:.4f}, mean_iou={mean_iou:.4f}), "
            f"classes={classes.tolist()}"
        )

```
Output:
```bash
Image 0 (000000012120.jpg): pixel_acc=1.0000, masks_match=True (min_iou=1.0000, mean_iou=1.0000), classes=[1, 37, 43, 62, 85, 92, 112, 138, 145, 161, 173]
Image 1 (000000011760.jpg): pixel_acc=1.0000, masks_match=True (min_iou=1.0000, mean_iou=1.0000), classes=[24, 111, 124, 169, 182]
Image 2 (000000007888.jpg): pixel_acc=1.0000, masks_match=True (min_iou=1.0000, mean_iou=1.0000), classes=[38, 132, 155, 157]
Image 3 (000000003661.jpg): pixel_acc=1.0000, masks_match=True (min_iou=1.0000, mean_iou=1.0000), classes=[3, 52, 62, 67, 96, 115, 123, 165, 172, 173, 181]
```

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)
