### PR TITLE
Add 0.16.0 LTDETRv2 news entry to index

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -39,7 +39,12 @@ Also check out [LightlyStudio](https://github.com/lightly-ai/lightly-studio) to 
 visualize your annotations and predictions.
 
 ## News
-
+- \[[0.16.0](https://docs.lightly.ai/train/stable/changelog.html#changelog-0-16-0)\] -
+  2026-06-25: ⚡ **Upgraded LTDETRv2 for object detection:** Following the success of
+  LTDETR, LightlyTrain's DETR model, we release LTDETRv2 with significant architectural
+  and performance improvements! It supports using ECViT backbones from
+  [EdgeCrafter](https://arxiv.org/abs/2603.18739) and ONNX/TensorRT export for faster
+  inference!
 - \[[0.15.0](https://docs.lightly.ai/train/stable/changelog.html#changelog-0-15-0)\] -
   2026-04-14: 🔎 **Distillationv3:** Better generalizing distillation method that
   performs equally well across dense and global tasks and across all models, from ViTs

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -39,6 +39,7 @@ Also check out [LightlyStudio](https://github.com/lightly-ai/lightly-studio) to 
 visualize your annotations and predictions.
 
 ## News
+
 - \[[0.16.0](https://docs.lightly.ai/train/stable/changelog.html#changelog-0-16-0)\] -
   2026-06-25: ⚡ **Upgraded LTDETRv2 for object detection:** Following the success of
   LTDETR, LightlyTrain's DETR model, we release LTDETRv2 with significant architectural


### PR DESCRIPTION
## What has changed and why?

Mirror the 0.16.0 news entry from the README into `docs/source/index.md` so the docs News section stays in sync with the README.

## How has it been tested?

Build the docs locally and verified the entry.
<img width="685" height="256" alt="image" src="https://github.com/user-attachments/assets/3ec064c6-a0cc-4585-9a21-8a723b198482" />

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
