### PR TITLE
Point Index banner to the Demo Page (Docs)

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,10 +1,10 @@
 # <span style="display:none;">LightlyTrain Documentation</span>
 
 <div style="text-align: center; margin-bottom: 2rem;">
-  <a href="https://www.lightly.ai/lightly-train" target="_blank" class="mobile-only">
+  <a href="https://www.lightly.ai/demo" target="_blank" class="mobile-only">
     <img src="_static/lightlyBannerMobile.svg" alt="LightlyTrain Banner" style="max-width: 100%; height: auto;" />
   </a>
-  <a href="https://www.lightly.ai/lightly-train" target="_blank" class="desktop-only">
+  <a href="https://www.lightly.ai/demo" target="_blank" class="desktop-only">
     <img src="_static/lightlyBanner.svg" alt="LightlyTrain Banner" style="max-width: 100%; height: auto;" />
   </a>
 </div>


### PR DESCRIPTION
## What has changed and why?
The "Talk to us" banner now points to the demo booking page.

## How has it been tested?

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
