### PR TITLE
Add Predict Batch Method to Image Classification

### DIFF
--- a/src/lightly_train/_task_models/image_classification/task_model.py
+++ b/src/lightly_train/_task_models/image_classification/task_model.py
@@ -206,46 +206,10 @@ class ImageClassification(TaskModel):
         self._track_inference()
         if self.training:
             self.eval()
-
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-
-        # Transform
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        if self.image_normalize is not None:
-            x = transforms_functional.normalize(
-                x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-            )
-        x = self.resize_and_pad(x)[0]
-        x = x.unsqueeze(0)  # (1, C, H', W')
-
-        # Forward
-        logits = self.forward_backend(x)  # (B, num_classes)
-        labels, scores = self.get_labels_scores(logits, topk=topk, threshold=threshold)
-
-        if self.classification_task == "multiclass":
-            labels = self.internal_class_to_class[labels]
-        elif self.classification_task == "multilabel":
-            labels = self.internal_class_to_class[labels[..., 1]]
-        else:
-            raise ValueError(
-                f"Invalid classification_task '{self.classification_task}'"
-            )
-
-        # Remove batch dimension.
-        if self.classification_task == "multiclass":
-            labels = labels.squeeze(0)  # Remove batch dimension
-            scores = scores.squeeze(0)  # Remove batch dimension
-        # Tensors are already in the correct shape for multilabel.
-
-        return {
-            "labels": labels,
-            "scores": scores,
-        }
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch(x.unsqueeze(0))
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata], topk=topk, threshold=threshold)[0]
 
     def preprocess_image(
         self, image: PathLike | PILImage | Tensor
@@ -292,7 +256,7 @@ class ImageClassification(TaskModel):
             batch_idx = labels[..., 0]
             mapped_labels = self.internal_class_to_class[labels[..., 1]]
             for i in range(len(metadata)):
-                keep = (batch_idx == i)
+                keep = batch_idx == i
                 out.append(
                     {
                         "labels": mapped_labels[keep],

--- a/src/lightly_train/_task_models/image_classification/task_model.py
+++ b/src/lightly_train/_task_models/image_classification/task_model.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -223,7 +224,7 @@ class ImageClassification(TaskModel):
         x = x.unsqueeze(0)  # (1, C, H', W')
 
         # Forward
-        logits = self.forward_train(x)  # (B, num_classes)
+        logits = self.forward_backend(x)  # (B, num_classes)
         labels, scores = self.get_labels_scores(logits, topk=topk, threshold=threshold)
 
         if self.classification_task == "multiclass":
@@ -246,6 +247,106 @@ class ImageClassification(TaskModel):
             "scores": scores,
         }
 
+    def preprocess_image(
+        self, image: PathLike | PILImage | Tensor
+    ) -> tuple[Tensor, dict[str, Any]]:
+        first_param = next(self.parameters())
+        device, dtype = first_param.device, first_param.dtype
+
+        x = file_helpers.as_image_tensor(image).to(device)
+
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        # Normalize before resize_and_pad so the zero padding inserted by
+        # resize_and_pad is identical to the per-image `predict` path.
+        if self.image_normalize is not None:
+            x = transforms_functional.normalize(
+                x,
+                mean=list(self.image_normalize["mean"]),
+                std=list(self.image_normalize["std"]),
+            )
+        x = self.resize_and_pad(x)[0]
+        return x, {}
+
+    def preprocess_batch(self, batch: Tensor) -> Tensor:
+        return batch
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: Tensor,
+        metadata: Sequence[dict[str, Any]],
+        topk: int,
+        threshold: float,
+    ) -> list[dict[str, Tensor]]:
+        logits = raw_outputs  # (B, num_classes)
+        labels, scores = self.get_labels_scores(logits, topk=topk, threshold=threshold)
+
+        out: list[dict[str, Tensor]] = []
+        if self.classification_task == "multiclass":
+            # labels: (B, topk), scores: (B, topk)
+            labels = self.internal_class_to_class[labels]
+            for i in range(len(metadata)):
+                out.append({"labels": labels[i], "scores": scores[i]})
+        elif self.classification_task == "multilabel":
+            # labels: (num_labels, 2) where columns are (batch_idx, label).
+            # scores: (num_labels,)
+            batch_idx = labels[..., 0]
+            mapped_labels = self.internal_class_to_class[labels[..., 1]]
+            for i in range(len(metadata)):
+                keep = (batch_idx == i)
+                out.append(
+                    {
+                        "labels": mapped_labels[keep],
+                        "scores": scores[keep],
+                    }
+                )
+        else:
+            raise ValueError(
+                f"Invalid classification_task '{self.classification_task}'"
+            )
+        return out
+
+    @torch.no_grad()
+    def predict_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+        topk: int = 1,
+        threshold: float = 0.5,
+    ) -> list[dict[str, Tensor]]:
+        """Returns the predicted labels and scores for the given batch of images.
+
+        Args:
+            images:
+                Sequence of input images. Each can be a path, URL, PIL image, or
+                tensor of shape (C, H, W).
+            topk:
+                Number of top predictions to return per image. Only used for
+                multiclass classification.
+            threshold:
+                Score threshold to filter low-confidence predictions. Only used
+                for multilabel classification.
+
+        Returns:
+            A list with one dict per input image. Each dict contains:
+                - "labels": Tensor of shape (topk,) for multiclass and
+                  (num_labels,) for multilabel where num_labels is the number of
+                  labels with score > threshold.
+                - "scores": Tensor with the same shape as labels containing the
+                  corresponding scores.
+        """
+        self._track_inference()
+        if self.training:
+            self.eval()
+        tensors: list[Tensor] = []
+        metadata: list[dict[str, Any]] = []
+        for image in images:
+            x, meta = self.preprocess_image(image)
+            tensors.append(x)
+            metadata.append(meta)
+        batch = torch.stack(tensors, dim=0)
+        batch = self.preprocess_batch(batch)
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, metadata, topk=topk, threshold=threshold)
+
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         """Forward for ONNX export.
 
@@ -254,7 +355,7 @@ class ImageClassification(TaskModel):
             (num_labels, 2) for multilabel where the columns are (batch_idx, label).
             Scores has shape (B, topk) for multiclass and (num_labels,) for multilabel.
         """
