### PR TITLE
fix: replace broken ltdetrv2-s-coco checkpoint

### DIFF
--- a/src/lightly_train/_task_models/task_model_helpers.py
+++ b/src/lightly_train/_task_models/task_model_helpers.py
@@ -76,12 +76,12 @@ DOWNLOADABLE_MODEL_URL_AND_HASH: dict[str, tuple[str, str]] = {
         "03fe6750392daf3ecd32bbab3f144bd5c4d6cdc8bd75635f9e1c5e296e7dd8b0",
     ),
     "edgecrafter/ecvitt-ltdetr-coco": (
-        "edgecrafter_ecvitt_ltdetr_coco_260522_2f46ce1e.pt",
-        "2f46ce1e12ccb81d24130ff13295e8de66557b09282f4fcf7cfccfc648676264",
+        "edgecrafter_ecvitt_ltdetr_coco_260624_f8aefe49.pt",
+        "f8aefe499be1579c55bfcb288f623399ea5f4efef0c5a5f00960663efeda4f49",
     ),
     "ltdetrv2-s-coco": (
-        "edgecrafter_ecvitt_ltdetr_coco_260522_2f46ce1e.pt",
-        "2f46ce1e12ccb81d24130ff13295e8de66557b09282f4fcf7cfccfc648676264",
+        "edgecrafter_ecvitt_ltdetr_coco_260624_f8aefe49.pt",
+        "f8aefe499be1579c55bfcb288f623399ea5f4efef0c5a5f00960663efeda4f49",
     ),
     "picodet-s-coco": (
         "picodet_s_coco_416_260303_23022a45.pt",


### PR DESCRIPTION
## What changed & why

The hosted `ltdetrv2-s-coco` / `edgecrafter/ecvitt-ltdetr-coco` checkpoint (`2f46ce1e`) was exported from a prototype branch and does not load with the current implementation: wrong `model_name` (`ecvit/ecvitt-ltdetr`), extra init kwargs (`backbone_type`, `ecvit_name`), and backbone state-dict keys nested one level too shallow (`backbone.backbone.*` vs current `backbone._model_wrapper.backbone.*`).

Re-hosted a converted, current-layout checkpoint (`f8aefe49`) and updated both `DOWNLOADABLE_MODEL_URL_AND_HASH` entries.

## How has it been tested?

- `load_model("ltdetrv2-s-coco")` downloads the new file and loads it (`DINOv3LTDETRObjectDetection` + `ECViTBackboneWrapper`).
- Strict `load_train_state_dict` matches all 553 keys (0 missing / 0 unexpected).
- 553/553 tensors byte-identical (`torch.equal`) between converted checkpoint and loaded model — no weight missing, misplaced, or altered.
- Forward returns finite `(labels (1,300), boxes (1,300,4), scores (1,300))`.
- `test_downloadable_model__ltdetrv2_s_coco_alias` passes.

## Did you update CHANGELOG.md?

- [x] Not needed (checkpoint-only fix)

## Did you update the documentation?

- [x] Not needed (internal change without effects for user)