### PR TITLE
Make dinov3 ltdetr object detection ONNX/TensorRT export work with FP16

### DIFF
--- a/src/lightly_train/_export/onnx_helpers.py
+++ b/src/lightly_train/_export/onnx_helpers.py
@@ -9,10 +9,17 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import logging
 from collections.abc import Iterator
 from enum import Enum
+from typing import TYPE_CHECKING, Any
 
 import torch
+
+if TYPE_CHECKING:
+    import onnx
+
+logger = logging.getLogger(__name__)
 
 _PRECALCULATE_FOR_ONNX_EXPORT = contextvars.ContextVar(
     "PRECALCULATE_FOR_ONNX_EXPORT", default=False
@@ -42,6 +49,81 @@ def precalculate_for_onnx_export() -> Iterator[None]:
         yield
     finally:
         _PRECALCULATE_FOR_ONNX_EXPORT.reset(token)
+
+
+def remove_redundant_casts(model: onnx.ModelProto) -> None:
+    """Remove redundant -> Cast16 -> Cast32 -> pairs from an ONNX model in-place."""
+    from onnx import TensorProto
+
+    graph = model.graph
+
+    # Build a map of tensor name -> element type for all tensors in the graph.
+    tensor_types: dict[str, int] = {}
+    for inp in graph.input:
+        if inp.type.HasField("tensor_type"):
+            tensor_types[inp.name] = inp.type.tensor_type.elem_type
+    for init in graph.initializer:
+        tensor_types[init.name] = init.data_type
+    for vi in graph.value_info:
+        if vi.type.HasField("tensor_type"):
+            tensor_types[vi.name] = vi.type.tensor_type.elem_type
+    for node in graph.node:
+        if node.op_type == "Cast":
+            to_attr = next((a for a in node.attribute if a.name == "to"), None)
+            if to_attr:
+                tensor_types[node.output[0]] = to_attr.i
+
+    # Build a map of tensor name -> list of nodes that consume it.
+    input_to_consumers: dict[str, list[Any]] = {}
+    for node in graph.node:
+        for inp in node.input:
+            input_to_consumers.setdefault(inp, []).append(node)
+
+    nodes_to_remove: set[int] = set()
+    rewire: dict[str, str] = {}
+
+    # Find X(fp32) -> Cast16 -> Cast32 -> Y patterns and mark for removal.
+    for node in graph.node:
+        if node.op_type != "Cast":
+            continue
+        to_attr = next((a for a in node.attribute if a.name == "to"), None)
+        if to_attr is None or to_attr.i != TensorProto.FLOAT16:
+            continue
+
+        input_type = tensor_types.get(node.input[0])
+        if input_type != TensorProto.FLOAT:
+            continue
+
+        consumers = input_to_consumers.get(node.output[0], [])
+        for consumer in consumers:
+            if consumer.op_type != "Cast":
+                continue
+            to_attr2 = next((a for a in consumer.attribute if a.name == "to"), None)
+            if to_attr2 is None or to_attr2.i != TensorProto.FLOAT:
+                continue
+
+            # Only remove Cast16 if it has no other consumers.
+            if len(consumers) == 1:
+                nodes_to_remove.add(id(node))
+            # Always remove Cast32 and rewire its output to Cast16's fp32 input.
+            nodes_to_remove.add(id(consumer))
+            rewire[consumer.output[0]] = node.input[0]
+
+    # Apply rewiring: replace all references to removed Cast32 outputs.
+    for node in graph.node:
+        for i, inp in enumerate(node.input):
+            if inp in rewire:
+                node.input[i] = rewire[inp]
+
+    for out in graph.output:
+        if out.name in rewire:
+            out.name = rewire[out.name]
+
+    new_nodes = [n for n in graph.node if id(n) not in nodes_to_remove]
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+
+    logger.info("Removed %d redundant Cast nodes", len(nodes_to_remove))
 
 
 class ONNXPrecision(str, Enum):

--- a/src/lightly_train/_export/onnx_helpers.py
+++ b/src/lightly_train/_export/onnx_helpers.py
@@ -53,6 +53,7 @@ def precalculate_for_onnx_export() -> Iterator[None]:
 
 def remove_redundant_casts(model: onnx.ModelProto) -> None:
     """Remove redundant -> Cast16 -> Cast32 -> pairs from an ONNX model in-place."""
+    import onnx
     from onnx import TensorProto
 
     graph = model.graph
@@ -115,11 +116,15 @@ def remove_redundant_casts(model: onnx.ModelProto) -> None:
             if inp in rewire:
                 node.input[i] = rewire[inp]
 
+    identity_nodes = []
     for out in graph.output:
         if out.name in rewire:
-            out.name = rewire[out.name]
+            identity_nodes.append(
+                onnx.helper.make_node("Identity", [rewire[out.name]], [out.name])
+            )
 
     new_nodes = [n for n in graph.node if id(n) not in nodes_to_remove]
+    new_nodes.extend(identity_nodes)
     del graph.node[:]
     graph.node.extend(new_nodes)
 

--- a/src/lightly_train/_export/onnx_helpers.py
+++ b/src/lightly_train/_export/onnx_helpers.py
@@ -126,6 +126,52 @@ def remove_redundant_casts(model: onnx.ModelProto) -> None:
     logger.info("Removed %d redundant Cast nodes", len(nodes_to_remove))
 
 
+def fix_topological_order(model: onnx.ModelProto) -> None:
+    """Sort graph nodes into topological order in-place."""
+    from collections import deque
+
+    graph = model.graph
+    nodes = list(graph.node)
+    if not nodes:
+        return
+
+    available: set[str] = set()
+    for inp in graph.input:
+        available.add(inp.name)
+    for init in graph.initializer:
+        available.add(init.name)
+
+    output_to_node: dict[str, int] = {}
+    for i, node in enumerate(nodes):
+        for out in node.output:
+            output_to_node[out] = i
+
+    deps: dict[int, set[int]] = {i: set() for i in range(len(nodes))}
+    for i, node in enumerate(nodes):
+        for inp in node.input:
+            if inp and inp not in available and inp in output_to_node:
+                deps[i].add(output_to_node[inp])
+
+    in_degree = {i: len(d) for i, d in deps.items()}
+    dependents: dict[int, list[int]] = {i: [] for i in range(len(nodes))}
+    for i, dep_set in deps.items():
+        for d in dep_set:
+            dependents[d].append(i)
+
+    queue: deque[int] = deque(i for i, d in in_degree.items() if d == 0)
+    sorted_nodes = []
+    while queue:
+        idx = queue.popleft()
+        sorted_nodes.append(nodes[idx])
+        for dep in dependents[idx]:
+            in_degree[dep] -= 1
+            if in_degree[dep] == 0:
+                queue.append(dep)
+
+    del graph.node[:]
+    graph.node.extend(sorted_nodes)
+
+
 class ONNXPrecision(str, Enum):
     F16_TRUE = "16-true"
     F32_TRUE = "32-true"

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -816,7 +816,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
             simplify:
                 If True, run onnxslim to simplify and overwrite the exported model.
             verify:
-                If True, validate the ONNX filef and compare outputs to a float32 CPU
+                If True, validate the ONNX file and compare outputs to a float32 CPU
                 reference forward pass.
             format_args:
                 Optional extra keyword arguments forwarded to `torch.onnx.export`.

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -816,7 +816,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
             simplify:
                 If True, run onnxslim to simplify and overwrite the exported model.
             verify:
-                If True, validate the ONNX file and compare outputs to a float32 CPU
+                If True, validate the ONNX filef and compare outputs to a float32 CPU
                 reference forward pass.
             format_args:
                 Optional extra keyword arguments forwarded to `torch.onnx.export`.

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -24,7 +24,10 @@ from lightly_train._commands import _warnings
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._data import file_helpers
 from lightly_train._export import tensorrt_helpers
-from lightly_train._export.onnx_helpers import remove_redundant_casts
+from lightly_train._export.onnx_helpers import (
+    fix_topological_order,
+    remove_redundant_casts,
+)
 from lightly_train._models import package_helpers
 from lightly_train._models.dinov3.dinov3_convnext import DINOv3VConvNeXtModelWrapper
 from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
@@ -1259,7 +1262,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             #  Cast32 -> MatMul -> Cast16 -> Cast32 -> Softmax -> Cast16. Therefore, we need to remove the middle
             #  Cast16 -> Cast32.
             remove_redundant_casts(model_fp16)
-            onnx.utils.fix_topological_order(model_fp16)
+            fix_topological_order(model_fp16)
             onnx.save(model_fp16, str(out))
 
         if simplify:

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -1278,75 +1278,77 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             import onnx
             import onnxruntime as ort
 
-            if precision == "fp16" and not torch.cuda.is_available():
+            onnx.checker.check_model(out, full_check=True)
+
+            providers = ort.get_available_providers()
+            if precision == "fp16" and "CUDAExecutionProvider" not in providers:
                 logger.warning(
-                    "Skipping ONNX full model check for fp16 model because no "
-                    "GPU is available. Run on a GPU to enable full verification."
+                    "Skipping ONNX runtime verification for fp16 model because "
+                    "CUDAExecutionProvider is not available in onnxruntime. "
+                    "Install onnxruntime-gpu to enable full verification."
                 )
             else:
-                onnx.checker.check_model(out, full_check=True)
-
-            # Always run the reference input in float32 and on cpu for consistency.
-            reference_model = deepcopy(self).cpu().to(torch.float32).eval()
-            reference_model.deploy()
-            reference_outputs = reference_model(
-                dummy_input.cpu().to(torch.float32),
-            )
-
-            # Get outputs from the ONNX model. Load from bytes to avoid
-            # ORT errors about missing external data when weights are inline.
-            with open(out, "rb") as f:
-                session = ort.InferenceSession(f.read())
-            onnx_input = dummy_input.cpu()
-            if precision == "fp16":
-                onnx_input = onnx_input.half()
-            input_feed = {
-                "images": onnx_input.numpy(),
-            }
-            outputs_onnx = session.run(output_names=None, input_feed=input_feed)
-            outputs_onnx = tuple(torch.from_numpy(y) for y in outputs_onnx)
-
-            # Verify that the outputs from both models are close.
-            if len(outputs_onnx) != len(reference_outputs):
-                raise AssertionError(
-                    f"Number of onnx outputs should be {len(reference_outputs)} but is {len(outputs_onnx)}"
+                # Always run the reference input in float32 and on cpu for consistency.
+                reference_model = deepcopy(self).cpu().to(torch.float32).eval()
+                reference_model.deploy()
+                reference_outputs = reference_model(
+                    dummy_input.cpu().to(torch.float32),
                 )
-            for output_onnx, output_model, output_name in zip(
-                outputs_onnx, reference_outputs, output_names
-            ):
 
-                def msg(s: str) -> str:
-                    return f'ONNX validation failed for output "{output_name}": {s}'
+                # Get outputs from the ONNX model. Load from bytes to avoid
+                # ORT errors about missing external data when weights are inline.
+                with open(out, "rb") as f:
+                    session = ort.InferenceSession(f.read())
+                onnx_input = dummy_input.cpu()
+                if precision == "fp16":
+                    onnx_input = onnx_input.half()
+                input_feed = {
+                    "images": onnx_input.numpy(),
+                }
+                outputs_onnx = session.run(output_names=None, input_feed=input_feed)
+                outputs_onnx = tuple(torch.from_numpy(y) for y in outputs_onnx)
 
-                # Due to the presence of top-k operations in the model, the outputs may be
-                # in different order but still valid. To account for this, we sum
-                # over the query dimension before comparing.
-                output_model = output_model.sum(dim=1)
-                if output_onnx.is_floating_point:
-                    # Convert to fp32 to avoid overflow issues when summing in fp16.
-                    output_onnx = output_onnx.float()
-                output_onnx = output_onnx.sum(dim=1)
-
-                if output_model.is_floating_point:
-                    # Absolute and relative tolerances are a bit arbitrary and taken from here:
-                    # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
-                    torch.testing.assert_close(
-                        output_onnx,
-                        output_model,
-                        msg=msg,
-                        equal_nan=True,
-                        check_device=False,
-                        check_dtype=False,
-                        check_layout=False,
-                        atol=5e-3,
-                        rtol=1e-1,
+                # Verify that the outputs from both models are close.
+                if len(outputs_onnx) != len(reference_outputs):
+                    raise AssertionError(
+                        f"Number of onnx outputs should be {len(reference_outputs)} but is {len(outputs_onnx)}"
                     )
-                else:
-                    _torch_testing.assert_most_equal(
-                        output_onnx,
-                        output_model,
-                        msg=msg,
-                    )
+                for output_onnx, output_model, output_name in zip(
+                    outputs_onnx, reference_outputs, output_names
+                ):
+
+                    def msg(s: str) -> str:
+                        return f'ONNX validation failed for output "{output_name}": {s}'
+
+                    # Due to the presence of top-k operations in the model, the outputs may be
+                    # in different order but still valid. To account for this, we sum
+                    # over the query dimension before comparing.
+                    output_model = output_model.sum(dim=1)
+                    if output_onnx.is_floating_point:
+                        # Convert to fp32 to avoid overflow issues when summing in fp16.
+                        output_onnx = output_onnx.float()
+                    output_onnx = output_onnx.sum(dim=1)
+
+                    if output_model.is_floating_point:
+                        # Absolute and relative tolerances are a bit arbitrary and taken from here:
+                        # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
+                        torch.testing.assert_close(
+                            output_onnx,
+                            output_model,
+                            msg=msg,
+                            equal_nan=True,
+                            check_device=False,
+                            check_dtype=False,
+                            check_layout=False,
+                            atol=5e-3,
+                            rtol=1e-1,
+                        )
+                    else:
+                        _torch_testing.assert_most_equal(
+                            output_onnx,
+                            output_model,
+                            msg=msg,
+                        )
 
         logger.info(f"Successfully exported ONNX model to '{out}'")
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -24,6 +24,7 @@ from lightly_train._commands import _warnings
 from lightly_train._configs.config import PydanticConfig
 from lightly_train._data import file_helpers
 from lightly_train._export import tensorrt_helpers
+from lightly_train._export.onnx_helpers import remove_redundant_casts
 from lightly_train._models import package_helpers
 from lightly_train._models.dinov3.dinov3_convnext import DINOv3VConvNeXtModelWrapper
 from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
@@ -1106,7 +1107,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         self,
         out: PathLike,
         *,
-        precision: Literal["auto", "fp32", "fp16"] = "auto",
+        precision: Literal["fp32", "fp16"] = "fp32",
         batch_size: int = 1,
         dynamic_batch_size: bool = True,
         opset_version: int | None = None,
@@ -1131,8 +1132,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             out:
                 Path where the ONNX model will be written.
             precision:
-                Precision for the ONNX model. Either "auto", "fp32", or "fp16". "auto"
-                uses the model's current precision.
+                Precision for the ONNX model. Either "fp32", or "fp16".
             batch_size:
                 Batch size for the ONNX input.
             dynamic_batch_size:
@@ -1160,25 +1160,16 @@ class DINOv3LTDETRObjectDetection(TaskModel):
 
         # Set the model in eval and deploy mode.
         self.eval()
-        self.deploy()
 
-        # Find the first parameter from the model.
-        first_parameter = next(self.parameters())
-
-        # Infer info from first parameter.
-        model_device = first_parameter.device
-        dtype = first_parameter.dtype
-
-        if precision == "fp32":
-            dtype = torch.float32
-        elif precision == "fp16":
-            dtype = torch.float16
-        elif precision != "auto":
+        if precision not in ("fp32", "fp16"):
             raise ValueError(
-                f"Invalid precision '{precision}'. Must be one of 'auto', 'fp32', 'fp16'."
+                f"Invalid precision '{precision}'. Must be one of 'fp32', 'fp16'."
             )
 
-        self.to(dtype)
+        # Always trace in fp32 to avoid dtype mismatches in the decoder's
+        # autocast(enabled=False) blocks. fp16 conversion is applied
+        # post-export via onnxruntime.transformers.
+        self.to(torch.float32)
         self.deploy()
         model_device = next(self.parameters()).device
 
@@ -1220,7 +1211,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             self.image_size[1],
             requires_grad=False,
             device=model_device,
-            dtype=dtype,
+            dtype=torch.float32,
         )
 
         # TODO(Thomas, 12/25): Add warm-up forward if needed.
@@ -1244,10 +1235,35 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             **(format_args or {}),
         )
 
+        if precision == "fp16":
+            # convert_float_to_float16 creates nodes with duplicate names. In order to avoid downstream issues
+            # we require simplify to be True, as this correctly renames nodes.
+            if not simplify:
+                raise ValueError("fp16 precision requires simplify=True.")
+
+            import onnx
+            from onnxruntime.transformers import float16 as ort_float16
+
+            model_onnx = onnx.load(str(out))
+            # If the input to Softmax are too large the output of Softmax will be NaN values. Therefore we run
+            #  the Softmax computation in fp32. The nodes before Softmax are always MatMul.
+            # TODO (simon, 05/26) Ideally we would only block operators were a Matmul directly feeds into a Softmax.
+            op_block_list = list(ort_float16.DEFAULT_OP_BLOCK_LIST) + [
+                "Softmax",
+                "MatMul",
+            ]
+            model_fp16 = ort_float16.convert_float_to_float16(
+                model_onnx, op_block_list=op_block_list
+            )
+            # Using the op blocklist on a graph that looks like Softmax -> MatMul creates a graph that looks like
+            #  Cast32 -> MatMul -> Cast16 -> Cast32 -> Softmax -> Cast16. Therefore, we need to remove the middle
+            #  Cast16 -> Cast32.
+            remove_redundant_casts(model_fp16)
+            onnx.save(model_fp16, str(out))
+
         if simplify:
             import onnxslim  # type: ignore [import-not-found,import-untyped]
 
-            # Simplify.
             onnxslim.slim(
                 str(out),
                 output_model=out,
@@ -1258,7 +1274,13 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             import onnx
             import onnxruntime as ort
 
-            onnx.checker.check_model(out, full_check=True)
+            if precision == "fp16" and not torch.cuda.is_available():
+                logger.warning(
+                    "Skipping ONNX full model check for fp16 model because no "
+                    "GPU is available. Run on a GPU to enable full verification."
+                )
+            else:
+                onnx.checker.check_model(out, full_check=True)
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = deepcopy(self).cpu().to(torch.float32).eval()
@@ -1267,10 +1289,15 @@ class DINOv3LTDETRObjectDetection(TaskModel):
                 dummy_input.cpu().to(torch.float32),
             )
 
-            # Get outputs from the ONNX model.
-            session = ort.InferenceSession(out)
+            # Get outputs from the ONNX model. Load from bytes to avoid
+            # ORT errors about missing external data when weights are inline.
+            with open(out, "rb") as f:
+                session = ort.InferenceSession(f.read())
+            onnx_input = dummy_input.cpu()
+            if precision == "fp16":
+                onnx_input = onnx_input.half()
             input_feed = {
-                "images": dummy_input.cpu().numpy(),
+                "images": onnx_input.numpy(),
             }
             outputs_onnx = session.run(output_names=None, input_feed=input_feed)
             outputs_onnx = tuple(torch.from_numpy(y) for y in outputs_onnx)
@@ -1323,7 +1350,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
         self,
         out: PathLike,
         *,
-        precision: Literal["auto", "fp32", "fp16"] = "auto",
+        precision: Literal["fp32", "fp16"] = "fp32",
         onnx_args: dict[str, Any] | None = None,
         max_batchsize: int = 1,
         opt_batchsize: int = 1,
@@ -1350,7 +1377,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
                 Path where the TensorRT engine will be saved.
             precision:
                 Precision for ONNX export and TensorRT engine building. Either
-                "auto", "fp32", or "fp16". "auto" uses the model's current precision.
+                "fp32" or "fp16".
             onnx_args:
                 Optional arguments to pass to `export_onnx` when exporting
                 the ONNX model prior to building the TensorRT engine. If None,
@@ -1381,9 +1408,8 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             max_batchsize=max_batchsize,
             opt_batchsize=opt_batchsize,
             min_batchsize=min_batchsize,
-            # FP32 attention scores required for FP16 model stability. Otherwise output
-            # contains NaN.
-            fp32_attention_scores=True,
+            # We convert the fp32 attention scores already during ONNX export
+            fp32_attention_scores=False,
             verbose=verbose,
         )
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -1259,6 +1259,7 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             #  Cast32 -> MatMul -> Cast16 -> Cast32 -> Softmax -> Cast16. Therefore, we need to remove the middle
             #  Cast16 -> Cast32.
             remove_redundant_casts(model_fp16)
