### PR TITLE
Refactor Image Processing for Depth Estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `debug_args.nancapture.enabled=True`.
 - Add ONNX and TensorRT export for depth estimation models via the `export_onnx` and
   `export_tensorrt` methods of `DepthAnythingDepthEstimation`.
-- Add a `process_res_method` argument to depth estimation `predict` and `predict_batch`
-  to control how images are resized to the model's processing resolution:
-  `"square_resize"` (the default), `"upper_bound_resize"`, or `"lower_bound_resize"`.
+- Add a `process_res_method` argument to depth estimation `predict`/`predict_batch`:
+  `"square_resize"` (default), `"upper_bound_resize"`, or `"lower_bound_resize"`.
 
 ### Changed
 
 - Consolidate the separate Depth Anything V2/V3 depth estimation task models into a
   single config-driven `DepthAnythingDepthEstimation` model.
+- Depth estimation `predict`/`predict_batch` now default to `square_resize` (previously
+  aspect-preserving upper/lower-bound per model), changing default depth outputs. Pass
+  `process_res_method="upper_bound_resize"`/`"lower_bound_resize"` to restore the
+  previous geometry.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `debug_args.nancapture.enabled=True`.
 - Add ONNX and TensorRT export for depth estimation models via the `export_onnx` and
   `export_tensorrt` methods of `DepthAnythingDepthEstimation`.
+- Add a `process_res_method` argument to depth estimation `predict` and `predict_batch`
+  to control how images are resized to the model's processing resolution:
+  `"square_resize"` (the default), `"upper_bound_resize"`, or `"lower_bound_resize"`.
 
 ### Changed
 

