### PR TITLE
Improve flat cosine error message

### DIFF
--- a/src/lightly_train/_task_models/object_detection_components/flat_cosine.py
+++ b/src/lightly_train/_task_models/object_detection_components/flat_cosine.py
@@ -105,6 +105,7 @@ class FlatCosineLRScheduler(LRScheduler):
                 f"flat_steps={self.flat_steps}, no_aug_steps={self.no_aug_steps}, "
                 f"cosine_start_step={self.cosine_start_step}, "
                 f"cosine_end_step={self.cosine_end_step}."
+                f"HINT: If you are debugging, or you don't need to use flat-cosine scheduling, you can use linear scheduling instead"
             )
 
         self.min_lrs = [


### PR DESCRIPTION
## What has changed and why?

Added a new line to the error in the flat-cosine scheduler. The purpose is to instruct that if you don't need to use flat-cosine, you can use linear instead.

This is motivated because sometimes people just want to debug pipelines and linear is the default one

## How has it been tested?

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
