### PR TITLE
Add Instance Segmentation Transforms

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -1497,14 +1497,14 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
             model_name=config.model,
             val_transform_args=val_transform_args,
         )
-        train_collate_fn = train_dataset.batch_collate_fn_cls(
-            split="train", transform_args=train_transform_args
-        )
-        val_collate_fn = val_dataset.batch_collate_fn_cls(
-            split="val", transform_args=val_transform_args
-        )
         train_dataset.set_transform(train_transform)
         val_dataset.set_transform(val_transform)
+        train_collate_fn = train_dataset.get_batch_collate_fn_cls()(
+            split="train", transform_args=train_transform_args
+        )
+        val_collate_fn = val_dataset.get_batch_collate_fn_cls()(
+            split="val", transform_args=val_transform_args
+        )
         train_dataloader.collate_fn = train_collate_fn  # type: ignore[assignment]
         val_dataloader.collate_fn = val_collate_fn  # type: ignore[assignment]
         helpers.disable_persistent_workers_for_step_aware_transforms(

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -40,6 +40,12 @@ from lightly_train._transforms.eomt_transforms.instance_segmentation import (
     EoMTInstanceSegmentationTransformInput,
     EoMTInstanceSegmentationTransformOutput,
 )
+from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
+    LTDETRInstanceSegmentationTransform,
+    LTDETRInstanceSegmentationTransformArgs,
+    LTDETRInstanceSegmentationTransformInput,
+    LTDETRInstanceSegmentationTransformOutput,
+)
 from lightly_train._transforms.task_transform import TaskCollateFunction, TaskTransform
 from lightly_train.types import (
     BinaryMasksDict,
@@ -154,7 +160,9 @@ class InstanceSegmentationDataset(TaskDataset):
         dataset_args: COCOInstanceSegmentationDatasetArgs
         | YOLOInstanceSegmentationDatasetArgs,
         image_info: Sequence[dict[str, str]],
-        transform: EoMTInstanceSegmentationTransform | None = None,
+        transform: EoMTInstanceSegmentationTransform
+        | LTDETRInstanceSegmentationTransform
+        | None = None,
     ) -> None:
         super().__init__(
             transform=transform, dataset_args=dataset_args, image_info=image_info
@@ -164,12 +172,25 @@ class InstanceSegmentationDataset(TaskDataset):
 
     def set_transform(self, transform: TaskTransform) -> None:
         super().set_transform(transform)
-        assert isinstance(transform, EoMTInstanceSegmentationTransform)
+        assert isinstance(
+            transform,
+            (EoMTInstanceSegmentationTransform, LTDETRInstanceSegmentationTransform),
+        )
         self._init_image_mode(transform)
 
-    def _init_image_mode(self, transform: EoMTInstanceSegmentationTransform) -> None:
+    def _init_image_mode(
+        self,
+        transform: EoMTInstanceSegmentationTransform
+        | LTDETRInstanceSegmentationTransform,
+    ) -> None:
         transform_args = transform.transform_args
-        assert isinstance(transform_args, EoMTInstanceSegmentationTransformArgs)
+        assert isinstance(
+            transform_args,
+            (
+                EoMTInstanceSegmentationTransformArgs,
+                LTDETRInstanceSegmentationTransformArgs,
+            ),
+        )
 
         image_mode = (
             None
@@ -230,7 +251,10 @@ class InstanceSegmentationDataset(TaskDataset):
             np.stack(mask_list) if mask_list else np.zeros((0, h, w), dtype=np.bool_)
         )
 
-        transform_input: EoMTInstanceSegmentationTransformInput = {
+        transform_input: (
+            EoMTInstanceSegmentationTransformInput
+            | LTDETRInstanceSegmentationTransformInput
+        ) = {
             "image": image_np,
             # Shape (n_instances, H, W)
             "binary_masks": binary_masks_np.astype(np.uint8),
@@ -238,9 +262,10 @@ class InstanceSegmentationDataset(TaskDataset):
             "class_labels": class_labels_np,  # Shape (n_instances,)
         }
 
-        transformed: EoMTInstanceSegmentationTransformOutput = self.transform(
-            transform_input
-        )
+        transformed: (
+            EoMTInstanceSegmentationTransformOutput
+            | LTDETRInstanceSegmentationTransformOutput
+        ) = self.transform(transform_input)
 
         image = transformed["image"]
         # Some albumentations versions return lists of tuples instead of arrays.

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -41,6 +41,7 @@ from lightly_train._transforms.eomt_transforms.instance_segmentation import (
     EoMTInstanceSegmentationTransformOutput,
 )
 from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
+    LTDETRInstanceSegmentationCollateFunction,
     LTDETRInstanceSegmentationTransform,
     LTDETRInstanceSegmentationTransformArgs,
     LTDETRInstanceSegmentationTransformInput,
@@ -177,6 +178,11 @@ class InstanceSegmentationDataset(TaskDataset):
             (EoMTInstanceSegmentationTransform, LTDETRInstanceSegmentationTransform),
         )
         self._init_image_mode(transform)
+
+    def get_batch_collate_fn_cls(self) -> type[TaskCollateFunction]:
+        if isinstance(self.transform, LTDETRInstanceSegmentationTransform):
+            return LTDETRInstanceSegmentationCollateFunction
+        return EoMTInstanceSegmentationCollateFunction
 
     def _init_image_mode(
         self,

--- a/src/lightly_train/_data/instance_segmentation_dataset.py
+++ b/src/lightly_train/_data/instance_segmentation_dataset.py
@@ -152,10 +152,6 @@ class InstanceSegmentationDataset(TaskDataset):
         COCOInstanceSegmentationDatasetArgs | YOLOInstanceSegmentationDatasetArgs
     )
 
-    batch_collate_fn_cls: ClassVar[type[TaskCollateFunction]] = (
-        EoMTInstanceSegmentationCollateFunction
-    )
-
     def __init__(
         self,
         dataset_args: COCOInstanceSegmentationDatasetArgs

--- a/src/lightly_train/_data/task_dataset.py
+++ b/src/lightly_train/_data/task_dataset.py
@@ -51,6 +51,9 @@ class TaskDataset(Dataset[TaskDatasetItem]):
     def set_transform(self, transform: TaskTransform) -> None:
         self._transform = transform
 
+    def get_batch_collate_fn_cls(self) -> type[TaskCollateFunction]:
+        return self.batch_collate_fn_cls
+
     def __len__(self) -> int:
         return len(self.image_info)
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -8,19 +8,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
 from albumentations import BboxParams
 from pydantic import Field
 
-from lightly_train._transforms.ltdetr_transforms.base import (
-    LTDETRMosaicArgs,
-    LTDETRRandomFlipArgs,
-    LTDETRRandomIoUCropArgs,
-    LTDETRRandomPhotometricDistortArgs,
-    LTDETRRandomZoomOutArgs,
-    LTDETRResizeArgs,
-)
 from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
     LTDETRInstanceSegmentationTransform,
     LTDETRInstanceSegmentationTransformArgs,
@@ -34,14 +26,104 @@ from lightly_train._transforms.ltdetr_transforms.utils import (
 from lightly_train._transforms.transform import (
     ChannelDropArgs,
     MixUpArgs,
+    MosaicArgs,
     NormalizeArgs,
+    RandomFlipArgs,
+    RandomIoUCropArgs,
+    RandomPhotometricDistortArgs,
     RandomRotate90Args,
     RandomRotationArgs,
+    RandomZoomOutArgs,
     ResizeArgs,
 )
 from lightly_train.types import ImageSizeTuple
 
 logger = logging.getLogger(__name__)
+
+
+class LTDETRInstanceSegmentationRandomPhotometricDistortArgs(
+    RandomPhotometricDistortArgs
+):
+    prob: float = 0.5
+
+    brightness: tuple[float, float] = (0.875, 1.125)
+    contrast: tuple[float, float] = (0.5, 1.5)
+    saturation: tuple[float, float] = (0.5, 1.5)
+    hue: tuple[float, float] = (-0.05, 0.05)
+
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
+    # None means photometric distort is always on.
+    step_stop: int | Literal["auto"] | None = "auto"
+
+
+class LTDETRInstanceSegmentationRandomZoomOutArgs(RandomZoomOutArgs):
+    prob: float = 0.5
+
+    fill: float = 0.0
+    side_range: tuple[float, float] = (1.0, 4.0)
+
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
+    # None means random zoom out is always on.
+    step_stop: int | Literal["auto"] | None = "auto"
+
+
+class LTDETRInstanceSegmentationRandomIoUCropArgs(RandomIoUCropArgs):
+    prob: float = 0.8
+
+    min_scale: float = 0.3
+    max_scale: float = 1.0
+    min_aspect_ratio: float = 0.5
+    max_aspect_ratio: float = 2.0
+    sampler_options: Sequence[float] | None = None
+    crop_trials: int = 40
+    iou_trials: int = 1000
+
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" resolves to epoch total_epochs - no_aug_epoch. For shorter runs,
+    # no_aug_epoch is scaled following a certain rule. See :func:`resolve_ltdetr_step_schedule` for the full algorithm.
+    # None means random IoU crop is always on.
+    step_stop: int | Literal["auto"] | None = "auto"
+
+
+class LTDETRInstanceSegmentationRandomFlipArgs(RandomFlipArgs):
+    horizontal_prob: float = 0.5
+    vertical_prob: float = 0.0
+
+
+class LTDETRInstanceSegmentationMosaicArgs(MosaicArgs):
+    prob: float = 0.5
+
+    output_size: int = 320
+    max_size: int | None = None
+    rotation_range: float = 10.0
+    translation_range: tuple[float, float] = (0.1, 0.1)
+    scaling_range: tuple[float, float] = (0.5, 1.5)
+    fill_value: int | float = 0
+    max_cached_images: int = 50
+    random_pop: bool = True
+
+    # "auto" resolves to epoch 4, or to floor(total_epochs / 3) for runs
+    # with <= 12 epochs.
+    step_start: int | Literal["auto"] = "auto"
+    # "auto" uses a compressed short-run schedule for <= 12 epochs and
+    # transitions to the midpoint rule on longer runs.
+    # None means mosaic is always on.
+    step_stop: int | Literal["auto"] | None = "auto"
+
+
+class LTDETRInstanceSegmentationResizeArgs(ResizeArgs):
+    height: int | Literal["auto"] = "auto"
+    width: int | Literal["auto"] = "auto"
 
 
 def _resolve_normalize_num_channels(
@@ -78,24 +160,28 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
 ):
     channel_drop: ChannelDropArgs | None = None
     num_channels: int | Literal["auto"] = "auto"
-    photometric_distort: LTDETRRandomPhotometricDistortArgs | None = Field(
-        default_factory=LTDETRRandomPhotometricDistortArgs
+    photometric_distort: (
+        LTDETRInstanceSegmentationRandomPhotometricDistortArgs | None
+    ) = Field(default_factory=LTDETRInstanceSegmentationRandomPhotometricDistortArgs)
+    random_zoom_out: LTDETRInstanceSegmentationRandomZoomOutArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationRandomZoomOutArgs
     )
-    random_zoom_out: LTDETRRandomZoomOutArgs | None = Field(
-        default_factory=LTDETRRandomZoomOutArgs
+    random_iou_crop: LTDETRInstanceSegmentationRandomIoUCropArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationRandomIoUCropArgs
     )
-    random_iou_crop: LTDETRRandomIoUCropArgs | None = Field(
-        default_factory=LTDETRRandomIoUCropArgs
-    )
-    random_flip: LTDETRRandomFlipArgs | None = Field(
-        default_factory=LTDETRRandomFlipArgs
+    random_flip: LTDETRInstanceSegmentationRandomFlipArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationRandomFlipArgs
     )
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple | Literal["auto"] = "auto"
-    resize: ResizeArgs | None = Field(default_factory=LTDETRResizeArgs)
+    resize: ResizeArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationResizeArgs
+    )
     scale_jitter: None = None
-    mosaic: LTDETRMosaicArgs | None = Field(default_factory=LTDETRMosaicArgs)
+    mosaic: LTDETRInstanceSegmentationMosaicArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationMosaicArgs
+    )
     mixup: LTDETRInstanceSegmentationMixUpArgs | None = Field(
         default_factory=LTDETRInstanceSegmentationMixUpArgs
     )
@@ -181,7 +267,9 @@ class LTDETRInstanceSegmentationValTransformArgs(
     random_rotate_90: RandomRotate90Args | None = None
     random_rotate: RandomRotationArgs | None = None
     image_size: ImageSizeTuple | Literal["auto"] = "auto"
-    resize: ResizeArgs | None = Field(default_factory=LTDETRResizeArgs)
+    resize: ResizeArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationResizeArgs
+    )
     scale_jitter: None = None
     mosaic: None = None
     mixup: None = None

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -238,6 +238,12 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
 
         if not isinstance(self.num_channels, int):
             raise RuntimeError("Expected num_channels to be resolved.")
+        if self.photometric_distort is not None and self.num_channels != 3:
+            raise RuntimeError(
+                "LT-DETR instance segmentation photometric_distort only supports "
+                f"RGB images but num_channels is {self.num_channels}. Set "
+                "photometric_distort=None for non-RGB inputs."
+            )
         if isinstance(self.normalize, NormalizeArgs):
             _resolve_normalize_num_channels(self.normalize, self.num_channels)
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -238,11 +238,10 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
 
         if not isinstance(self.num_channels, int):
             raise RuntimeError("Expected num_channels to be resolved.")
-        if self.photometric_distort is not None and self.num_channels != 3:
+        if self.num_channels != 3:
             raise RuntimeError(
-                "LT-DETR instance segmentation photometric_distort only supports "
-                f"RGB images but num_channels is {self.num_channels}. Set "
-                "photometric_distort=None for non-RGB inputs."
+                "LT-DETR instance segmentation only supports RGB images but "
+                f"num_channels is {self.num_channels}."
             )
         if isinstance(self.normalize, NormalizeArgs):
             _resolve_normalize_num_channels(self.normalize, self.num_channels)

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -1,0 +1,213 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from albumentations import BboxParams
+from pydantic import Field
+
+from lightly_train._transforms.ltdetr_transforms.base import (
+    LTDETRMosaicArgs,
+    LTDETRRandomFlipArgs,
+    LTDETRRandomIoUCropArgs,
+    LTDETRRandomPhotometricDistortArgs,
+    LTDETRRandomZoomOutArgs,
+    LTDETRResizeArgs,
+)
+from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
+    LTDETRInstanceSegmentationTransform,
+    LTDETRInstanceSegmentationTransformArgs,
+)
+from lightly_train._transforms.ltdetr_transforms.utils import (
+    ALBUMENTATIONS_VERSION_GREATER_EQUAL_1_4_5,
+    ALBUMENTATIONS_VERSION_GREATER_EQUAL_2_0_1,
+    resolve_image_size_for_patch_size,
+    resolve_ltdetr_step_schedule_for_augmentation,
+)
+from lightly_train._transforms.transform import (
+    ChannelDropArgs,
+    MixUpArgs,
+    NormalizeArgs,
+    RandomRotate90Args,
+    RandomRotationArgs,
+    ResizeArgs,
+)
+from lightly_train.types import ImageSizeTuple
+
+
+class LTDETRInstanceSegmentationMixUpArgs(MixUpArgs):
+    prob: float = 0.5
+    step_start: int | Literal["auto"] = "auto"
+    step_stop: int | Literal["auto"] | None = "auto"
+
+
+class LTDETRInstanceSegmentationTrainTransformArgs(
+    LTDETRInstanceSegmentationTransformArgs
+):
+    channel_drop: ChannelDropArgs | None = None
+    num_channels: int | Literal["auto"] = "auto"
+    photometric_distort: LTDETRRandomPhotometricDistortArgs | None = Field(
+        default_factory=LTDETRRandomPhotometricDistortArgs
+    )
+    random_zoom_out: LTDETRRandomZoomOutArgs | None = Field(
+        default_factory=LTDETRRandomZoomOutArgs
+    )
+    random_iou_crop: LTDETRRandomIoUCropArgs | None = Field(
+        default_factory=LTDETRRandomIoUCropArgs
+    )
+    random_flip: LTDETRRandomFlipArgs | None = Field(
+        default_factory=LTDETRRandomFlipArgs
+    )
+    random_rotate_90: RandomRotate90Args | None = None
+    random_rotate: RandomRotationArgs | None = None
+    image_size: ImageSizeTuple | Literal["auto"] = "auto"
+    resize: ResizeArgs | None = Field(default_factory=LTDETRResizeArgs)
+    scale_jitter: None = None
+    mosaic: LTDETRMosaicArgs | None = Field(default_factory=LTDETRMosaicArgs)
+    mixup: LTDETRInstanceSegmentationMixUpArgs | None = Field(
+        default_factory=LTDETRInstanceSegmentationMixUpArgs
+    )
+    copyblend: None = None
+    bbox_params: BboxParams = Field(
+        default_factory=lambda: BboxParams(
+            format="yolo",
+            label_fields=["class_labels", "indices"],
+            min_area=1.0,
+            min_width=0.0,
+            min_height=0.0,
+            **(
+                dict(filter_invalid_bboxes=True)
+                if ALBUMENTATIONS_VERSION_GREATER_EQUAL_2_0_1
+                else {}
+            ),
+            **(dict(clip=True) if ALBUMENTATIONS_VERSION_GREATER_EQUAL_1_4_5 else {}),
+        ),
+    )
+    normalize: NormalizeArgs | Literal["auto"] | None = "auto"
+
+    def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
+        patch_size: int | None = model_init_args.get("patch_size")
+        if self.image_size == "auto":
+            self.image_size = resolve_image_size_for_patch_size(
+                model_init_args,
+                default_image_size=(640, 640),
+                patch_size=patch_size,
+            )
+
+        height, width = self.image_size
+        for field_name in self.__class__.model_fields:
+            field = getattr(self, field_name)
+            if hasattr(field, "resolve_auto"):
+                field.resolve_auto(height=height, width=width)
+
+        if self.normalize == "auto":
+            normalize = model_init_args.get("image_normalize", "none")
+            if normalize is None:
+                self.normalize = None
+            elif normalize == "none":
+                self.normalize = NormalizeArgs()
+            else:
+                assert isinstance(normalize, dict)
+                self.normalize = NormalizeArgs.from_dict(normalize)
+
+        if self.num_channels == "auto":
+            if self.channel_drop is not None:
+                self.num_channels = self.channel_drop.num_channels_keep
+            elif self.normalize is None:
+                self.num_channels = 3
+            else:
+                self.num_channels = len(self.normalize.mean)
+
+    def resolve_step_schedule(
+        self,
+        total_steps: int,
+        train_num_batches: int,
+        gradient_accumulation_steps: int,
+    ) -> None:
+        resolve_ltdetr_step_schedule_for_augmentation(
+            args=self,
+            total_steps=total_steps,
+            train_num_batches=train_num_batches,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+        )
+
+
+class LTDETRInstanceSegmentationValTransformArgs(
+    LTDETRInstanceSegmentationTransformArgs
+):
+    channel_drop: None = None
+    num_channels: int | Literal["auto"] = "auto"
+    photometric_distort: None = None
+    random_zoom_out: None = None
+    random_iou_crop: None = None
+    random_flip: None = None
+    random_rotate_90: RandomRotate90Args | None = None
+    random_rotate: RandomRotationArgs | None = None
+    image_size: ImageSizeTuple | Literal["auto"] = "auto"
+    resize: ResizeArgs | None = Field(default_factory=LTDETRResizeArgs)
+    scale_jitter: None = None
+    mosaic: None = None
+    mixup: None = None
+    copyblend: None = None
+    bbox_params: BboxParams = Field(
+        default_factory=lambda: BboxParams(
+            format="yolo",
+            label_fields=["class_labels", "indices"],
+            min_width=0.0,
+            min_height=0.0,
+            **(
+                dict(filter_invalid_bboxes=True)
+                if ALBUMENTATIONS_VERSION_GREATER_EQUAL_2_0_1
+                else {}
+            ),
+            **(dict(clip=True) if ALBUMENTATIONS_VERSION_GREATER_EQUAL_1_4_5 else {}),
+        ),
+    )
+    normalize: NormalizeArgs | Literal["auto"] | None = "auto"
+
+    def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
+        patch_size: int | None = model_init_args.get("patch_size")
+        if self.image_size == "auto":
+            self.image_size = resolve_image_size_for_patch_size(
+                model_init_args,
+                default_image_size=(640, 640),
+                patch_size=patch_size,
+            )
+
+        height, width = self.image_size
+        for field_name in self.__class__.model_fields:
+            field = getattr(self, field_name)
+            if hasattr(field, "resolve_auto"):
+                field.resolve_auto(height=height, width=width)
+
+        if self.normalize == "auto":
+            normalize = model_init_args.get("image_normalize", "none")
+            if normalize is None:
+                self.normalize = None
+            elif normalize == "none":
+                self.normalize = NormalizeArgs()
+            else:
+                assert isinstance(normalize, dict)
+                self.normalize = NormalizeArgs.from_dict(normalize)
+
+        if self.num_channels == "auto":
+            if self.channel_drop is not None:
+                self.num_channels = self.channel_drop.num_channels_keep
+            elif self.normalize is None:
+                self.num_channels = 3
+            else:
+                self.num_channels = len(self.normalize.mean)
+
+
+class LTDETRInstanceSegmentationTrainTransform(LTDETRInstanceSegmentationTransform):
+    transform_args_cls = LTDETRInstanceSegmentationTrainTransformArgs
+
+
+class LTDETRInstanceSegmentationValTransform(LTDETRInstanceSegmentationTransform):
+    transform_args_cls = LTDETRInstanceSegmentationValTransformArgs

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -7,6 +7,7 @@
 #
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal
 
 from albumentations import BboxParams