--- a/docs/source/depth_estimation.md
+++ b/docs/source/depth_estimation.md
@@ -214,10 +214,14 @@ depths = model.predict_batch(
 ```
 
 ```{note}
-Images with different aspect ratios are center-cropped to the smallest processed size in
-the batch before inference, so their depth maps are slightly stretched when resized back
-to the original resolution. For pixel-perfect results on images of different sizes, call
-`predict` on each image individually.
+By default (`process_res_method="square_resize"`) every image is resized to the same
+square processing resolution, so batches of differently sized images are handled without
+any cropping. The aspect-preserving methods (`"upper_bound_resize"` and
+`"lower_bound_resize"`) can yield different processed sizes across a batch; those images
+are then center-cropped to the smallest processed size before inference, so their depth
+maps are slightly stretched when resized back to the original resolution. For
+pixel-perfect results with an aspect-preserving method, call `predict` on each image
+individually.
 ```
 
 (depth-estimation-convert)=

--- a/src/lightly_train/_task_models/depth_estimation/task_model.py
+++ b/src/lightly_train/_task_models/depth_estimation/task_model.py
@@ -30,8 +30,6 @@ from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
 
-# Depth Anything V3 processes images by resizing the longer side to the inference size.
-_PROCESS_RES_METHOD_DAV3 = "upper_bound_resize"
 # Depth Anything V3 metric scaling constant: ``metric_depth = focal * output / 300``.
 _METRIC_SCALE_FACTOR = 300.0
 
@@ -40,7 +38,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-relative-small",
         "backbone_name": "vits14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "relu",
         "use_sky_head": False,
         "align_corners": True,
@@ -58,7 +55,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-relative-base",
         "backbone_name": "vitb14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "relu",
         "use_sky_head": False,
         "align_corners": True,
@@ -76,7 +72,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-relative-large",
         "backbone_name": "vitl14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "relu",
         "use_sky_head": False,
         "align_corners": True,
@@ -98,7 +93,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-metric-small-hypersim",
         "backbone_name": "vits14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "sigmoid",
         "use_sky_head": False,
         "align_corners": True,
@@ -117,7 +111,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-metric-base-hypersim",
         "backbone_name": "vitb14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "sigmoid",
         "use_sky_head": False,
         "align_corners": True,
@@ -136,7 +129,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-metric-large-hypersim",
         "backbone_name": "vitl14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "sigmoid",
         "use_sky_head": False,
         "align_corners": True,
@@ -155,7 +147,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-metric-small-vkitti",
         "backbone_name": "vits14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "sigmoid",
         "use_sky_head": False,
         "align_corners": True,
@@ -174,7 +165,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-metric-base-vkitti",
         "backbone_name": "vitb14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "sigmoid",
         "use_sky_head": False,
         "align_corners": True,
@@ -193,7 +183,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav2-metric-large-vkitti",
         "backbone_name": "vitl14-noreg",
         "image_size": 518,
-        "preprocess": "dav2",
         "activation": "sigmoid",
         "use_sky_head": False,
         "align_corners": True,
@@ -212,7 +201,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav3-relative-large",
         "backbone_name": "vitl14-noreg",
         "image_size": 504,
-        "preprocess": "dav3",
         "activation": "exp",
         "use_sky_head": True,
         "align_corners": False,
@@ -231,7 +219,6 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "canonical_name": "dinov2/dav3-metric-large",
         "backbone_name": "vitl14-noreg",
         "image_size": 504,
-        "preprocess": "dav3",
         "activation": "exp",
         "use_sky_head": True,
         "align_corners": False,
@@ -310,7 +297,6 @@ class DepthAnythingDepthEstimation(TaskModel):
         # size, so it is not a user-facing parameter.
         self.image_size = int(config["image_size"])
 
-        self._preprocess: str = config["preprocess"]
         self._align_corners: bool = bool(config["align_corners"])
         self._scale_mode: str = config["scale_mode"]
 
@@ -381,6 +367,7 @@ class DepthAnythingDepthEstimation(TaskModel):
         self,
         image: PathLike | PILImage | Tensor,
         *,
+        process_res_method: str = "square_resize",
         intrinsics: Tensor | None = None,
     ) -> Tensor:
         """Returns a depth map for the given image.
@@ -390,6 +377,12 @@ class DepthAnythingDepthEstimation(TaskModel):
                 The input image as a path, URL, PIL image, or tensor. Tensors must have
                 shape ``(C, H, W)``; uint8 tensors are interpreted in [0, 255] and
                 float tensors in [0, 1].
+            process_res_method:
+                How the image is resized to the model's fixed processing resolution.
+                One of ``"square_resize"`` (resize to a square of the processing
+                resolution, the default), ``"upper_bound_resize"`` (longest side to the
+                processing resolution) or ``"lower_bound_resize"`` (shortest side to the
+                processing resolution); the latter two preserve the aspect ratio.
             intrinsics:
                 ``(3, 3)`` camera intrinsics matrix of the original image in pixel
                 coordinates. Required for the metric V3 model, which returns metric depth
@@ -408,7 +401,9 @@ class DepthAnythingDepthEstimation(TaskModel):
             self.eval()
 
         self._validate_intrinsics(intrinsics=intrinsics)
-        x, metadata = self.preprocess_image(image)
+        x, metadata = self.preprocess_image(
+            image, process_res_method=process_res_method
+        )
         if intrinsics is not None:
             metadata["focal"] = _processed_focal_length(
                 intrinsics=intrinsics,
@@ -426,6 +421,7 @@ class DepthAnythingDepthEstimation(TaskModel):
         self,
         images: Sequence[PathLike | PILImage | Tensor],
         *,
+        process_res_method: str = "square_resize",
         intrinsics: Sequence[Tensor] | None = None,
     ) -> list[Tensor]:
         """Returns depth maps for the given batch of images.
@@ -435,6 +431,12 @@ class DepthAnythingDepthEstimation(TaskModel):
                 Sequence of input images. Each can be a path, URL, PIL image, or
                 tensor. Tensors must have shape ``(C, H, W)``; uint8 tensors are
                 interpreted in [0, 255] and float tensors in [0, 1].
+            process_res_method:
+                How each image is resized to the model's fixed processing resolution.
+                One of ``"square_resize"`` (the default), ``"upper_bound_resize"`` or
+                ``"lower_bound_resize"``; see ``predict``. With the aspect-preserving
+                methods, images whose processed sizes differ are center-cropped to the
+                smallest size in the batch before inference.
             intrinsics:
                 Sequence of ``(3, 3)`` camera intrinsics matrices, one per image, in
                 original-image pixel coordinates. Required for the metric V3 model and
@@ -460,7 +462,9 @@ class DepthAnythingDepthEstimation(TaskModel):
         tensors: list[Tensor] = []
         metadata: list[dict[str, Any]] = []
         for i, image in enumerate(images):
-            x, meta = self.preprocess_image(image)
+            x, meta = self.preprocess_image(
+                image, process_res_method=process_res_method
+            )
             if intrinsics is not None:
                 meta["focal"] = _processed_focal_length(
                     intrinsics=intrinsics[i],
@@ -476,27 +480,24 @@ class DepthAnythingDepthEstimation(TaskModel):
         return self.postprocess(raw, metadata)
 
     def preprocess_image(
-        self, image: PathLike | PILImage | Tensor
+        self,
+        image: PathLike | PILImage | Tensor,
+        *,
+        process_res_method: str = "square_resize",
     ) -> tuple[Tensor, dict[str, Any]]:
         """Per-image preprocessing producing a model-input tensor and metadata.
 
-        The aspect-preserving resize means outputs across a batch may have different
-        shapes, so they are not always stackable; `preprocess_batch` therefore takes a
-        sequence and unifies the sizes.
+        The ``upper_bound_resize``/``lower_bound_resize`` methods preserve the aspect
+        ratio, so outputs across a batch may have different shapes and are not always
+        stackable; `preprocess_batch` therefore takes a sequence and unifies the sizes.
         """
         x = file_helpers.as_image_tensor(image)
         image_h, image_w = x.shape[-2:]
-        if self._preprocess == "dav3":
-            # Process on the input's native device: the cv2-parity resize rounds after an
-            # einsum whose accumulation order differs between CPU and GPU, so moving to
-            # the model device first could flip pixels and break bit-exactness.
-            x = image_utils.process_image_dav3(
-                x,
-                process_res=self.image_size,
-                process_res_method=_PROCESS_RES_METHOD_DAV3,
-            )
-        else:
-            x = image_utils.process_image_dav2(x, process_res=self.image_size)
+        x = image_utils.process_image(
+            x,
+            process_res=self.image_size,
+            process_res_method=process_res_method,
+        )
         device = next(self.parameters()).device
         return x.to(device=device), {"orig_h": image_h, "orig_w": image_w}
 

--- a/src/lightly_train/_task_models/depth_estimation/task_model.py
+++ b/src/lightly_train/_task_models/depth_estimation/task_model.py
@@ -25,6 +25,9 @@ from lightly_train._models.dinov2_vit.dinov2_vit_package import DINOV2_VIT_PACKA
 from lightly_train._task_models import task_model_helpers
 from lightly_train._task_models.depth_estimation_components import image_utils
 from lightly_train._task_models.depth_estimation_components.dpt import DPT
+from lightly_train._task_models.depth_estimation_components.image_utils import (
+    ResizeMethod,
+)
 from lightly_train._task_models.task_model import TaskModel
 from lightly_train.types import PathLike
 
@@ -367,7 +370,7 @@ class DepthAnythingDepthEstimation(TaskModel):
         self,
         image: PathLike | PILImage | Tensor,
         *,
-        process_res_method: str = "square_resize",
+        process_res_method: ResizeMethod = "square_resize",
         intrinsics: Tensor | None = None,
     ) -> Tensor:
         """Returns a depth map for the given image.
@@ -421,7 +424,7 @@ class DepthAnythingDepthEstimation(TaskModel):
         self,
         images: Sequence[PathLike | PILImage | Tensor],
         *,
-        process_res_method: str = "square_resize",
+        process_res_method: ResizeMethod = "square_resize",
         intrinsics: Sequence[Tensor] | None = None,
     ) -> list[Tensor]:
         """Returns depth maps for the given batch of images.
@@ -483,7 +486,7 @@ class DepthAnythingDepthEstimation(TaskModel):
         self,
         image: PathLike | PILImage | Tensor,
         *,
-        process_res_method: str = "square_resize",
+        process_res_method: ResizeMethod = "square_resize",
     ) -> tuple[Tensor, dict[str, Any]]:
         """Per-image preprocessing producing a model-input tensor and metadata.
 

--- a/src/lightly_train/_task_models/depth_estimation_components/image_utils.py
+++ b/src/lightly_train/_task_models/depth_estimation_components/image_utils.py
@@ -16,14 +16,20 @@
 
 """Image preprocessing for the Depth Anything depth-estimation models.
 
-Split into a per-image stage (one function per model family) and a shared batch stage,
-so the per-image stage can be baked into an export. Output order matches input order.
+Split into a per-image stage (``process_image``) and a shared batch stage
+(``process_batch``), so the per-image stage can be baked into an export. Output order
+matches input order.
 
-Per-image stage, each returning a float RGB tensor in [0, 255] of shape ``(3, H, W)``:
-  - ``process_image_dav3``: boundary resize, then round each side to a multiple of
-    ``PATCH_SIZE``. Float32, rounding to the integer grid after every resize.
-  - ``process_image_dav2``: a single cubic resize so the shorter side reaches the
-    target, both sides a multiple of ``PATCH_SIZE``. Float64, no intermediate rounding.
+The per-image stage returns a float RGB tensor in [0, 255] of shape ``(3, H, W)``,
+resized per one of ``RESIZE_METHODS``:
+  - ``upper_bound_resize``: longest side to ``process_res``, aspect preserved, both sides
+    rounded to a multiple of ``PATCH_SIZE``.
+  - ``lower_bound_resize``: shortest side to ``process_res``, aspect preserved, both sides
+    rounded to a multiple of ``PATCH_SIZE``.
+  - ``square_resize``: resize to exactly ``(process_res, process_res)``.
+
+Resizing uses torchvision bilinear interpolation (the codebase-standard preprocessing
+resize). Normalization happens later in ``process_batch``.
 
 Batch stage (``process_batch``): center-crop to the smallest size in the batch, stack,
 ImageNet-normalize.
@@ -32,12 +38,12 @@ ImageNet-normalize.
 from __future__ import annotations
 
 import logging
-import math
 from collections.abc import Sequence
 
 import torch
 from torch import Tensor
 from torchvision.transforms.v2 import functional as transforms_functional
+from torchvision.transforms.v2.functional import InterpolationMode
 
 logger = logging.getLogger(__name__)
 
@@ -47,26 +53,31 @@ PATCH_SIZE = 14
 RESIZE_METHODS = (
     "upper_bound_resize",
     "lower_bound_resize",
+    "square_resize",
 )
 
 
-def process_image_dav3(
+def process_image(
     img: Tensor,
     *,
-    process_res: int = 504,
-    process_res_method: str = "upper_bound_resize",
+    process_res: int,
+    process_res_method: str = "square_resize",
 ) -> Tensor:
-    """Preprocesses one image for Depth Anything 3.
+    """Preprocesses one image for Depth Anything depth inference.
 
-    Resizes so one side matches ``process_res`` (preserving aspect ratio), then rounds
-    both sides to a multiple of ``PATCH_SIZE``. Runs in float32, rounding to the integer
-    grid after each resize. Normalization happens later in ``process_batch``.
+    Resizes according to ``process_res_method``, returning a float32 RGB tensor in
+    [0, 255]. Normalization happens later in ``process_batch``.
 
     Args:
         img: Image of shape ``(C, H, W)``. Uint8 is read as [0, 255], float as [0, 1];
             other dtypes raise.
-        process_res: Target size for the boundary resize.
-        process_res_method: One of ``RESIZE_METHODS``.
+        process_res: Target resolution for the resize.
+        process_res_method: One of ``RESIZE_METHODS``:
+            ``"upper_bound_resize"`` scales the longest side to ``process_res``,
+            ``"lower_bound_resize"`` scales the shortest side to ``process_res`` (both
+            preserve the aspect ratio and round each side to a multiple of
+            ``PATCH_SIZE``), and ``"square_resize"`` resizes to exactly
+            ``(process_res, process_res)``.
 
     Returns:
         A float32 RGB tensor in [0, 255] of shape ``(3, H, W)``.
@@ -77,41 +88,11 @@ def process_image_dav3(
             f"methods are: {RESIZE_METHODS}."
         )
     image = _to_float_rgb(img)
+    if process_res_method == "square_resize":
+        return _resize(image, new_h=process_res, new_w=process_res)
     image = _resize_bound(image, target_size=process_res, method=process_res_method)
     image = _resize_to_patch_multiple(image, patch=PATCH_SIZE)
     return image
-
-
-def process_image_dav2(
-    img: Tensor,
-    *,
-    process_res: int = 518,
-) -> Tensor:
-    """Preprocesses one image for Depth Anything V2.
-
-    Lower-bound resize so the shorter side reaches ``process_res``, both sides rounded
-    to a multiple of ``PATCH_SIZE``, as a single cubic resize with no intermediate
-    rounding. Stays in [0, 255] float; normalization happens later in ``process_batch``.
-
-    Args:
-        img: Image of shape ``(C, H, W)``. Uint8 is read as [0, 255], float as [0, 1];
-            other dtypes raise.
-        process_res: Target size for the shorter side.
-
-    Returns:
-        A float64 RGB tensor in [0, 255] of shape ``(3, H', W')``, H'/W' multiples of
-        ``PATCH_SIZE``.
-    """
-    # Float64 mirrors the official float64 image and roughly halves the resize's
-    # accumulation error vs float32, at negligible cost; DAv3 stays in float32.
-    image = _to_float_rgb(img).to(torch.float64)
-    h, w = image.shape[-2:]
-    new_h, new_w = _dav2_target_size(
-        h=h, w=w, process_res=process_res, patch=PATCH_SIZE
-    )
-    if (new_h, new_w) == (h, w):
-        return image
-    return _resize(image, new_h=new_h, new_w=new_w, method="cubic", round_to_grid=False)
 
 
 def process_batch(images: Sequence[Tensor]) -> Tensor:
@@ -119,8 +100,8 @@ def process_batch(images: Sequence[Tensor]) -> Tensor:
 
     Args:
         images: Float RGB tensors in [0, 255] of shape ``(3, H, W)`` from
-            ``process_image_dav3``/``process_image_dav2``. Differing sizes are
-            center-cropped to the smallest in the batch.
+            ``process_image``. Differing sizes are center-cropped to the smallest in the
+            batch.
 
     Returns:
         A normalized batch of shape ``(N, 3, H, W)``.
@@ -194,7 +175,7 @@ def _resize_bound(img: Tensor, *, target_size: int, method: str) -> Tensor:
     scale = target_size / float(bound)
     new_h = max(1, int(round(h * scale)))
     new_w = max(1, int(round(w * scale)))
-    return _resize_to_grid(img, new_h=new_h, new_w=new_w)
+    return _resize(img, new_h=new_h, new_w=new_w)
 
 
 def _resize_to_patch_multiple(img: Tensor, *, patch: int) -> Tensor:
@@ -210,131 +191,15 @@ def _resize_to_patch_multiple(img: Tensor, *, patch: int) -> Tensor:
     new_w = max(1, nearest_multiple(w))
     if new_w == w and new_h == h:
         return img
-    return _resize_to_grid(img, new_h=new_h, new_w=new_w)
+    return _resize(img, new_h=new_h, new_w=new_w)
 
 
-def _resize_to_grid(img: Tensor, *, new_h: int, new_w: int) -> Tensor:
-    """Resizes to ``(new_h, new_w)`` and rounds back to the integer grid (DAv3 path).
-
-    Kernel is joint over both axes: cubic if either axis enlarges, otherwise area.
-    """
-    h, w = img.shape[-2:]
-    method = "cubic" if new_h > h or new_w > w else "area"
-    return _resize(img, new_h=new_h, new_w=new_w, method=method, round_to_grid=True)
-
-
-def _dav2_target_size(
-    *, h: int, w: int, process_res: int, patch: int
-) -> tuple[int, int]:
-    """Computes the DAv2 lower-bound resize target size.
-
-    Scales so the shorter side reaches ``process_res``, then rounds each side to a
-    multiple of ``patch`` (ceiling up if rounding down would drop below ``process_res``).
-
-    Returns:
-        The ``(new_h, new_w)`` target size, both multiples of ``patch``.
-    """
-    scale = max(process_res / h, process_res / w)
-
-    def _constrain(x: float) -> int:
-        y = int(round(x / patch) * patch)
-        if y < process_res:
-            y = int(math.ceil(x / patch) * patch)
-        return y
-
-    return _constrain(scale * h), _constrain(scale * w)
-
-
-def _resize(
-    img: Tensor, *, new_h: int, new_w: int, method: str, round_to_grid: bool
-) -> Tensor:
-    """Resizes a ``(C, H, W)`` float image to ``(new_h, new_w)``, matching cv2 without it.
-
-    ``"area"`` matches cv2 ``INTER_AREA`` and ``"cubic"`` matches ``INTER_CUBIC``. Both
-    are separable: per-axis ``(dst, src)`` weight matrices (in ``img``'s dtype) applied
-    over height then width.
-
-    Args:
-        img: Float image of shape ``(C, H, W)``.
-        new_h: Target height.
-        new_w: Target width.
-        method: ``"area"`` or ``"cubic"``.
-        round_to_grid: If True, round to the integer grid and clamp to [0, 255] (DAv3,
-            for cv2 bit-exactness); DAv2 passes False to keep the unrounded float.
-
-    Returns:
-        The resized image of shape ``(C, new_h, new_w)``.
-    """
-    if method == "area":
-        weights = _area_weights
-    elif method == "cubic":
-        weights = _cubic_weights
-    else:
-        raise ValueError(
-            f"Unsupported resize method '{method}'. Supported methods are: "
-            f"('area', 'cubic')."
-        )
-    h, w = img.shape[-2:]
-    row_weights = weights(src=h, dst=new_h, device=img.device, dtype=img.dtype)
-    col_weights = weights(src=w, dst=new_w, device=img.device, dtype=img.dtype)
-    x = torch.einsum("ph,chw->cpw", row_weights, img)
-    x = torch.einsum("qw,cpw->cpq", col_weights, x)
-    if round_to_grid:
-        x = x.round().clamp(min=0.0, max=255.0)
-    return x
-
-
-def _area_weights(
-    *, src: int, dst: int, device: torch.device, dtype: torch.dtype = torch.float32
-) -> Tensor:
-    """Builds the ``(dst, src)`` cv2 ``INTER_AREA`` weight matrix for one axis.
-
-    Output cell ``i`` spans ``[i*scale, (i+1)*scale)`` (``scale = src/dst``); pixel
-    ``j``'s weight is its overlap with ``[j, j+1)`` divided by ``scale``. ``scale == 1``
-    is the identity, so an unchanged axis passes through exactly.
-    """
-    scale = src / dst
-    out_idx = torch.arange(dst, dtype=dtype, device=device)[:, None]
-    src_idx = torch.arange(src, dtype=dtype, device=device)[None, :]
-    lo = torch.maximum(out_idx * scale, src_idx)
-    hi = torch.minimum((out_idx + 1) * scale, src_idx + 1)
-    return (hi - lo).clamp(min=0) / scale
-
-
-def _cubic_weights(
-    *, src: int, dst: int, device: torch.device, dtype: torch.dtype = torch.float32
-) -> Tensor:
-    """Builds the ``(dst, src)`` cv2 ``INTER_CUBIC`` weight matrix for one axis.
-
-    Keys cubic kernel with ``a = -0.75`` (cv2's constant) and half-pixel centers: output
-    ``i`` samples ``(i+0.5)*scale - 0.5`` from its four nearest taps, clamping
-    out-of-range taps to the border (cv2 replicate). The four weights sum to one.
-
-    Args:
-        src: Source axis length.
-        dst: Destination axis length.
-        device: Device for the weights.
-        dtype: Weight dtype. DAv2 uses float64 (less accumulation error vs the cv2
-            reference); DAv3 uses float32.
-    """
-    a = -0.75
-    scale = src / dst
-    out_idx = torch.arange(dst, dtype=dtype, device=device)
-    center = (out_idx + 0.5) * scale - 0.5
-    base = torch.floor(center)
-    frac = center - base
-
-    def kernel(t: Tensor) -> Tensor:
-        t = t.abs()
-        inner = (a + 2) * t**3 - (a + 3) * t**2 + 1
-        outer = a * t**3 - 5 * a * t**2 + 8 * a * t - 4 * a
-        return torch.where(
-            t <= 1, inner, torch.where(t < 2, outer, torch.zeros_like(t))
-        )
-
-    weights = torch.zeros(dst, src, dtype=dtype, device=device)
-    rows = torch.arange(dst, device=device)
-    for offset in (-1, 0, 1, 2):
-        taps = (base + offset).long().clamp(min=0, max=src - 1)
-        weights[rows, taps] += kernel(frac - offset)
-    return weights
+def _resize(img: Tensor, *, new_h: int, new_w: int) -> Tensor:
+    """Resizes a ``(C, H, W)`` image to ``(new_h, new_w)`` with torchvision bilinear."""
+    resized: Tensor = transforms_functional.resize(
+        img,
+        size=[new_h, new_w],
+        interpolation=InterpolationMode.BILINEAR,
+        antialias=True,
+    )
+    return resized

--- a/src/lightly_train/_task_models/depth_estimation_components/image_utils.py
+++ b/src/lightly_train/_task_models/depth_estimation_components/image_utils.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from typing import Literal, get_args
 
 import torch
 from torch import Tensor
@@ -50,18 +51,19 @@ logger = logging.getLogger(__name__)
 NORMALIZE_MEAN = (0.485, 0.456, 0.406)
 NORMALIZE_STD = (0.229, 0.224, 0.225)
 PATCH_SIZE = 14
-RESIZE_METHODS = (
+ResizeMethod = Literal[
     "upper_bound_resize",
     "lower_bound_resize",
     "square_resize",
-)
+]
+RESIZE_METHODS = get_args(ResizeMethod)
 
 
 def process_image(
     img: Tensor,
     *,
     process_res: int,
-    process_res_method: str = "square_resize",
+    process_res_method: ResizeMethod = "square_resize",
 ) -> Tensor:
     """Preprocesses one image for Depth Anything depth inference.
 

--- a/tests/_task_models/depth_estimation_components/test_image_utils.py
+++ b/tests/_task_models/depth_estimation_components/test_image_utils.py
@@ -7,63 +7,101 @@
 #
 from __future__ import annotations
 
-import cv2
-import numpy as np
 import pytest
 import torch
-from torch import Tensor
 
 from lightly_train._task_models.depth_estimation_components import image_utils
+
+
+class TestProcessImage:
+    def test_process_image__upper_bound_resize(self) -> None:
+        # 64x100 image, longest side (100) scaled to 42, aspect preserved (64 -> ~27),
+        # then both sides rounded to the nearest multiple of 14.
+        img = torch.randint(0, 256, (3, 64, 100), dtype=torch.uint8)
+
+        out = image_utils.process_image(
+            img, process_res=42, process_res_method="upper_bound_resize"
+        )
+
+        assert out.dtype == torch.float32
+        h, w = out.shape[-2:]
+        assert h % image_utils.PATCH_SIZE == 0
+        assert w % image_utils.PATCH_SIZE == 0
+        # The longest side reaches the target multiple; height stays smaller.
+        assert w == 42
+        assert h < w
+
+    def test_process_image__lower_bound_resize(self) -> None:
+        # 64x100 image, shortest side (64) scaled to 42, aspect preserved, both sides
+        # rounded to a multiple of 14.
+        img = torch.randint(0, 256, (3, 64, 100), dtype=torch.uint8)
+
+        out = image_utils.process_image(
+            img, process_res=42, process_res_method="lower_bound_resize"
+        )
+
+        assert out.dtype == torch.float32
+        h, w = out.shape[-2:]
+        assert h % image_utils.PATCH_SIZE == 0
+        assert w % image_utils.PATCH_SIZE == 0
+        # The shortest side reaches the target multiple; width stays larger.
+        assert h == 42
+        assert w > h
+
+    def test_process_image__square_resize(self) -> None:
+        # Any input aspect ratio maps to an exact (process_res, process_res) square.
+        img = torch.randint(0, 256, (3, 64, 100), dtype=torch.uint8)
+
+        out = image_utils.process_image(
+            img, process_res=56, process_res_method="square_resize"
+        )
+
+        assert out.shape == (3, 56, 56)
+        assert out.dtype == torch.float32
+
+    def test_process_image__unsupported_method_raises(self) -> None:
+        img = torch.zeros(3, 32, 32, dtype=torch.uint8)
+
+        with pytest.raises(ValueError, match="Unsupported process_res_method 'nope'"):
+            image_utils.process_image(img, process_res=28, process_res_method="nope")
+
+    def test_process_image__grayscale_expanded_to_rgb(self) -> None:
+        img = torch.full((1, 28, 28), 128, dtype=torch.uint8)
+
+        out = image_utils.process_image(
+            img, process_res=28, process_res_method="square_resize"
+        )
+
+        assert out.shape == (3, 28, 28)
+
+    def test_process_image__alpha_channel_dropped(self) -> None:
+        img = torch.randint(0, 256, (4, 28, 28), dtype=torch.uint8)
+
+        out = image_utils.process_image(
+            img, process_res=28, process_res_method="square_resize"
+        )
+
+        assert out.shape == (3, 28, 28)
+
+    def test_process_image__unsupported_channels_raises(self) -> None:
+        img = torch.zeros(2, 28, 28, dtype=torch.uint8)
+
+        with pytest.raises(ValueError, match="1, 3, or 4 channels"):
+            image_utils.process_image(
+                img, process_res=28, process_res_method="square_resize"
+            )
 
 
 def test__resize_bound__upper_bound_resizes_longest_side() -> None:
     img = torch.full((3, 8, 4), 100.0)
     out = image_utils._resize_bound(img, target_size=4, method="upper_bound_resize")
     assert out.shape == (3, 4, 2)
-    assert torch.equal(out, torch.full((3, 4, 2), 100.0))
 
 
 def test__resize_bound__lower_bound_resizes_shortest_side() -> None:
     img = torch.full((3, 8, 4), 100.0)
     out = image_utils._resize_bound(img, target_size=2, method="lower_bound_resize")
     assert out.shape == (3, 4, 2)
-    assert torch.equal(out, torch.full((3, 4, 2), 100.0))
-
-
-def test__resize__area_matches_cv2_bit_exactly() -> None:
-    generator = torch.Generator().manual_seed(0)
-    img = torch.randint(0, 256, (3, 30, 48), generator=generator, dtype=torch.uint8)
-    out = image_utils._resize(
-        img.float(), new_h=20, new_w=32, method="area", round_to_grid=True
-    )
-    expected = _cv2_resize(img, new_h=20, new_w=32, interpolation=cv2.INTER_AREA)
-    assert torch.equal(out, expected.round().clamp(min=0.0, max=255.0))
-
-
-def test__resize__cubic_matches_cv2_up_to_rounding_ties() -> None:
-    generator = torch.Generator().manual_seed(0)
-    img = torch.randint(0, 256, (3, 32, 48), generator=generator, dtype=torch.uint8)
-    out = image_utils._resize(
-        img.float(), new_h=48, new_w=72, method="cubic", round_to_grid=True
-    )
-    expected = _cv2_resize(img, new_h=48, new_w=72, interpolation=cv2.INTER_CUBIC)
-    expected_rounded = expected.round().clamp(min=0.0, max=255.0)
-    # Cubic weights at half-pixel offsets are dyadic, so a pre-rounding value can
-    # land exactly on a .5 tie where the float accumulation order may flip the
-    # rounding by one. Non-tie pixels must match bit-exactly; tie pixels may
-    # differ by at most one and must be rare.
-    tie = (expected - expected.floor() - 0.5).abs() < 1e-3
-    mismatch = out != expected_rounded
-    assert not (mismatch & ~tie).any()
-    assert (out - expected_rounded).abs().max() <= 1.0
-    assert mismatch.float().mean() < 0.01
-
-
-def test__resize__unsupported_method_raises() -> None:
-    img = torch.zeros(3, 4, 4)
-
-    with pytest.raises(ValueError, match="Unsupported resize method 'nearest'"):
-        image_utils._resize(img, new_h=2, new_w=2, method="nearest", round_to_grid=True)
 
 
 def test__resize_to_patch_multiple__rounds_each_side_to_nearest_multiple() -> None:
@@ -73,7 +111,6 @@ def test__resize_to_patch_multiple__rounds_each_side_to_nearest_multiple() -> No
 
     # 45 rounds down to 42; 56 is already a multiple of 14 and stays unchanged.
     assert out.shape == (3, 42, 56)
-    assert torch.equal(out, torch.full((3, 42, 56), 100.0))
 
 
 def test__resize_to_patch_multiple__halfway_rounds_up() -> None:
@@ -83,87 +120,3 @@ def test__resize_to_patch_multiple__halfway_rounds_up() -> None:
 
     # 21 is equally far from 14 and 28; the tie rounds up.
     assert out.shape == (3, 28, 28)
-    assert torch.equal(out, torch.full((3, 28, 28), 100.0))
-
-
-def test__dav2_target_size__lower_bound_rounds_to_multiple_of_14() -> None:
-    # The shorter side (480) scales to process_res (518); the longer side scales by the
-    # same factor (690.67) and rounds to the nearest multiple of 14 (686).
-    new_h, new_w = image_utils._dav2_target_size(
-        h=480, w=640, process_res=518, patch=14
-    )
-    assert (new_h, new_w) == (518, 686)
-
-
-def test__dav2_target_size__square_maps_to_process_res() -> None:
-    new_h, new_w = image_utils._dav2_target_size(
-        h=500, w=500, process_res=518, patch=14
-    )
-    assert (new_h, new_w) == (518, 518)
-
-
-def test__dav2_target_size__ceils_when_below_min_val() -> None:
-    # With a process_res that is not a multiple of patch, rounding the shorter side down
-    # would fall below process_res, so it must ceil up to the next multiple (532).
-    new_h, new_w = image_utils._dav2_target_size(
-        h=500, w=500, process_res=520, patch=14
-    )
-    assert (new_h, new_w) == (532, 532)
-
-
-def test__resize__cubic_no_round_matches_cv2_float64() -> None:
-    generator = torch.Generator().manual_seed(0)
-    img = torch.randint(0, 256, (3, 30, 48), generator=generator, dtype=torch.uint8)
-    img64 = img.to(torch.float64)
-
-    out = image_utils._resize(
-        img64, new_h=42, new_w=70, method="cubic", round_to_grid=False
-    )
-
-    expected = _cv2_resize_f64(img64, new_h=42, new_w=70, interpolation=cv2.INTER_CUBIC)
-    # cv2 computes the cubic source coordinate and coefficients in float32 internally
-    # (even for float64 data), so a dependency-free float64 reproduction matches cv2 to
-    # ~1e-2 in [0, 255] space rather than bit-exactly. A wrong kernel/coordinate would
-    # differ by whole pixel values, so this still strongly pins the implementation.
-    assert out.dtype == torch.float64
-    assert (out - expected).abs().max() < 0.05
-    assert (out - expected).abs().mean() < 5e-3
-
-
-def test_process_image_dav2__matches_official_cubic_pipeline() -> None:
-    generator = torch.Generator().manual_seed(0)
-    img = torch.randint(0, 256, (3, 360, 540), generator=generator, dtype=torch.uint8)
-
-    out = image_utils.process_image_dav2(img, process_res=518)
-
-    new_h, new_w = image_utils._dav2_target_size(
-        h=360, w=540, process_res=518, patch=14
-    )
-    assert out.shape == (3, new_h, new_w)
-    # The official pipeline resizes the float image with cv2.INTER_CUBIC without
-    # rounding back to the integer grid; comparing in [0, 255] space is equivalent to
-    # the official /255-then-resize because the resize is linear. See the note in
-    # test__resize__cubic_no_round_matches_cv2_float64 on the cv2 float32 internals.
-    expected = _cv2_resize_f64(
-        img.to(torch.float64), new_h=new_h, new_w=new_w, interpolation=cv2.INTER_CUBIC
-    )
-    assert (out - expected).abs().max() < 0.05
-    assert (out - expected).abs().mean() < 5e-3
-
-
-def _cv2_resize(img: Tensor, *, new_h: int, new_w: int, interpolation: int) -> Tensor:
-    """Resizes a ``(C, H, W)`` tensor with cv2 in float32, as the official DA3
-    pipeline does, and returns the unrounded float ``(C, H, W)`` result."""
-    img_np = img.permute(1, 2, 0).numpy().astype(np.float32)
-    resized = cv2.resize(src=img_np, dsize=(new_w, new_h), interpolation=interpolation)
-    return torch.from_numpy(resized).permute(2, 0, 1)
-
-
-def _cv2_resize_f64(
-    img: Tensor, *, new_h: int, new_w: int, interpolation: int
-) -> Tensor:
-    """Resizes a ``(C, H, W)`` tensor with cv2 in float64, as the official DA2
-    pipeline does, and returns the unrounded float ``(C, H, W)`` result."""
-    img_np = img.permute(1, 2, 0).numpy().astype(np.float64)
-    resized = cv2.resize(src=img_np, dsize=(new_w, new_h), interpolation=interpolation)
-    return torch.from_numpy(resized).permute(2, 0, 1)

--- a/tests/_task_models/depth_estimation_components/test_image_utils.py
+++ b/tests/_task_models/depth_estimation_components/test_image_utils.py
@@ -63,7 +63,11 @@ class TestProcessImage:
         img = torch.zeros(3, 32, 32, dtype=torch.uint8)
 
         with pytest.raises(ValueError, match="Unsupported process_res_method 'nope'"):
-            image_utils.process_image(img, process_res=28, process_res_method="nope")
+            image_utils.process_image(
+                img,
+                process_res=28,
+                process_res_method="nope",  # type: ignore[arg-type]
+            )
 
     def test_process_image__grayscale_expanded_to_rgb(self) -> None:
         img = torch.full((1, 28, 28), 128, dtype=torch.uint8)


### PR DESCRIPTION
## What has changed and why?

Consolidated the depth-estimation image preprocessing. Previously there were two parallel per-image functions (`process_image_dav2` / `process_image_dav3`) backed by a large amount of custom resize code written to reproduce OpenCV's `INTER_AREA`/`INTER_CUBIC` output pixel-for-pixel. That cv2-bit-exactness goal has been abandoned, so the custom machinery is no longer needed.

- **Single preprocessing path**: `process_image_dav2` + `process_image_dav3` → one `process_image`. Dropped the cv2-parity resize (`_area_weights`,` _cubic_weights`, `_dav2_target_size`, etc.); resizing now uses `torchvision.transforms.v2.functional.resize` (bilinear + antialias), matching every other task model.
- **Resize method is now a call-time parameter** on `predict` / `predict_batch` (`process_res_method`, default `"square_resize"`) instead of a fixed per-model setting. Removed the now-dead `preprocess` config key and `_PROCESS_RES_METHOD_DAV3` constant.
- Added `square_resize` (resize to `image_size × image_size`) alongside upper_bound_resize and lower_bound_resize; all three now work for both DAv2 and DAv3.

Note: the default processing geometry changes (was upper-bound for DAv3, lower-bound for DAv2; now `square_resize` for both). Callers can pass `process_res_method=` to select the old behavior.


## How has it been tested?

- Rewrote `test_image_utils.py`: removed the cv2-parity tests, added coverage for all three resize methods, dtype/channel handling, and process_batch.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
