### PR TITLE
Replace torch.tile with torch.cat for better ONNX export

### DIFF
--- a/src/lightly_train/_models/dinov3/dinov3_src/layers/rope_position_encoding.py
+++ b/src/lightly_train/_models/dinov3/dinov3_src/layers/rope_position_encoding.py
@@ -110,7 +110,7 @@ class RopePositionEmbedding(nn.Module):
             2 * math.pi * coords[:, :, None] / self.periods[None, None, :]
         )  # [HW, 2, D//4]
         angles = angles.flatten(1, 2)  # [HW, D//2]
-        angles = angles.tile(2)  # [HW, D]
+        angles = torch.cat((angles, angles), dim=-1)  # [HW, D]
         cos = torch.cos(angles)  # [HW, D]
         sin = torch.sin(angles)  # [HW, D]
 


### PR DESCRIPTION
## What has changed and why?

While debugging the object detection model TensorRT inaccuracies I found one inaccuracy already in the backbone. The reason is:

1. PyTorch with torchscript is not able to correctly infer that the dimensions in the RoPE layer are static. Dynamo might have helped here.
2. As a result, torch.tile results in an [If node](https://onnx.ai/onnx/operators/onnx__If.html) in the exported ONNX model.
3. When running the model with TensorRT, we get different outputs that are amplified by using `cos` and `sin` afterwards. While TensorRT supports If nodes, there are apparently still some [limitations](https://docs.nvidia.com/deeplearning/tensorrt/latest/inference-library/work-with-conditionals.html#limitations).

As a side effect, the exported ONNX model with this patch seems to have far fewer nodes.

This is not a complete fix for the inaccuracies with TensorRT yet, as we also have unrelated issues in the decoder.

 
## How has it been tested?

I checked manually that the exported ONNX file does not contain If-nodes. Furthermore the inaccuracies in the TensorRT model after the RoPE layer seem to have disappeared.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