+            onnx.utils.fix_topological_order(model_fp16)
             onnx.save(model_fp16, str(out))
 
         if simplify:
@@ -1398,6 +1399,9 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             ValueError: If batch size constraints are invalid or H/W are dynamic.
         """
         model_dtype = next(self.parameters()).dtype
+
+        onnx_args = dict(onnx_args) if onnx_args is not None else {}
+        onnx_args.setdefault("precision", precision)
 
         tensorrt_helpers.export_tensorrt(
             export_onnx_fn=self.export_onnx,

--- a/tests/_export/__init__.py
+++ b/tests/_export/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_export/test_onnx_helpers.py
+++ b/tests/_export/test_onnx_helpers.py
@@ -1,0 +1,277 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from lightning_utilities.core.imports import RequirementCache
+
+from lightly_train._export.onnx_helpers import remove_redundant_casts
+
+pytestmark = pytest.mark.skipif(
+    not RequirementCache("onnx"), reason="onnx not installed"
+)
+
+
+def _make_model(graph: Any) -> Any:
+    import onnx
+
+    return onnx.helper.make_model(
+        graph, opset_imports=[onnx.helper.make_opsetid("", 17)]
+    )
+
+
+def test_removes_fp32_fp16_fp32_pair(tmp_path: Path) -> None:
+    """A simple FP32->FP16->FP32 round-trip pair should be removed entirely."""
+    import onnx
+
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X"], ["X_fp16"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    cast_to_fp32 = onnx.helper.make_node(
+        "Cast", ["X_fp16"], ["Y"], name="cast_up", to=onnx.TensorProto.FLOAT
+    )
+    graph = onnx.helper.make_graph(
+        [cast_to_fp16, cast_to_fp32],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 3])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 3])],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    assert len(model.graph.node) == 0
+
+
+def test_preserves_non_cast_nodes(tmp_path: Path) -> None:
+    """Non-cast nodes between other operations should be preserved."""
+    import onnx
+
+    relu = onnx.helper.make_node("Relu", ["X"], ["X_relu"], name="relu")
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X_relu"], ["X_fp16"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    cast_to_fp32 = onnx.helper.make_node(
+        "Cast", ["X_fp16"], ["Y"], name="cast_up", to=onnx.TensorProto.FLOAT
+    )
+    graph = onnx.helper.make_graph(
+        [relu, cast_to_fp16, cast_to_fp32],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 3])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 3])],
+        value_info=[
+            onnx.helper.make_tensor_value_info("X_relu", onnx.TensorProto.FLOAT, [1, 3])
+        ],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    assert len(model.graph.node) == 1
+    assert model.graph.node[0].op_type == "Relu"
+    # Relu output should feed directly to the graph output after rewiring.
+    assert model.graph.output[0].name == "X_relu"
+
+
+def test_keeps_fp16_cast_with_multiple_consumers(tmp_path: Path) -> None:
+    """FP16 cast with multiple consumers: only the back-cast is removed, not the
+    FP16 cast itself, since other consumers still need the FP16 tensor."""
+    import onnx
+
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X"], ["X_fp16"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    cast_to_fp32 = onnx.helper.make_node(
+        "Cast", ["X_fp16"], ["Y"], name="cast_up", to=onnx.TensorProto.FLOAT
+    )
+    relu = onnx.helper.make_node("Relu", ["X_fp16"], ["Z"], name="relu")
+    graph = onnx.helper.make_graph(
+        [cast_to_fp16, cast_to_fp32, relu],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 3])],
+        [
+            onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 3]),
+            onnx.helper.make_tensor_value_info("Z", onnx.TensorProto.FLOAT16, [1, 3]),
+        ],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    op_types = [n.op_type for n in model.graph.node]
+    # The FP16 cast is kept (has 2 consumers), the FP32 back-cast is removed.
+    assert "Relu" in op_types
+    assert op_types.count("Cast") == 1
+    cast_node = [n for n in model.graph.node if n.op_type == "Cast"][0]
+    to_attr = next(a for a in cast_node.attribute if a.name == "to")
+    assert to_attr.i == onnx.TensorProto.FLOAT16
+
+
+def test_skips_fp16_input_cast_pair(tmp_path: Path) -> None:
+    """A Cast(fp16->fp16->fp32) should NOT be removed because the input is
+    already FP16, not FP32."""
+    import onnx
+
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X"], ["X_fp16"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    cast_to_fp32 = onnx.helper.make_node(
+        "Cast", ["X_fp16"], ["Y"], name="cast_up", to=onnx.TensorProto.FLOAT
+    )
+    graph = onnx.helper.make_graph(
+        [cast_to_fp16, cast_to_fp32],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT16, [1, 3])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 3])],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    # Nothing should be removed since input is FP16, not FP32.
+    assert len(model.graph.node) == 2
+
+
+def test_preserves_useful_casts(tmp_path: Path) -> None:
+    """A single FP32->FP16 cast (no back-cast) should be preserved."""
+    import onnx
+
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X"], ["Y"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    graph = onnx.helper.make_graph(
+        [cast_to_fp16],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 3])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT16, [1, 3])],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    assert [n.op_type for n in model.graph.node] == ["Cast"]
+
+
+def test_removes_multiple_pairs(tmp_path: Path) -> None:
+    """Multiple independent FP32->FP16->FP32 pairs should all be removed."""
+    import onnx
+
+    nodes = []
+    for i in range(3):
+        nodes.append(
+            onnx.helper.make_node(
+                "Cast",
+                [f"X{i}"],
+                [f"X{i}_fp16"],
+                name=f"cast_down_{i}",
+                to=onnx.TensorProto.FLOAT16,
+            )
+        )
+        nodes.append(
+            onnx.helper.make_node(
+                "Cast",
+                [f"X{i}_fp16"],
+                [f"Y{i}"],
+                name=f"cast_up_{i}",
+                to=onnx.TensorProto.FLOAT,
+            )
+        )
+
+    graph = onnx.helper.make_graph(
+        nodes,
+        "test",
+        [
+            onnx.helper.make_tensor_value_info(f"X{i}", onnx.TensorProto.FLOAT, [1, 3])
+            for i in range(3)
+        ],
+        [
+            onnx.helper.make_tensor_value_info(f"Y{i}", onnx.TensorProto.FLOAT, [1, 3])
+            for i in range(3)
+        ],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    assert len(model.graph.node) == 0
+
+
+def test_in_place_overwrite(tmp_path: Path) -> None:
+    """Passing the same path for input and output should work (in-place)."""
+    import onnx
+
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X"], ["X_fp16"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    cast_to_fp32 = onnx.helper.make_node(
+        "Cast", ["X_fp16"], ["Y"], name="cast_up", to=onnx.TensorProto.FLOAT
+    )
+    graph = onnx.helper.make_graph(
+        [cast_to_fp16, cast_to_fp32],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 3])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 3])],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+    onnx.save(model, model_path)
+
+    reloaded = onnx.load(model_path)
+    assert len(reloaded.graph.node) == 0
+
+
+def test_rewires_downstream_consumers(tmp_path: Path) -> None:
+    """After removing a cast pair, downstream nodes should reference the
+    original FP32 tensor, not the removed cast's output."""
+    import onnx
+
+    cast_to_fp16 = onnx.helper.make_node(
+        "Cast", ["X"], ["X_fp16"], name="cast_down", to=onnx.TensorProto.FLOAT16
+    )
+    cast_to_fp32 = onnx.helper.make_node(
+        "Cast", ["X_fp16"], ["X_back"], name="cast_up", to=onnx.TensorProto.FLOAT
+    )
+    relu = onnx.helper.make_node("Relu", ["X_back"], ["Y"], name="relu")
+    graph = onnx.helper.make_graph(
+        [cast_to_fp16, cast_to_fp32, relu],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1, 3])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1, 3])],
+        value_info=[
+            onnx.helper.make_tensor_value_info("X_back", onnx.TensorProto.FLOAT, [1, 3])
+        ],
+    )
+    model_path = str(tmp_path / "model.onnx")
+    onnx.save(_make_model(graph), model_path)
+
+    model = onnx.load(model_path)
+    remove_redundant_casts(model)
+
+    assert len(model.graph.node) == 1
+    relu_node = model.graph.node[0]
+    assert relu_node.op_type == "Relu"
+    # Relu should now consume "X" directly, not "X_back".
+    assert relu_node.input[0] == "X"

