### PR TITLE
Fix overflow in LT-DETR ViT-S TensorRT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix PicoDet fine-tuning with mismatched `num_classes`.
 - Fix DINOv3 LT-DETR patch size precedence so `model_args.patch_size` overrides the
   backbone default.
+- Fix TensorRT export with LT-DETR ViT-S, which caused overflows due to non-enforcement
+  of "strongly-typed" option in the TensorRT exporter.
 
 ### Security
 

--- a/src/lightly_train/_export/tensorrt_helpers.py
+++ b/src/lightly_train/_export/tensorrt_helpers.py
@@ -34,6 +34,7 @@ def export_tensorrt(
     opt_batchsize: int = 1,
     min_batchsize: int = 1,
     fp32_attention_scores: bool = False,
+    strongly_typed: bool = False,
     verbose: bool = False,
     debug: bool = False,
     update_network_fn: Callable[[trt.INetworkDefinition], None] | None = None,
@@ -78,6 +79,14 @@ def export_tensorrt(
             Minimum supported batch size.
         fp32_attention_scores:
             Force attention score computations to use FP32 precision.
+        strongly_typed:
+            Build the engine as a strongly-typed network. TensorRT then derives all
+            tensor precisions from the ONNX graph itself (including any fp32 Cast nodes
+            the export inserted around attention scores) instead of applying its own
+            FP16 rules. Use this when the ONNX already encodes the desired mixed
+            precision. Mutually exclusive with ``fp32_attention_scores`` (which relies on
+            per-layer precision overrides that a strongly-typed network does not allow),
+            and the ``precision`` / FP16 builder flags become no-ops under it.
         verbose:
             Enable verbose TensorRT logging.
         debug:
@@ -114,8 +123,19 @@ def export_tensorrt(
         trt.Logger.VERBOSE if (verbose or debug) else trt.Logger.INFO
     )
 
+    if strongly_typed and fp32_attention_scores:
+        raise ValueError(
+            "strongly_typed and fp32_attention_scores are mutually exclusive: a "
+            "strongly-typed network derives all precisions from the ONNX graph and does "
+            "not allow the per-layer precision overrides used by fp32_attention_scores. "
+            "If the ONNX export already casts attention scores to FP32, use "
+            "strongly_typed=True alone."
+        )
+
     builder = trt.Builder(trt_logger)
     network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    if strongly_typed:
+        network_flags |= 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     network = builder.create_network(network_flags)
 
     parser = trt.OnnxParser(network, trt_logger)
@@ -172,8 +192,16 @@ def export_tensorrt(
     if hasattr(trt.BuilderFlag, "TF32"):
         config.clear_flag(trt.BuilderFlag.TF32)
 
+    if strongly_typed:
+        # Precision is fully determined by the ONNX graph's tensor dtypes and Cast nodes.
+        # Setting FP16 / precision-constraint builder flags is redundant and rejected for
+        # strongly-typed networks, so we skip them here.
+        logger.info(
+            "Strongly-typed network: precision taken from the ONNX graph "
+            "(FP16/precision-constraint flags not applied)."
+        )
     # Use FP16 if requested and supported.
-    if precision == "fp16" or (model_dtype == torch.float16 and precision == "auto"):
+    elif precision == "fp16" or (model_dtype == torch.float16 and precision == "auto"):
         if builder.platform_has_fast_fp16:
             config.set_flag(trt.BuilderFlag.FP16)
 

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -1501,8 +1501,11 @@ class DINOv3LTDETRObjectDetection(TaskModel):
             max_batchsize=max_batchsize,
             opt_batchsize=opt_batchsize,
             min_batchsize=min_batchsize,
-            # We convert the fp32 attention scores already during ONNX export
+            # We convert the fp32 attention scores already during ONNX export, so we
+            # build a strongly-typed engine: TensorRT then honors those fp32 Cast nodes
+            # instead of forcing the whole attention into FP16 (which overflows to NaN).
             fp32_attention_scores=False,
+            strongly_typed=True,
             verbose=verbose,
         )
 


### PR DESCRIPTION
## What has changed and why?
- ViT-S TensorRT experienced overflows. This was already solved in the ONNX exports, but did not propagate to TensorRT, since we did not use the "strongly-typed" flag.

## How has it been tested?
- benchmark command now generates the correct numbers

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed 