-        logits = self.forward_train(x)
+        logits = self.forward_backend(x)
         labels, scores = self.get_labels_scores(logits, topk=1, threshold=-1)
         if self.classification_task == "multiclass":
             labels = self.internal_class_to_class[labels]
@@ -266,8 +367,8 @@ class ImageClassification(TaskModel):
             )
         return labels, scores
 
-    def forward_train(self, x: Tensor) -> Tensor:
-        """Forward pass for training. Returns the class logits."""
+    def forward_backend(self, x: Tensor) -> Tensor:
+        """Returns the class logits."""
         features = self.backbone.forward_pool(self.backbone.forward_features(x))
         x = features["pooled_features"]  # (B, C, H, W)
         x = self.class_head(x.flatten(start_dim=1))  # (B, num_classes)

--- a/src/lightly_train/_task_models/image_classification/train_model.py
+++ b/src/lightly_train/_task_models/image_classification/train_model.py
@@ -175,7 +175,7 @@ class ImageClassificationTrain(TrainModel):
         return self.model
 
     def forward(self, images: Tensor) -> Tensor:
-        return self.model.forward_train(images)
+        return self.model.forward_backend(images)
 
     def training_step(
         self, fabric: Fabric, batch: ImageClassificationBatch, step: int

--- a/tests/_task_models/image_classification/test_task_model.py
+++ b/tests/_task_models/image_classification/test_task_model.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import torch
 from lightning_utilities.core.imports import RequirementCache
+from pytest_mock import MockerFixture
 
 from lightly_train._task_models.image_classification.task_model import (
     ImageClassification,
@@ -28,6 +30,40 @@ def model() -> ImageClassification:
         backbone_freeze=False,
         load_weights=False,
     )
+
+
+def test_predict_batch__composes_stages_in_order(
+    model: ImageClassification, mocker: MockerFixture
+) -> None:
+    preprocess_image_spy = mocker.spy(model, "preprocess_image")
+    preprocess_batch_spy = mocker.spy(model, "preprocess_batch")
+    forward_backend_spy = mocker.spy(model, "forward_backend")
+    postprocess_spy = mocker.spy(model, "postprocess")
+
+    images = [torch.rand(3, 24, 32), torch.rand(3, 40, 24)]
+    result = model.predict_batch(images=images)
+
+    # Each input image goes through preprocess_image once.
+    assert preprocess_image_spy.call_count == 2
+
+    # The stacked batch is preprocessed in a single call with shape (B, C, H, W).
+    assert preprocess_batch_spy.call_count == 1
+    (batch_in,) = preprocess_batch_spy.call_args.args
+    assert batch_in.shape == (2, 3, 14, 14)
+
+    # forward_backend receives the output of preprocess_batch.
+    assert forward_backend_spy.call_count == 1
+    (forward_in,) = forward_backend_spy.call_args.args
+    assert forward_in is preprocess_batch_spy.spy_return
+
+    # postprocess receives forward_backend's output and per-image metadata.
+    assert postprocess_spy.call_count == 1
+    raw_in, metadata = postprocess_spy.call_args.args
+    assert raw_in is forward_backend_spy.spy_return
+    assert len(metadata) == 2
+
+    # predict_batch returns whatever postprocess produced.
+    assert result is postprocess_spy.spy_return
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")


### PR DESCRIPTION
## What has changed and why?
- Added `predict_batch()` to `ImageClassification` for running inference on a batch of images in a single forward pass, consistent with the pattern introduced for object detection (#738), instance segmentation (#741), and semantic segmentation (#744).
- Decomposed inference into four reusable stages: `preprocess_image`, `preprocess_batch`, `forward_backend`, `postprocess`, and refactored `predict() `to compose these same stages, eliminating duplicated logic.
- Renamed `forward_train` to `forward_backend`.

## How has it been tested?

- Added `test_predict_batch__composes_stages_in_order` which uses mocker.spy to verify that predict_batch calls each stage exactly once, in the correct order, and passes outputs between stages correctly.
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)