--- a/tests/_export/test_onnx_helpers.py
+++ b/tests/_export/test_onnx_helpers.py
@@ -53,7 +53,11 @@ def test_removes_fp32_fp16_fp32_pair(tmp_path: Path) -> None:
     model = onnx.load(model_path)
     remove_redundant_casts(model)
 
-    assert len(model.graph.node) == 0
+    # Both Cast nodes removed, but an Identity is inserted to preserve the
+    # graph output name "Y".
+    assert len(model.graph.node) == 1
+    assert model.graph.node[0].op_type == "Identity"
+    assert model.graph.output[0].name == "Y"
 
 
 def test_preserves_non_cast_nodes(tmp_path: Path) -> None:
@@ -82,10 +86,11 @@ def test_preserves_non_cast_nodes(tmp_path: Path) -> None:
     model = onnx.load(model_path)
     remove_redundant_casts(model)
 
-    assert len(model.graph.node) == 1
-    assert model.graph.node[0].op_type == "Relu"
-    # Relu output should feed directly to the graph output after rewiring.
-    assert model.graph.output[0].name == "X_relu"
+    op_types = [n.op_type for n in model.graph.node]
+    assert "Relu" in op_types
+    # An Identity is inserted so that the graph output name "Y" is preserved.
+    assert "Identity" in op_types
+    assert model.graph.output[0].name == "Y"
 
 
 def test_keeps_fp16_cast_with_multiple_consumers(tmp_path: Path) -> None:
