### PR TITLE
    Sort files to ensure deterministic runs

### DIFF
--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -132,7 +132,7 @@ def _get_image_filenames(
     )
     for dirpath, _, filenames in os.walk(image_dir, followlinks=True):
         filenames.sort()
-        
+
         # Make paths relative to image_dir. `dirpath` is absolute.
         parent = os.path.relpath(dirpath, start=image_dir)
         parent = "" if parent == "." else parent

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -131,6 +131,8 @@ def _get_image_filenames(
         _supported_image_extensions() if image_extensions is None else image_extensions
     )
     for dirpath, _, filenames in os.walk(image_dir, followlinks=True):
+        filenames.sort()
+        
         # Make paths relative to image_dir. `dirpath` is absolute.
         parent = os.path.relpath(dirpath, start=image_dir)
         parent = "" if parent == "." else parent


### PR DESCRIPTION
## What has changed and why?

The input filenames are now sorted before processing. Previously, the file processing order depended on the order returned by the filesystem, which is not guaranteed to be consistent across platforms or architectures. As a result, the processing sequence could differ even with shuffle=False, leading to different validation results. Sorting the filenames ensures a deterministic processing order across runs and environments.

## How has it been tested?

NA

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