@@ -39,6 +40,31 @@ from lightly_train._transforms.transform import (
     ResizeArgs,
 )
 from lightly_train.types import ImageSizeTuple
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_normalize_num_channels(
+    normalize: NormalizeArgs, num_channels: int
+) -> None:
+    if len(normalize.mean) != num_channels:
+        logger.debug(
+            "Adjusting mean of normalize transform to match num_channels. "
+            f"num_channels is {num_channels} but "
+            f"normalize.mean has length {len(normalize.mean)}."
+        )
+        normalize.mean = tuple(
+            normalize.mean[i % len(normalize.mean)] for i in range(num_channels)
+        )
+    if len(normalize.std) != num_channels:
+        logger.debug(
+            "Adjusting std of normalize transform to match num_channels. "
+            f"num_channels is {num_channels} but "
+            f"normalize.std has length {len(normalize.std)}."
+        )
+        normalize.std = tuple(
+            normalize.std[i % len(normalize.std)] for i in range(num_channels)
+        )
 
 
 class LTDETRInstanceSegmentationMixUpArgs(MixUpArgs):
@@ -124,6 +150,11 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
             else:
                 self.num_channels = len(self.normalize.mean)
 
+        if not isinstance(self.num_channels, int):
+            raise RuntimeError("Expected num_channels to be resolved.")
+        if isinstance(self.normalize, NormalizeArgs):
+            _resolve_normalize_num_channels(self.normalize, self.num_channels)
+
     def resolve_step_schedule(
         self,
         total_steps: int,
@@ -203,6 +234,11 @@ class LTDETRInstanceSegmentationValTransformArgs(
                 self.num_channels = 3
             else:
                 self.num_channels = len(self.normalize.mean)
+
+        if not isinstance(self.num_channels, int):
+            raise RuntimeError("Expected num_channels to be resolved.")
+        if isinstance(self.normalize, NormalizeArgs):
+            _resolve_normalize_num_channels(self.normalize, self.num_channels)
 
 
 class LTDETRInstanceSegmentationTrainTransform(LTDETRInstanceSegmentationTransform):

--- a/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
+++ b/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
@@ -11,23 +11,42 @@ from typing import Literal
 
 import numpy as np
 import torch
-from albumentations import Compose
+from albumentations import BboxParams, Compose
 from albumentations.pytorch.transforms import ToTensorV2
+from pydantic import ConfigDict
 from torch import Tensor
 
-from lightly_train._transforms.ltdetr_transforms.base import (
-    LTDETRTransformArgs,
-    _LTDETRCollateFunction,
-    _LTDETRTransform,
+from lightly_train._transforms.ltdetr_transforms.components import (
+    StepActivationTracker,
+    StepScheduledCompose,
 )
 from lightly_train._transforms.ltdetr_transforms.utils import (
     filter_degenerate_yolo_boxes,
 )
 from lightly_train._transforms.task_transform import (
+    TaskCollateFunction,
+    TaskTransform,
+    TaskTransformArgs,
     TaskTransformInput,
     TaskTransformOutput,
 )
+from lightly_train._transforms.transform import (
+    ChannelDropArgs,
+    CopyBlendArgs,
+    MixUpArgs,
+    MosaicArgs,
+    NormalizeArgs,
+    RandomFlipArgs,
+    RandomIoUCropArgs,
+    RandomPhotometricDistortArgs,
+    RandomRotate90Args,
+    RandomRotationArgs,
+    RandomZoomOutArgs,
+    ResizeArgs,
+    ScaleJitterArgs,
+)
 from lightly_train.types import (
+    ImageSizeTuple,
     InstanceSegmentationBatch,
     InstanceSegmentationDatasetItem,
     NDArrayBBoxes,
@@ -51,21 +70,73 @@ class LTDETRInstanceSegmentationTransformOutput(TaskTransformOutput):
     class_labels: NDArrayClasses
 
 
-class LTDETRInstanceSegmentationTransformArgs(LTDETRTransformArgs):
-    pass
+class LTDETRInstanceSegmentationTransformArgs(TaskTransformArgs):
+    """Transform arguments for LT-DETR instance segmentation.
+
+    Task-specific transforms subclass this to set their own field defaults; it is
+    not used directly.
+    """
+
+    channel_drop: ChannelDropArgs | None
+    num_channels: int | Literal["auto"]
+    photometric_distort: RandomPhotometricDistortArgs | None
+    random_zoom_out: RandomZoomOutArgs | None
+    random_iou_crop: RandomIoUCropArgs | None
+    random_flip: RandomFlipArgs | None
+    random_rotate_90: RandomRotate90Args | None
+    random_rotate: RandomRotationArgs | None
+    image_size: ImageSizeTuple | Literal["auto"]
+    mixup: MixUpArgs | None = None
+    copyblend: CopyBlendArgs | None = None
+    mosaic: MosaicArgs | None = None
+    scale_jitter: ScaleJitterArgs | None = None
+    resize: ResizeArgs | None
+    bbox_params: BboxParams | None
+    normalize: NormalizeArgs | Literal["auto"] | None
+
+    # Necessary for BboxParams, which are not serializable by pydantic.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
-    transform_args_cls: type[LTDETRInstanceSegmentationTransformArgs] = (
-        LTDETRInstanceSegmentationTransformArgs
-    )
+class _MaskAwareStepScheduledCompose(StepScheduledCompose):
+    """Step-scheduled compose that also converts images and masks to tensors.
 
-    transform_args: LTDETRInstanceSegmentationTransformArgs
+    Instance segmentation appends ``ToTensorV2`` so albumentations converts the
+    image and the per-instance masks together, keeping them aligned.
+    """
 
     def _build_transform(self, key: tuple[bool, bool, bool]) -> Compose:
         transform = super()._build_transform(key)
         transform.transforms.append(ToTensorV2())
         return transform
+
+
+class LTDETRInstanceSegmentationTransform(TaskTransform):
+    transform_args_cls: type[LTDETRInstanceSegmentationTransformArgs] = (
+        LTDETRInstanceSegmentationTransformArgs
+    )
+
+    def __init__(
+        self,
+        transform_args: LTDETRInstanceSegmentationTransformArgs,
+    ) -> None:
+        super().__init__(transform_args=transform_args)
+        self.transform_args: LTDETRInstanceSegmentationTransformArgs = transform_args
+        # The step-scheduling and Compose-caching machinery is a component the
+        # transform holds, not a base class it inherits from.
+        self._transform_compose = _MaskAwareStepScheduledCompose(transform_args)
+
+    def set_step(self, step: int) -> None:
+        self._transform_compose.set_step(step)
+
+    def uses_step_dependent_worker_state(self) -> bool:
+        return self._transform_compose.uses_step_dependent_worker_state()
+
+    def requires_dataloader_reinitialization(self) -> bool:
+        return self._transform_compose.requires_dataloader_reinitialization()
+
+    def mark_dataloader_as_reinitialized(self) -> None:
+        self._transform_compose.mark_dataloader_as_reinitialized()
 
     def __call__(
         self, input: LTDETRInstanceSegmentationTransformInput
@@ -76,9 +147,16 @@ class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
         binary_masks = input["binary_masks"]
         indices = np.arange(len(bboxes), dtype=np.int64)
 
-        if self._should_apply_mosaic():
-            image, bboxes, class_labels, binary_masks_opt = self.mosaic(  # type: ignore[misc]
-                image, bboxes, class_labels, binary_masks
+        if self._transform_compose.should_apply_mosaic():
+            if image.ndim != 3 or image.shape[2] != 3:
+                raise RuntimeError(
+                    "LT-DETR instance segmentation mosaic only supports RGB images "
+                    "with shape (H, W, 3). Disable mosaic for non-RGB inputs."
+                )
+            image, bboxes, class_labels, binary_masks_opt = (
+                self._transform_compose.mosaic(  # type: ignore[misc]
+                    image, bboxes, class_labels, binary_masks
+                )
             )
             if binary_masks_opt is None:
                 raise RuntimeError("Expected mask-aware mosaic output.")
@@ -93,9 +171,11 @@ class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
             indices = indices_opt
             binary_masks = binary_masks[indices]
             indices = np.arange(len(bboxes), dtype=np.int64)
-            transform = self._get_transform_from_cache(skip_zoomout_ioucrop=True)
+            transform = self._transform_compose.get_transform(skip_zoomout_ioucrop=True)
         else:
-            transform = self._get_transform_from_cache(skip_zoomout_ioucrop=False)
+            transform = self._transform_compose.get_transform(
+                skip_zoomout_ioucrop=False
+            )
 
         if len(binary_masks) == 0:
             transformed = transform(
@@ -162,7 +242,7 @@ class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
         }
 
 
-class LTDETRInstanceSegmentationCollateFunction(_LTDETRCollateFunction):
+class LTDETRInstanceSegmentationCollateFunction(TaskCollateFunction):
     def __init__(
         self,
         split: Literal["train", "val"],
@@ -170,9 +250,21 @@ class LTDETRInstanceSegmentationCollateFunction(_LTDETRCollateFunction):
     ) -> None:
         super().__init__(split, transform_args)
         self.transform_args: LTDETRInstanceSegmentationTransformArgs = transform_args
-        self._step = 0
-        self._current_transform_active_status = (
-            self._get_transform_active_status_at_step(self._step)
+        # Reinit bookkeeping is a shared primitive the collate holds, not inherited.
+        self._activation = StepActivationTracker(
+            self._get_transform_active_status_at_step
+        )
+
+    def _is_mixup_active_at_step(self, step: int) -> bool:
+        if self.transform_args.mixup is None or self.transform_args.mixup.prob <= 0.0:
+            return False
+        return self.transform_args.mixup.is_active(step)
+
+    def _should_apply_mixup(self) -> bool:
+        return (
+            self.transform_args.mixup is not None
+            and self._is_mixup_active_at_step(self._activation.step)
+            and np.random.random() < self.transform_args.mixup.prob
         )
 
     def _get_transform_active_status_at_step(self, step: int) -> tuple[bool]:
@@ -187,6 +279,15 @@ class LTDETRInstanceSegmentationCollateFunction(_LTDETRCollateFunction):
                 or self.transform_args.mixup.step_stop is not None
             )
         )
+
+    def set_step(self, step: int) -> None:
+        self._activation.set_step(step)
+
+    def requires_dataloader_reinitialization(self) -> bool:
+        return self._activation.requires_dataloader_reinitialization()
+
+    def mark_dataloader_as_reinitialized(self) -> None:
+        self._activation.mark_dataloader_as_reinitialized()
 
     def __call__(
         self, batch: list[InstanceSegmentationDatasetItem]

--- a/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
+++ b/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
@@ -97,9 +97,33 @@ class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
         else:
             transform = self._get_transform_from_cache(skip_zoomout_ioucrop=False)
 
+        if len(binary_masks) == 0:
+            transformed = transform(
+                image=image,
+                bboxes=bboxes,
+                class_labels=class_labels,
+                indices=indices,
+            )
+            image_out = transformed["image"]
+            height, width = image_out.shape[-2:]
+            bboxes_out = transformed["bboxes"]
+            class_labels_out = transformed["class_labels"]
+            if isinstance(bboxes_out, list):
+                bboxes_out = np.array(bboxes_out, dtype=np.float64).reshape(-1, 4)
+            elif bboxes_out.size == 0:
+                bboxes_out = bboxes_out.reshape(0, 4)
+            if isinstance(class_labels_out, list):
+                class_labels_out = np.array(class_labels_out)
+            return {
+                "image": image_out,
+                "binary_masks": image_out.new_zeros(0, height, width, dtype=torch.int),
+                "bboxes": bboxes_out,
+                "class_labels": class_labels_out,
+            }
+
         transformed = transform(
             image=image,
-            masks=[] if len(binary_masks) == 0 else binary_masks,
+            masks=binary_masks,
             bboxes=bboxes,
             class_labels=class_labels,
             indices=indices,
@@ -109,7 +133,9 @@ class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
         class_labels_out = transformed["class_labels"]
         indices_out = transformed["indices"]
         if isinstance(bboxes_out, list):
-            bboxes_out = np.array(bboxes_out)
+            bboxes_out = np.array(bboxes_out, dtype=np.float64).reshape(-1, 4)
+        elif bboxes_out.size == 0:
+            bboxes_out = bboxes_out.reshape(0, 4)
         if isinstance(class_labels_out, list):
             class_labels_out = np.array(class_labels_out)
         if isinstance(indices_out, list):

--- a/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
+++ b/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
@@ -174,7 +174,7 @@ class LTDETRInstanceSegmentationTransform(TaskTransform):
             transform = self._transform_compose.get_transform(skip_zoomout_ioucrop=True)
         else:
             transform = self._transform_compose.get_transform(
-                skip_zoomout_ioucrop=False
+                skip_zoomout_ioucrop=len(bboxes) == 0
             )
 
         if len(binary_masks) == 0:

--- a/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
+++ b/src/lightly_train/_transforms/ltdetr_transforms/instance_segmentation.py
@@ -1,0 +1,206 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import torch
+from albumentations import Compose
+from albumentations.pytorch.transforms import ToTensorV2
+from torch import Tensor
+
+from lightly_train._transforms.ltdetr_transforms.base import (
+    LTDETRTransformArgs,
+    _LTDETRCollateFunction,
+    _LTDETRTransform,
+)
+from lightly_train._transforms.ltdetr_transforms.utils import (
+    filter_degenerate_yolo_boxes,
+)
+from lightly_train._transforms.task_transform import (
+    TaskTransformInput,
+    TaskTransformOutput,
+)
+from lightly_train.types import (
+    InstanceSegmentationBatch,
+    InstanceSegmentationDatasetItem,
+    NDArrayBBoxes,
+    NDArrayBinaryMasksInt,
+    NDArrayClasses,
+    NDArrayImage,
+)
+
+
+class LTDETRInstanceSegmentationTransformInput(TaskTransformInput):
+    image: NDArrayImage
+    binary_masks: NDArrayBinaryMasksInt
+    bboxes: NDArrayBBoxes
+    class_labels: NDArrayClasses
+
+
+class LTDETRInstanceSegmentationTransformOutput(TaskTransformOutput):
+    image: Tensor
+    binary_masks: Tensor
+    bboxes: NDArrayBBoxes
+    class_labels: NDArrayClasses
+
+
+class LTDETRInstanceSegmentationTransformArgs(LTDETRTransformArgs):
+    pass
+
+
+class LTDETRInstanceSegmentationTransform(_LTDETRTransform):
+    transform_args_cls: type[LTDETRInstanceSegmentationTransformArgs] = (
+        LTDETRInstanceSegmentationTransformArgs
+    )
+
+    transform_args: LTDETRInstanceSegmentationTransformArgs
+
+    def _build_transform(self, key: tuple[bool, bool, bool]) -> Compose:
+        transform = super()._build_transform(key)
+        transform.transforms.append(ToTensorV2())
+        return transform
+
+    def __call__(
+        self, input: LTDETRInstanceSegmentationTransformInput
+    ) -> LTDETRInstanceSegmentationTransformOutput:
+        image = input["image"]
+        bboxes = input["bboxes"]
+        class_labels = input["class_labels"]
+        binary_masks = input["binary_masks"]
+        indices = np.arange(len(bboxes), dtype=np.int64)
+
+        if self._should_apply_mosaic():
+            image, bboxes, class_labels, binary_masks_opt = self.mosaic(  # type: ignore[misc]
+                image, bboxes, class_labels, binary_masks
+            )
+            if binary_masks_opt is None:
+                raise RuntimeError("Expected mask-aware mosaic output.")
+            binary_masks = binary_masks_opt
+            indices = np.arange(len(bboxes), dtype=np.int64)
+            bboxes, class_labels, indices_opt = filter_degenerate_yolo_boxes(
+                bboxes=bboxes,
+                class_labels=class_labels,
+                indices=indices,
+            )
+            assert indices_opt is not None
+            indices = indices_opt
+            binary_masks = binary_masks[indices]
+            indices = np.arange(len(bboxes), dtype=np.int64)
+            transform = self._get_transform_from_cache(skip_zoomout_ioucrop=True)
+        else:
+            transform = self._get_transform_from_cache(skip_zoomout_ioucrop=False)
+
+        transformed = transform(
+            image=image,
+            masks=[] if len(binary_masks) == 0 else binary_masks,
+            bboxes=bboxes,
+            class_labels=class_labels,
+            indices=indices,
+        )
+
+        bboxes_out = transformed["bboxes"]
+        class_labels_out = transformed["class_labels"]
+        indices_out = transformed["indices"]
+        if isinstance(bboxes_out, list):
+            bboxes_out = np.array(bboxes_out)
+        if isinstance(class_labels_out, list):
+            class_labels_out = np.array(class_labels_out)
+        if isinstance(indices_out, list):
+            indices_out = np.array(indices_out)
+        indices_out = indices_out.astype(np.int64, copy=False)
+
+        image_out = transformed["image"]
+        masks = transformed["masks"]
+        height, width = image_out.shape[-2:]
+        # ``masks`` is never filtered by albumentations, so its length can be
+        # non-zero even when every box was dropped. Guard on the surviving
+        # instances (``indices_out``) instead to avoid ``torch.stack([])``.
+        kept_masks = [masks[int(index)] for index in indices_out]
+        if len(kept_masks) == 0:
+            binary_masks_out = image_out.new_zeros(0, height, width, dtype=torch.int)
+        else:
+            binary_masks_out = torch.stack(kept_masks).to(dtype=torch.int)
+
+        return {
+            "image": image_out,
+            "binary_masks": binary_masks_out,
+            "bboxes": bboxes_out,
+            "class_labels": class_labels_out,
+        }
+
+
+class LTDETRInstanceSegmentationCollateFunction(_LTDETRCollateFunction):
+    def __init__(
+        self,
+        split: Literal["train", "val"],
+        transform_args: LTDETRInstanceSegmentationTransformArgs,
+    ) -> None:
+        super().__init__(split, transform_args)
+        self.transform_args: LTDETRInstanceSegmentationTransformArgs = transform_args
+        self._step = 0
+        self._current_transform_active_status = (
+            self._get_transform_active_status_at_step(self._step)
+        )
+
+    def _get_transform_active_status_at_step(self, step: int) -> tuple[bool]:
+        return (self._is_mixup_active_at_step(step),)
+
+    def uses_step_dependent_worker_state(self) -> bool:
+        return (
+            self.transform_args.mixup is not None
+            and self.transform_args.mixup.prob > 0.0
+            and (
+                self.transform_args.mixup.step_start != 0
+                or self.transform_args.mixup.step_stop is not None
+            )
+        )
+
+    def __call__(
+        self, batch: list[InstanceSegmentationDatasetItem]
+    ) -> InstanceSegmentationBatch:
+        images = [item["image"] for item in batch]
+        bboxes = [item["bboxes"] for item in batch]
+        classes = [item["classes"] for item in batch]
+        masks = [item["binary_masks"]["masks"] for item in batch]
+
+        if self.split == "train":
+            image_batch_train = torch.stack(images)
+            if len(batch) >= 2 and self._should_apply_mixup():
+                beta = torch.empty(1).uniform_(0.45, 0.55).item()
+                shifted_images = image_batch_train.roll(shifts=1, dims=0)
+                image_batch_train = image_batch_train.mul(beta).add(
+                    shifted_images.mul(1.0 - beta)
+                )
+                bboxes = [
+                    torch.cat([current, shifted], dim=0)
+                    for current, shifted in zip(bboxes, bboxes[-1:] + bboxes[:-1])
+                ]
+                classes = [
+                    torch.cat([current, shifted], dim=0)
+                    for current, shifted in zip(classes, classes[-1:] + classes[:-1])
+                ]
+                masks = [
+                    torch.cat([current, shifted], dim=0)
+                    for current, shifted in zip(masks, masks[-1:] + masks[:-1])
+                ]
+            image_batch: Tensor | list[Tensor] = image_batch_train
+        else:
+            image_batch = images
+
+        return {
+            "image_path": [item["image_path"] for item in batch],
+            "image": image_batch,
+            "binary_masks": [
+                {"masks": mask.bool(), "labels": labels}
+                for mask, labels in zip(masks, classes)
+            ],
+            "bboxes": bboxes,
+            "classes": classes,
+        }

--- a/src/lightly_train/_transforms/ltdetr_transforms/utils.py
+++ b/src/lightly_train/_transforms/ltdetr_transforms/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 from albumentations import (
@@ -42,11 +42,6 @@ from lightly_train._transforms.random_photometric_distort import (
 from lightly_train._transforms.random_zoom_out import RandomZoomOut
 from lightly_train._transforms.transform import ActivationPolicyArgs
 from lightly_train.types import NDArrayBBoxes, NDArrayClasses
-
-if TYPE_CHECKING:
-    from lightly_train._transforms.ltdetr_transforms.object_detection import (
-        LTDETRObjectDetectionTransformArgs,
-    )
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +80,7 @@ def resolve_image_size_for_patch_size(
 
 
 def resolve_ltdetr_step_schedule_for_augmentation(
-    args: LTDETRObjectDetectionTransformArgs,
+    args: LTDETRTransformArgs,
     total_steps: int,
     train_num_batches: int,
     gradient_accumulation_steps: int,
@@ -134,13 +129,13 @@ def resolve_ltdetr_step_schedule_for_augmentation(
                 f"step_stop ({step_schedule.step_stop}) <= 0. "
                 "Disabling scale_jitter for this run."
             )
-            args.scale_jitter = None
+            setattr(args, "scale_jitter", None)
         else:
             scale_jitter.step_stop = step_schedule.step_stop
 
 
 def _resolve_aug_fields(
-    args: LTDETRObjectDetectionTransformArgs,
+    args: LTDETRTransformArgs,
     field_names: tuple[str, ...],
     step_start_resolved: int,
     step_stop_resolved: int,

--- a/tests/_transforms/ltdetr_transforms/test_instance_segmentation.py
+++ b/tests/_transforms/ltdetr_transforms/test_instance_segmentation.py
@@ -278,7 +278,7 @@ class TestLTDETRInstanceSegmentationTransform:
 
 
 class TestLTDETRInstanceSegmentationTrainTransformArgs:
-    def test_resolve_auto_rejects_photometric_distort_for_non_rgb(self) -> None:
+    def test_resolve_auto_rejects_non_rgb(self) -> None:
         transform_args = LTDETRInstanceSegmentationTrainTransformArgs(
             channel_drop=ChannelDropArgs(
                 num_channels_keep=2,
@@ -289,7 +289,8 @@ class TestLTDETRInstanceSegmentationTrainTransformArgs:
         with pytest.raises(
             RuntimeError,
             match=(
-                "photometric_distort only supports RGB images but num_channels is 2"
+                "LT-DETR instance segmentation only supports RGB images but "
+                "num_channels is 2"
             ),
         ):
             transform_args.resolve_auto(model_init_args={})

--- a/tests/_transforms/ltdetr_transforms/test_instance_segmentation.py
+++ b/tests/_transforms/ltdetr_transforms/test_instance_segmentation.py
@@ -1,0 +1,394 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+from albumentations import BboxParams
+from numpy.typing import NDArray
+from torch import Tensor
+
+from lightly_train._task_models.ltdetr_instance_segmentation.transforms import (
+    LTDETRInstanceSegmentationMixUpArgs,
+    LTDETRInstanceSegmentationTrainTransformArgs,
+)
+from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
+    LTDETRInstanceSegmentationCollateFunction,
+    LTDETRInstanceSegmentationTransform,
+    LTDETRInstanceSegmentationTransformArgs,
+    LTDETRInstanceSegmentationTransformInput,
+)
+from lightly_train._transforms.transform import (
+    ChannelDropArgs,
+    MosaicArgs,
+    NormalizeArgs,
+    RandomFlipArgs,
+    RandomIoUCropArgs,
+    RandomPhotometricDistortArgs,
+    RandomRotate90Args,
+    RandomRotationArgs,
+    RandomZoomOutArgs,
+    ResizeArgs,
+)
+from lightly_train.types import InstanceSegmentationDatasetItem
+
+# Only the mask-aware behavior that is unique to instance segmentation is tested here.
+# The shared step-scheduling / dataloader-reinitialization machinery lives in the
+# ``_LTDETR*`` base classes and is covered once in ``test_base.py``; the pure helpers in
+# ``ltdetr_transforms.utils`` are covered in ``test_utils.py``.
+
+
+def _get_channel_drop_args() -> ChannelDropArgs:
+    return ChannelDropArgs(
+        num_channels_keep=3,
+        weight_drop=(1.0, 1.0, 0.0, 0.0),
+    )
+
+
+def _get_photometric_distort_args() -> RandomPhotometricDistortArgs:
+    return RandomPhotometricDistortArgs(
+        brightness=(0.8, 1.2),
+        contrast=(0.8, 1.2),
+        saturation=(0.8, 1.2),
+        hue=(-0.1, 0.1),
+        prob=0.5,
+    )
+
+
+def _get_random_zoom_out_args() -> RandomZoomOutArgs:
+    return RandomZoomOutArgs(
+        prob=1.0,
+        fill=0.0,
+        side_range=(1.0, 1.5),
+    )
+
+
+def _get_random_iou_crop_args() -> RandomIoUCropArgs:
+    return RandomIoUCropArgs(
+        min_scale=0.3,
+        max_scale=1.0,
+        min_aspect_ratio=0.5,
+        max_aspect_ratio=2.0,
+        sampler_options=None,
+        crop_trials=40,
+        iou_trials=1000,
+        prob=1.0,
+    )
+
+
+def _get_random_flip_args() -> RandomFlipArgs:
+    return RandomFlipArgs(horizontal_prob=1.0, vertical_prob=1.0)
+
+
+def _get_random_rotate_90_args() -> RandomRotate90Args:
+    return RandomRotate90Args(prob=1.0)
+
+
+def _get_random_rotate_args() -> RandomRotationArgs:
+    return RandomRotationArgs(prob=1.0, degrees=30.0)
+
+
+def _get_resize_args() -> ResizeArgs:
+    return ResizeArgs(height=64, width=64)
+
+
+def _get_normalize_args() -> NormalizeArgs:
+    return NormalizeArgs()
+
+
+def _get_mosaic_args() -> MosaicArgs:
+    return MosaicArgs(
+        prob=1.0,
+        step_start=0,
+        step_stop=100,
+        output_size=32,
+        max_size=None,
+        rotation_range=10.0,
+        translation_range=(0.1, 0.1),
+        scaling_range=(0.5, 1.5),
+        fill_value=0,
+        max_cached_images=50,
+        random_pop=True,
+    )
+
+
+def _get_image_size() -> tuple[int, int]:
+    return (64, 64)
+
+
+def _get_bbox_params() -> BboxParams:
+    # Instance segmentation threads an ``indices`` label field alongside
+    # ``class_labels`` so masks can be re-aligned after the spatial transforms.
+    return BboxParams(
+        format="yolo",
+        label_fields=["class_labels", "indices"],
+        min_area=0,
+        min_visibility=0.0,
+    )
+
+
+def _make_transform_args(
+    **overrides: Any,
+) -> LTDETRInstanceSegmentationTransformArgs:
+    defaults: dict[str, Any] = dict(
+        channel_drop=None,
+        num_channels=3,
+        photometric_distort=None,
+        random_zoom_out=None,
+        random_iou_crop=None,
+        random_flip=None,
+        random_rotate_90=None,
+        random_rotate=None,
+        image_size=_get_image_size(),
+        bbox_params=_get_bbox_params(),
+        resize=_get_resize_args(),
+        normalize=None,
+        mosaic=None,
+    )
+    defaults.update(overrides)
+    return LTDETRInstanceSegmentationTransformArgs(**defaults)
+
+
+def _make_input(
+    *,
+    num_instances: int,
+    height: int = 128,
+    width: int = 128,
+) -> LTDETRInstanceSegmentationTransformInput:
+    image: NDArray[np.uint8] = np.random.randint(
+        0, 256, (height, width, 3), dtype=np.uint8
+    )
+    if num_instances == 0:
+        bboxes = np.zeros((0, 4), dtype=np.float64)
+        class_labels = np.zeros((0,), dtype=np.int64)
+        binary_masks = np.zeros((0, height, width), dtype=np.uint8)
+    else:
+        # YOLO normalized format: (cx, cy, w, h) in [0, 1].
+        bboxes = np.array([[0.3, 0.3, 0.2, 0.2]] * num_instances, dtype=np.float64)
+        class_labels = np.arange(1, num_instances + 1, dtype=np.int64)
+        binary_masks = np.zeros((num_instances, height, width), dtype=np.uint8)
+        # Give each instance a distinct non-empty mask region.
+        for i in range(num_instances):
+            binary_masks[i, 10 : 30 + i, 10 : 30 + i] = 1
+    return {
+        "image": image,
+        "binary_masks": binary_masks,
+        "bboxes": bboxes,
+        "class_labels": class_labels,
+    }
+
+
+class TestLTDETRInstanceSegmentationTransform:
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {},
+            {"random_flip": _get_random_flip_args()},
+            {"random_iou_crop": _get_random_iou_crop_args()},
+            {"random_zoom_out": _get_random_zoom_out_args()},
+            {"random_rotate_90": _get_random_rotate_90_args()},
+            {"random_rotate": _get_random_rotate_args()},
+            {"photometric_distort": _get_photometric_distort_args()},
+            {"channel_drop": _get_channel_drop_args()},
+            {"normalize": _get_normalize_args()},
+            {"mosaic": _get_mosaic_args()},
+            {
+                "random_flip": _get_random_flip_args(),
+                "random_iou_crop": _get_random_iou_crop_args(),
+                "random_zoom_out": _get_random_zoom_out_args(),
+                "photometric_distort": _get_photometric_distort_args(),
+                "normalize": _get_normalize_args(),
+            },
+        ],
+    )
+    def test___call__output_contract(self, overrides: dict[str, Any]) -> None:
+        transform_args = _make_transform_args(**overrides)
+        transform_args.resolve_auto(model_init_args={})
+        transform = LTDETRInstanceSegmentationTransform(transform_args)
+
+        tr_input = _make_input(num_instances=2)
+        tr_output = transform(tr_input)
+
+        # Instance segmentation returns tensors for image and masks, but keeps
+        # bboxes/class_labels as numpy arrays.
+        assert isinstance(tr_output["image"], Tensor)
+        assert tr_output["image"].dtype == torch.float32
+        assert isinstance(tr_output["binary_masks"], Tensor)
+        assert tr_output["binary_masks"].dtype == torch.int
+        assert isinstance(tr_output["bboxes"], np.ndarray)
+        assert tr_output["bboxes"].dtype == np.float64
+        assert isinstance(tr_output["class_labels"], np.ndarray)
+        assert tr_output["class_labels"].dtype == np.int64
+
+        # Masks stay aligned with the surviving boxes and match the image size.
+        num_kept = tr_output["bboxes"].shape[0]
+        _, height, width = tr_output["binary_masks"].shape
+        assert tr_output["binary_masks"].shape[0] == num_kept
+        assert tr_output["class_labels"].shape[0] == num_kept
+        assert tr_output["image"].shape[-2:] == (height, width)
+
+    def test_masks_track_bboxes(self) -> None:
+        # A crop can drop or reorder instances; the mask count must always equal the
+        # surviving bbox count so masks stay aligned with their boxes.
+        np.random.seed(0)
+        transform_args = _make_transform_args(
+            random_iou_crop=_get_random_iou_crop_args(),
+            random_flip=_get_random_flip_args(),
+        )
+        transform_args.resolve_auto(model_init_args={})
+        transform = LTDETRInstanceSegmentationTransform(transform_args)
+
+        for _ in range(5):
+            tr_output = transform(_make_input(num_instances=4))
+            assert tr_output["binary_masks"].shape[0] == tr_output["bboxes"].shape[0]
+            assert tr_output["class_labels"].shape[0] == tr_output["bboxes"].shape[0]
+
+    def test_empty_masks(self) -> None:
+        transform_args = _make_transform_args()
+        transform_args.resolve_auto(model_init_args={})
+        transform = LTDETRInstanceSegmentationTransform(transform_args)
+
+        tr_output = transform(_make_input(num_instances=0))
+
+        assert isinstance(tr_output["binary_masks"], Tensor)
+        assert tr_output["binary_masks"].dtype == torch.int
+        assert tr_output["binary_masks"].shape[0] == 0
+        # The empty masks tensor still carries the resized spatial dimensions.
+        assert tr_output["binary_masks"].shape[-2:] == tr_output["image"].shape[-2:]
+
+    def test_mosaic_mask_aware(self) -> None:
+        np.random.seed(0)
+        transform_args = _make_transform_args(mosaic=_get_mosaic_args())
+        transform_args.resolve_auto(model_init_args={})
+        transform = LTDETRInstanceSegmentationTransform(transform_args)
+
+        tr_output = transform(_make_input(num_instances=3))
+
+        assert isinstance(tr_output["image"], Tensor)
+        assert tr_output["binary_masks"].shape[0] == tr_output["bboxes"].shape[0]
+
+
+def _make_dataset_item(
+    *,
+    image_path: str,
+    num_instances: int,
+    channels: int = 3,
+    height: int = 8,
+    width: int = 8,
+) -> InstanceSegmentationDatasetItem:
+    image = torch.rand(channels, height, width)
+    bboxes = torch.tensor(
+        [[0.3, 0.3, 0.2, 0.2]] * num_instances, dtype=torch.float32
+    ).reshape(num_instances, 4)
+    classes = torch.arange(1, num_instances + 1, dtype=torch.int64)
+    masks = torch.zeros(num_instances, height, width, dtype=torch.int)
+    for i in range(num_instances):
+        masks[i, 0, 0] = 1
+    return {
+        "image_path": image_path,
+        "image": image,
+        "binary_masks": {"masks": masks, "labels": classes},
+        "bboxes": bboxes,
+        "classes": classes,
+    }
+
+
+class TestLTDETRInstanceSegmentationCollateFunction:
+    def test__call__train(self) -> None:
+        # mixup disabled so the batch structure is asserted without mixing.
+        transform_args = LTDETRInstanceSegmentationTrainTransformArgs(mixup=None)
+        transform_args.resolve_auto(model_init_args={})
+        collate_fn = LTDETRInstanceSegmentationCollateFunction(
+            split="train", transform_args=transform_args
+        )
+
+        batch = [
+            _make_dataset_item(image_path="img1.png", num_instances=2),
+            _make_dataset_item(image_path="img2.png", num_instances=3),
+        ]
+        out = collate_fn(batch)
+
+        assert isinstance(out["image"], Tensor)
+        assert out["image"].shape == (2, 3, 8, 8)
+        assert isinstance(out["bboxes"], list)
+        assert isinstance(out["classes"], list)
+        assert isinstance(out["binary_masks"], list)
+        assert [b.shape[0] for b in out["bboxes"]] == [2, 3]
+        assert all(bm["masks"].dtype == torch.bool for bm in out["binary_masks"])
+        assert out["image_path"] == ["img1.png", "img2.png"]
+
+    def test__call__val_split(self) -> None:
+        transform_args = LTDETRInstanceSegmentationTrainTransformArgs(mixup=None)
+        transform_args.resolve_auto(model_init_args={})
+        collate_fn = LTDETRInstanceSegmentationCollateFunction(
+            split="val", transform_args=transform_args
+        )
+
+        batch = [
+            _make_dataset_item(image_path="img1.png", num_instances=2),
+            _make_dataset_item(image_path="img2.png", num_instances=1),
+        ]
+        out = collate_fn(batch)
+
+        # Validation keeps images as a list (no stacking / mixup).
+        assert isinstance(out["image"], list)
+        assert all(isinstance(img, Tensor) for img in out["image"])
+        assert [b.shape[0] for b in out["bboxes"]] == [2, 1]
+
+    def test_mixup_concatenates_instances(self) -> None:
+        transform_args = LTDETRInstanceSegmentationTrainTransformArgs(
+            mixup=LTDETRInstanceSegmentationMixUpArgs(
+                prob=1.0, step_start=0, step_stop=None
+            ),
+        )
+        transform_args.resolve_auto(model_init_args={})
+        collate_fn = LTDETRInstanceSegmentationCollateFunction(
+            split="train", transform_args=transform_args
+        )
+
+        batch = [
+            _make_dataset_item(image_path="img1.png", num_instances=2),
+            _make_dataset_item(image_path="img2.png", num_instances=3),
+        ]
+        out = collate_fn(batch)
+
+        # Each image gains its rolled partner's instances: 2+3 and 3+2.
+        assert [b.shape[0] for b in out["bboxes"]] == [5, 5]
+        assert [c.shape[0] for c in out["classes"]] == [5, 5]
+        assert [bm["masks"].shape[0] for bm in out["binary_masks"]] == [5, 5]
+        assert isinstance(out["image"], Tensor)
+        assert out["image"].shape == (2, 3, 8, 8)
+
+    def test_requires_dataloader_reinitialization(self) -> None:
+        transform_args = LTDETRInstanceSegmentationTrainTransformArgs(
+            mixup=LTDETRInstanceSegmentationMixUpArgs(
+                prob=1.0, step_start=1, step_stop=2
+            ),
+        )
+        transform_args.resolve_auto(model_init_args={})
+        collate_fn = LTDETRInstanceSegmentationCollateFunction(
+            split="train", transform_args=transform_args
+        )
+
+        assert collate_fn.requires_dataloader_reinitialization() is False
+
+        # step 1: mixup activates
+        collate_fn.set_step(1)
+        assert collate_fn.requires_dataloader_reinitialization() is True
+        collate_fn.mark_dataloader_as_reinitialized()
+        assert collate_fn.requires_dataloader_reinitialization() is False
+
+        # step 2: mixup deactivates
+        collate_fn.set_step(2)
+        assert collate_fn.requires_dataloader_reinitialization() is True
+        collate_fn.mark_dataloader_as_reinitialized()
+        assert collate_fn.requires_dataloader_reinitialization() is False

--- a/tests/_transforms/ltdetr_transforms/test_instance_segmentation.py
+++ b/tests/_transforms/ltdetr_transforms/test_instance_segmentation.py
@@ -277,6 +277,24 @@ class TestLTDETRInstanceSegmentationTransform:
         assert tr_output["binary_masks"].shape[0] == tr_output["bboxes"].shape[0]
 
 
+class TestLTDETRInstanceSegmentationTrainTransformArgs:
+    def test_resolve_auto_rejects_photometric_distort_for_non_rgb(self) -> None:
+        transform_args = LTDETRInstanceSegmentationTrainTransformArgs(
+            channel_drop=ChannelDropArgs(
+                num_channels_keep=2,
+                weight_drop=(1.0, 1.0, 0.0, 0.0),
+            ),
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "photometric_distort only supports RGB images but num_channels is 2"
+            ),
+        ):
+            transform_args.resolve_auto(model_init_args={})
+
+
 def _make_dataset_item(
     *,
     image_path: str,


### PR DESCRIPTION
## What has changed and why?

This PR stacks on top of #835.

It adds LT-DETR instance segmentation transform support on top of the object detection transform refactor:

- add instance segmentation dataset mask handling
- add LT-DETR instance segmentation transform wiring
- add a reusable `ltdetr_transforms` instance segmentation transform module
- add focused transform coverage for the new instance segmentation path

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