@@ -216,7 +221,10 @@ def test_removes_multiple_pairs(tmp_path: Path) -> None:
     model = onnx.load(model_path)
     remove_redundant_casts(model)
 
-    assert len(model.graph.node) == 0
+    # 6 Cast nodes removed, 3 Identity nodes inserted to preserve output names.
+    assert len(model.graph.node) == 3
+    assert all(n.op_type == "Identity" for n in model.graph.node)
+    assert {out.name for out in model.graph.output} == {"Y0", "Y1", "Y2"}
 
 
 def test_in_place_overwrite(tmp_path: Path) -> None:
@@ -243,7 +251,10 @@ def test_in_place_overwrite(tmp_path: Path) -> None:
     onnx.save(model, model_path)
 
     reloaded = onnx.load(model_path)
-    assert len(reloaded.graph.node) == 0
+    # Identity node preserves the output name "Y".
+    assert len(reloaded.graph.node) == 1
+    assert reloaded.graph.node[0].op_type == "Identity"
+    assert reloaded.graph.output[0].name == "Y"
 
 
 def test_rewires_downstream_consumers(tmp_path: Path) -> None:

--- a/tests/_export/test_onnx_helpers.py
+++ b/tests/_export/test_onnx_helpers.py
@@ -13,7 +13,10 @@ from typing import Any
 import pytest
 from lightning_utilities.core.imports import RequirementCache
 
