### PR TITLE
Refactor predict to reuse predict_batch components in object detection

### DIFF
--- a/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_ltdetr_object_detection/task_model.py
@@ -787,36 +787,10 @@ class DINOv2LTDETRObjectDetection(TaskModel):
         self._track_inference()
         if self.training or not self.postprocessor.deploy_mode:
             self.deploy()
-
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        # Normalize the image.
-        if self.image_normalize is not None:
-            x = transforms_functional.normalize(
-                x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-            )
-        x = transforms_functional.resize(x, self.image_size)
-        x = x.unsqueeze(0)
-
-        # Select high-confidence predictions. Noteworthy that the selection approach
-        # flattens the first two dimensions and would not work with batchsize > 1.
-        labels, boxes, scores = self(
-            x, orig_target_size=torch.tensor([[image_h, image_w]], device=device)
-        )
-        keep = scores > threshold
-        labels, boxes, scores = labels[keep], boxes[keep], scores[keep]
-        return {
-            "labels": labels,
-            "bboxes": boxes,
-            "scores": scores,
-        }
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch(x.unsqueeze(0))
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata], threshold=threshold)[0]
 
     @torch.no_grad()
     def predict_sahi(

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -945,35 +945,10 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         self._track_inference()
         if self.training or not self.postprocessor.deploy_mode:
             self.deploy()
-
-        first_param = next(self.parameters())
-        device = first_param.device
-        dtype = first_param.dtype
-
-        # Load image
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-
-        # Normalize the image.
-        if self.image_normalize is not None:
-            x = transforms_functional.normalize(
-                x, mean=self.image_normalize["mean"], std=self.image_normalize["std"]
-            )
-        x = transforms_functional.resize(x, self.image_size)
-        x = x.unsqueeze(0)
-
-        labels, boxes, scores = self(
-            x, orig_target_size=torch.tensor([[image_h, image_w]])
-        )
-        keep = scores > threshold
-        labels, boxes, scores = labels[keep], boxes[keep], scores[keep]
-        return {
-            "labels": labels,
-            "bboxes": boxes,
-            "scores": scores,
-        }
+        x, metadata = self.preprocess_image(image)
+        batch = self.preprocess_batch(x.unsqueeze(0))
+        raw = self.forward_backend(batch)
+        return self.postprocess(raw, [metadata], threshold=threshold)[0]
 
     @torch.no_grad()
     def predict_sahi(


### PR DESCRIPTION
## What has changed and why?

Small follow-up on #738. Refactors predict in `DINOv3LTDETRObjectDetection` and `DINOv2LTDETRObjectDetection` to reuse the same `preprocess_image` -> `preprocess_batch` -> `forward_backend` -> `postprocess` pipeline as `predict_batch`. Same pattern as #741 and #746.


## How has it been tested?
NA

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
