### PR TITLE
Add task_model.py for LTDETR Instance Segmentation

### DIFF
--- a/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/__init__.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/task_model.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from typing import Any, Literal
 
 import torch
+import torch.nn.functional as F
 from torch import Tensor
 
 from lightly_train._task_models.dinov3_ltdetr.task_model import (
@@ -65,7 +66,6 @@ class DINOv3LTDETRInstanceSegmentation(_DINOv3LTDETRBase):
         return EdgeCrafterInstanceSegmentationTransformer(  # type: ignore[no-untyped-call]
             **decoder_config,
             eval_spatial_size=self.image_size,
-            mask_spatial_level=0,
         )
 
     def build_postprocessor(
@@ -147,13 +147,25 @@ class DINOv3LTDETRInstanceSegmentation(_DINOv3LTDETRBase):
         labels_batch = self.internal_class_to_class[labels_batch]
 
         out: list[dict[str, Tensor]] = []
-        for i in range(len(metadata)):
+        for i, meta in enumerate(metadata):
             keep = scores_batch[i] > threshold
+            # The deploy postprocessor returns raw mask logits at the mask-head
+            # resolution (image_size // downsample_ratio). Interpolate them back
+            # to the original image size and binarize, matching the
+            # postprocessor's non-deploy branch and the instance-segmentation
+            # `predict` contract (boolean masks of shape (N, orig_h, orig_w)).
+            masks = masks_batch[i][keep]
+            masks = F.interpolate(
+                masks.unsqueeze(1),
+                size=(int(meta["orig_h"]), int(meta["orig_w"])),
+                mode="bilinear",
+                align_corners=False,
+            ).squeeze(1)
             out.append(
                 {
                     "labels": labels_batch[i][keep],
                     "bboxes": boxes_batch[i][keep],
-                    "masks": masks_batch[i][keep],
+                    "masks": masks > 0.0,
                     "scores": scores_batch[i][keep],
                 }
             )

--- a/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/task_model.py
@@ -1,0 +1,160 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+import torch
+from torch import Tensor
+
+from lightly_train._task_models.dinov3_ltdetr.task_model import (
+    _DINOv3LTDETRBase,
+    _DINOv3LTDETRConfig,
+)
+from lightly_train._task_models.instance_segmentation_components.edgecrafter_decoder import (
+    EdgeCrafterInstanceSegmentationTransformer,
+)
+from lightly_train._task_models.instance_segmentation_components.edgecrafter_postprocessor import (
+    EdgeCrafterInstanceSegmentationPostProcessor,
+)
+from lightly_train.types import PathLike
+
+
+class DINOv3LTDETRInstanceSegmentation(_DINOv3LTDETRBase):
+    """DINOv3/EdgeCrafter LTDETR model for instance segmentation."""
+
+    # TODO (Yutong 06/26): remove this after the default decoder is changed to `dfine` for LTDETRv2
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        classes: dict[int, str],
+        image_size: tuple[int, int],
+        patch_size: int | None = None,
+        image_normalize: dict[str, tuple[float, ...]] | None = None,
+        backbone_freeze: bool = False,
+        backbone_weights: PathLike | None = None,
+        backbone_args: dict[str, Any] | None = None,
+        decoder_name: Literal["dfine"] = "dfine",
+        load_weights: bool = True,
+    ) -> None:
+        super().__init__(
+            model_name=model_name,
+            classes=classes,
+            image_size=image_size,
+            patch_size=patch_size,
+            image_normalize=image_normalize,
+            backbone_freeze=backbone_freeze,
+            backbone_weights=backbone_weights,
+            backbone_args=backbone_args,
+            decoder_name=decoder_name,
+            load_weights=load_weights,
+        )
+
+    def build_decoder(
+        self, config: _DINOv3LTDETRConfig
+    ) -> EdgeCrafterInstanceSegmentationTransformer:
+        decoder_config = config.dfine_transformer.model_dump()
+        decoder_config.update({"num_classes": len(self.classes)})
+        return EdgeCrafterInstanceSegmentationTransformer(  # type: ignore[no-untyped-call]
+            **decoder_config,
+            eval_spatial_size=self.image_size,
+            mask_spatial_level=0,
+        )
+
+    def build_postprocessor(
+        self, config: _DINOv3LTDETRConfig
+    ) -> EdgeCrafterInstanceSegmentationPostProcessor:
+        postprocessor_config = config.rtdetr_postprocessor.model_dump()
+        postprocessor_config.update({"num_classes": len(self.classes)})
+        return EdgeCrafterInstanceSegmentationPostProcessor(**postprocessor_config)
+
+    def get_export_output_names(self) -> list[str]:
+        return ["labels", "boxes", "masks", "scores"]
+
+    def forward_backend(self, x: Tensor) -> Any:
+        x = self.backbone(x)
+        x = self.encoder(x)
+
+        return self.decoder(
+            feats=x,
+            spatial_feat=x[0],
+        )
+
+    def forward(
+        self, x: Tensor, orig_target_size: Tensor | None = None
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        if orig_target_size is None:
+            h, w = x.shape[-2:]
+            orig_target_size_ = torch.tensor([[w, h]]).to(x.device)
+        else:
+            orig_target_size_ = orig_target_size[:, [1, 0]].to(
+                device=x.device,
+                dtype=torch.int64,
+            )
+
+        x = self.forward_backend(x)
+
+        result = self.postprocessor(x, orig_target_size_)
+        # Postprocessor must be in deploy mode at this point. It returns only tuples
+        # during deploy mode.
+        assert isinstance(result, tuple) and len(result) == 4
+        labels, boxes, scores, masks = result
+        labels = self.internal_class_to_class[labels]
+        return (labels, boxes, masks, scores)
+
+    def _forward_train(self, x: Tensor, targets):  # type: ignore[no-untyped-def]
+        x = self.backbone(x)
+        x = self.encoder(x)
+        x = self.decoder(
+            feats=x,
+            targets=targets,
+            spatial_feat=x[0],
+        )
+        return x
+
+    def postprocess(  # type: ignore[override]
+        self,
+        raw_outputs: Any | dict[str, Tensor],
+        metadata: Sequence[dict[str, Any]],
+        threshold: float,
+    ) -> list[dict[str, Tensor]]:
+        if not isinstance(raw_outputs, dict):
+            raise ValueError(
+                f"Expected raw_outputs to be a dict, got {type(raw_outputs).__name__}."
+            )
+
+        device = next(self.parameters()).device
+        orig_target_size = torch.tensor(
+            [[m["orig_w"], m["orig_h"]] for m in metadata],
+            dtype=torch.int64,
+            device=device,
+        )
+        postprocessor_out = self.postprocessor(raw_outputs, orig_target_size)
+        if not isinstance(postprocessor_out, tuple) or len(postprocessor_out) != 4:
+            raise ValueError(
+                "Expected deploy postprocessor output to be a 4-tuple "
+                "(labels, boxes, scores, masks)."
+            )
+
+        labels_batch, boxes_batch, scores_batch, masks_batch = postprocessor_out
+        labels_batch = self.internal_class_to_class[labels_batch]
+
+        out: list[dict[str, Tensor]] = []
+        for i in range(len(metadata)):
+            keep = scores_batch[i] > threshold
+            out.append(
+                {
+                    "labels": labels_batch[i][keep],
+                    "bboxes": boxes_batch[i][keep],
+                    "masks": masks_batch[i][keep],
+                    "scores": scores_batch[i][keep],
+                }
+            )
+        return out

--- a/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_instance_segmentation/task_model.py
@@ -82,10 +82,13 @@ class DINOv3LTDETRInstanceSegmentation(_DINOv3LTDETRBase):
         x = self.backbone(x)
         x = self.encoder(x)
 
-        return self.decoder(
-            feats=x,
-            spatial_feat=x[0],
-        )
+        # Don't pass ``spatial_feat`` so the decoder uses its projected feature
+        # ``proj_feats[0]``. For ViT/ECViT presets the decoder's ``input_proj`` is
+        # ``Identity`` (encoder and decoder share ``hidden_dim``), so this matches
+        # EdgeCrafter's ``spatial_feat = x[0]``. For ConvNeXt presets the encoder
+        # emits more channels than the decoder ``hidden_dim``; using the projected
+        # feature gives the mask head the channel count it expects.
+        return self.decoder(feats=x)
 
     def forward(
         self, x: Tensor, orig_target_size: Tensor | None = None
@@ -112,11 +115,9 @@ class DINOv3LTDETRInstanceSegmentation(_DINOv3LTDETRBase):
     def _forward_train(self, x: Tensor, targets):  # type: ignore[no-untyped-def]
         x = self.backbone(x)
         x = self.encoder(x)
-        x = self.decoder(
-            feats=x,
-            targets=targets,
-            spatial_feat=x[0],
-        )
+        # See ``forward_backend``: omit ``spatial_feat`` so the decoder uses its
+        # projected feature ``proj_feats[0]`` (Identity for ViT/ECViT presets).
+        x = self.decoder(feats=x, targets=targets)
         return x
 
     def postprocess(  # type: ignore[override]

--- a/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_ltdetr_object_detection/task_model.py
@@ -69,6 +69,39 @@ class DINOv3LTDETRObjectDetection(_DINOv3LTDETRBase):
         x = self.encoder(x)
         return self.decoder(x)
 
+    def forward(
+        self, x: Tensor, orig_target_size: Tensor | None = None
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        # Function used for ONNX export
+        if orig_target_size is None:
+            h, w = x.shape[-2:]
+            orig_target_size_ = torch.tensor([[w, h]]).to(x.device)
+        else:
+            # Flip from (H, W) to (W, H).
+            orig_target_size = orig_target_size[:, [1, 0]]
+
+            # Move to device.
+            orig_target_size_ = orig_target_size.to(device=x.device, dtype=torch.int64)
+
+        # Forward the image through the model.
+        x = self.forward_backend(x)
+
+        result: list[dict[str, Tensor]] | tuple[Tensor, Tensor, Tensor] = (
+            self.postprocessor(x, orig_target_size_)
+        )
+        # Postprocessor must be in deploy mode at this point. It returns only tuples
+        # during deploy mode.
+        assert isinstance(result, tuple)
+        labels, boxes, scores = result
+        labels = self.internal_class_to_class[labels]
+        return (labels, boxes, scores)
+
+    def _forward_train(self, x: Tensor, targets):  # type: ignore[no-untyped-def]
+        x = self.backbone(x)
+        x = self.encoder(x)
+        x = self.decoder(feats=x, targets=targets)
+        return x
+
     def postprocess(  # type: ignore[override]
         self,
         raw_outputs: Any | dict[str, Tensor],
@@ -224,41 +257,6 @@ class DINOv3LTDETRObjectDetection(_DINOv3LTDETRBase):
             "bboxes": boxes,
             "scores": scores,
         }
-
-    def forward(
-        self, x: Tensor, orig_target_size: Tensor | None = None
-    ) -> tuple[Tensor, Tensor, Tensor]:
-        # Function used for ONNX export
-        if orig_target_size is None:
-            h, w = x.shape[-2:]
-            orig_target_size_ = torch.tensor([[w, h]]).to(x.device)
-        else:
-            # Flip from (H, W) to (W, H).
-            orig_target_size = orig_target_size[:, [1, 0]]
-
-            # Move to device.
-            orig_target_size_ = orig_target_size.to(device=x.device, dtype=torch.int64)
-
-        # Forward the image through the model.
-        x = self.backbone(x)
-        x = self.encoder(x)
-        x = self.decoder(x)
-
-        result: list[dict[str, Tensor]] | tuple[Tensor, Tensor, Tensor] = (
-            self.postprocessor(x, orig_target_size_)
-        )
-        # Postprocessor must be in deploy mode at this point. It returns only tuples
-        # during deploy mode.
-        assert isinstance(result, tuple)
-        labels, boxes, scores = result
-        labels = self.internal_class_to_class[labels]
-        return (labels, boxes, scores)
-
-    def _forward_train(self, x: Tensor, targets):  # type: ignore[no-untyped-def]
-        x = self.backbone(x)
-        x = self.encoder(x)
-        x = self.decoder(feats=x, targets=targets)
-        return x
 
     @torch.no_grad()
     def export_onnx(

--- a/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_decoder.py
+++ b/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_decoder.py
@@ -48,7 +48,6 @@ class EdgeCrafterInstanceSegmentationTransformer(DFINETransformer):
         *args: Any,
         mask_bottleneck_ratio: int | None = 1,
         mask_downsample_ratio: int = 4,
-        mask_spatial_level: int = 0,
         mask_layer_scale_init_value: float = 0.0,
         eval_spatial_size: tuple[int, int],
         **kwargs: Any,
@@ -72,7 +71,6 @@ class EdgeCrafterInstanceSegmentationTransformer(DFINETransformer):
                 "eval_idx < num_layers - 1)."
             )
 
-        self.mask_spatial_level = mask_spatial_level
         self.mask_head = EdgeCrafterInstanceSegmentationHead(
             in_dim=self.hidden_dim,
             # One block per decoder layer. With the unsupported wide-layer config
@@ -94,7 +92,7 @@ class EdgeCrafterInstanceSegmentationTransformer(DFINETransformer):
     ) -> dict[str, Any]:
         proj_feats = self._get_projected_feats(feats)  # type: ignore[no-untyped-call]
         if spatial_feat is None:
-            spatial_feat = proj_feats[self.mask_spatial_level]
+            spatial_feat = proj_feats[0]
 
         memory, spatial_shapes = self._get_encoder_input_from_projected_feats(
             proj_feats


### PR DESCRIPTION
## What has changed and why?

Add `task_model.py` for LTDETR Instance Segmentation. 

Note that we don't include `export_onnx` and `export_tensorrt` for now.

Also
- reordered the methods in LTDETR object detection model
- remove `mask_spatial_level` and use fixed `0` to follow the original EdgeCrafter design

## How has it been tested?

N/A

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