-from lightly_train._export.onnx_helpers import remove_redundant_casts
+from lightly_train._export.onnx_helpers import (
+    fix_topological_order,
+    remove_redundant_casts,
+)
 
 pytestmark = pytest.mark.skipif(
     not RequirementCache("onnx"), reason="onnx not installed"
@@ -275,3 +278,130 @@ def test_rewires_downstream_consumers(tmp_path: Path) -> None:
     assert relu_node.op_type == "Relu"
     # Relu should now consume "X" directly, not "X_back".
     assert relu_node.input[0] == "X"
+
+
+# --- fix_topological_order tests ---
+
+
+def _node_names(model: Any) -> list[str]:
+    return [n.name for n in model.graph.node]
+
+
+def test_fix_topological_order_already_sorted() -> None:
+    """Nodes already in topological order should remain unchanged."""
+    import onnx
+
+    relu = onnx.helper.make_node("Relu", ["X"], ["A"], name="relu")
+    sigmoid = onnx.helper.make_node("Sigmoid", ["A"], ["Y"], name="sigmoid")
+    graph = onnx.helper.make_graph(
+        [relu, sigmoid],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = _make_model(graph)
+    fix_topological_order(model)
+    assert _node_names(model) == ["relu", "sigmoid"]
+
+
+def test_fix_topological_order_reversed() -> None:
+    """Nodes in reverse order should be sorted so producers come first."""
+    import onnx
+
+    sigmoid = onnx.helper.make_node("Sigmoid", ["A"], ["Y"], name="sigmoid")
+    relu = onnx.helper.make_node("Relu", ["X"], ["A"], name="relu")
+    graph = onnx.helper.make_graph(
+        [sigmoid, relu],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = _make_model(graph)
+    fix_topological_order(model)
+    assert _node_names(model) == ["relu", "sigmoid"]
+
+
+def test_fix_topological_order_diamond() -> None:
+    """Diamond dependency: A -> {B, C} -> D. All valid orderings place A first
+    and D last."""
+    import onnx
+
+    a = onnx.helper.make_node("Relu", ["X"], ["A"], name="a")
+    b = onnx.helper.make_node("Relu", ["A"], ["B"], name="b")
+    c = onnx.helper.make_node("Sigmoid", ["A"], ["C"], name="c")
+    d = onnx.helper.make_node("Add", ["B", "C"], ["Y"], name="d")
+    graph = onnx.helper.make_graph(
+        [d, c, b, a],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = _make_model(graph)
+    fix_topological_order(model)
+    names = _node_names(model)
+    assert names[0] == "a"
+    assert names[-1] == "d"
+    assert set(names[1:3]) == {"b", "c"}
+
+
+def test_fix_topological_order_independent_chains() -> None:
+    """Two independent chains should both appear in valid order."""
+    import onnx
+
+    r1 = onnx.helper.make_node("Relu", ["X1"], ["A1"], name="r1")
+    s1 = onnx.helper.make_node("Sigmoid", ["A1"], ["Y1"], name="s1")
+    r2 = onnx.helper.make_node("Relu", ["X2"], ["A2"], name="r2")
+    s2 = onnx.helper.make_node("Sigmoid", ["A2"], ["Y2"], name="s2")
+    graph = onnx.helper.make_graph(
+        [s2, s1, r2, r1],
+        "test",
+        [
+            onnx.helper.make_tensor_value_info("X1", onnx.TensorProto.FLOAT, [1]),
+            onnx.helper.make_tensor_value_info("X2", onnx.TensorProto.FLOAT, [1]),
+        ],
+        [
+            onnx.helper.make_tensor_value_info("Y1", onnx.TensorProto.FLOAT, [1]),
+            onnx.helper.make_tensor_value_info("Y2", onnx.TensorProto.FLOAT, [1]),
+        ],
+    )
+    model = _make_model(graph)
+    fix_topological_order(model)
+    names = _node_names(model)
+    assert names.index("r1") < names.index("s1")
+    assert names.index("r2") < names.index("s2")
+
+
+def test_fix_topological_order_empty_graph() -> None:
+    """An empty graph should not raise."""
+    import onnx
+
+    graph = onnx.helper.make_graph(
+        [],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = _make_model(graph)
+    fix_topological_order(model)
+    assert len(model.graph.node) == 0
+
+
+def test_fix_topological_order_uses_initializers() -> None:
+    """Nodes consuming initializers (not graph inputs) should be treated as
+    having no graph-node dependencies."""
+    import numpy as np
+    import onnx
+
+    add = onnx.helper.make_node("Add", ["X", "bias"], ["A"], name="add")
+    relu = onnx.helper.make_node("Relu", ["A"], ["Y"], name="relu")
+    bias = onnx.numpy_helper.from_array(np.zeros(1, dtype=np.float32), name="bias")
+    graph = onnx.helper.make_graph(
+        [relu, add],
+        "test",
+        [onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [1])],
+        initializer=[bias],
+    )
+    model = _make_model(graph)
+    fix_topological_order(model)
+    assert _node_names(model) == ["add", "relu"]

--- a/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/dinov3_ltdetr_object_detection/test_task_model.py
@@ -498,3 +498,34 @@ def test_export_onnx__static_batch_size(tmp_path: Path) -> None:
     model.export_onnx(
         out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
     )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU.")
+@pytest.mark.parametrize("decoder_name", ["rtdetrv2", "dfine"])
+def test_export_onnx__fp16(
+    tmp_path: Path, decoder_name: Literal["rtdetrv2", "dfine"]
+) -> None:
+    import onnx
+
+    model = DINOv3LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "car", 1: "person"},
+        image_size=(256, 256),
+        decoder_name=decoder_name,
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, precision="fp16", simplify=True, verify=True)
+
+    model_onnx = onnx.load(str(out))
+    # Verify the model has fp16 tensors.
+    has_fp16 = any(
+        init.data_type == onnx.TensorProto.FLOAT16
+        for init in model_onnx.graph.initializer
+    )
+    assert has_fp16


### PR DESCRIPTION
## What has changed and why?

This PR fixes two issues with FP16 export to ONNX and TensorRT.

* The export did not work when converting the model with `model.half()`. Instead we always export the model in `fp32` precision and then manually convert the model to `fp16`.
* Converting the model to `fp16` creates overflow/NaN issues around Softmax. We avoid this by carefully using casts to FP32 around these nodes. This previously already worked for TensorRT export, but not for ONNX export.

In addtion
* Removed "auto" as an option for the precision as it was not clear what exactly would happen in that case.
* Exporting to FP16 now requires `simplify=True` - this is, because the simplifier also solves an issue where some two nodes would have the same name in the ONNX Graph.

## How has it been tested?

Added some tests - especially for the removal of unncessary cast nodes. In addition tested on Google Colab and ensured that the FP16 models would correctly run without NaN values. 

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
