### PR TITLE
Fix normalization with legacy LT-DETR models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed an issue with legacy LT-DETR checkpoints that used a [0,1] normalization instead
+  of the now-default ImageNet normalization.
+
 ### Security
 
 ## [0.16.1] - 2026-06-26

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -76,6 +76,11 @@ from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
 
+LTDETR_DEFAULT_IMAGE_NORMALIZE: dict[str, tuple[float, ...]] = {
+    "mean": (0.0, 0.0, 0.0),
+    "std": (1.0, 1.0, 1.0),
+}
+
 _LTDETRDecoderName = Literal["rtdetrv2", "dfine"]
 _TransformerConfig = Union[RTDETRTransformerv2Config, DFINETransformerConfig]
 _TransformerConfigFactory = Callable[[], _TransformerConfig]
@@ -196,7 +201,11 @@ class LTDETRObjectDetection(TaskModel):
             for internal_class_id, class_name in enumerate(self.classes.values())
         }
 
-        self.image_normalize = image_normalize
+        self.image_normalize = (
+            image_normalize
+            if image_normalize is not None
+            else dict(LTDETR_DEFAULT_IMAGE_NORMALIZE)
+        )
 
         # Resolve the backbone's expected input channel count.
         # backbone_args["in_chans"] overrides image_normalize, which overrides 3.
@@ -205,10 +214,8 @@ class LTDETRObjectDetection(TaskModel):
             self._expected_input_channels = 3
         elif backbone_args is not None and "in_chans" in backbone_args:
             self._expected_input_channels = backbone_args["in_chans"]
-        elif self.image_normalize is not None:
-            self._expected_input_channels = len(self.image_normalize["mean"])
         else:
-            self._expected_input_channels = 3
+            self._expected_input_channels = len(self.image_normalize["mean"])
 
         # Build backbone model args: start from config defaults, then apply overrides.
         backbone_model_args: dict[str, Any] = dict(config.backbone_args)
@@ -221,9 +228,9 @@ class LTDETRObjectDetection(TaskModel):
         if backbone_weights is not None and not is_dinov2_backbone:
             backbone_model_args["weights"] = str(backbone_weights)
 
-        get_model_kwargs = {}
-        if self.image_normalize is not None:
-            get_model_kwargs["num_input_channels"] = len(self.image_normalize["mean"])
+        get_model_kwargs = {
+            "num_input_channels": len(self.image_normalize["mean"]),
+        }
 
         package = package_helpers.get_package(package_name)
 

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -387,7 +387,10 @@ def test_task_model_uses_default_image_normalize_when_none() -> None:
 
 
 def test_task_model_explicit_image_normalize_overrides_default() -> None:
-    image_normalize = {"mean": (0.5, 0.5, 0.5), "std": (0.25, 0.25, 0.25)}
+    image_normalize: dict[str, tuple[float, ...]] = {
+        "mean": (0.5, 0.5, 0.5),
+        "std": (0.25, 0.25, 0.25),
+    }
 
     model = LTDETRObjectDetection(
         model_name="dinov3/vitt16-notpretrained-ltdetr",

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -34,6 +34,7 @@ from lightly_train._task_models.ltdetr_object_detection.dino_vit_wrapper import 
     DINOSTAs,
 )
 from lightly_train._task_models.ltdetr_object_detection.task_model import (
+    LTDETR_DEFAULT_IMAGE_NORMALIZE,
     LTDETRObjectDetection,
     _resolve_transformer_config,
 )
@@ -370,6 +371,33 @@ def test_resolve_auto__auto_lr_warmup_steps_short_run(
 
     assert isinstance(model_args.lr_warmup_steps, int)
     assert 0 <= model_args.lr_warmup_steps < 100
+
+
+def test_task_model_uses_default_image_normalize_when_none() -> None:
+    model = LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(640, 640),
+        image_normalize=None,
+        load_weights=False,
+    )
+
+    assert model.image_normalize == LTDETR_DEFAULT_IMAGE_NORMALIZE
+    assert model.init_args["image_normalize"] is None
+
+
+def test_task_model_explicit_image_normalize_overrides_default() -> None:
+    image_normalize = {"mean": (0.5, 0.5, 0.5), "std": (0.25, 0.25, 0.25)}
+
+    model = LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(640, 640),
+        image_normalize=image_normalize,
+        load_weights=False,
+    )
+
+    assert model.image_normalize == image_normalize
 
 
 def test_task_model_init_args_roundtrip_preserves_patch_size() -> None:


### PR DESCRIPTION
## What has changed and why?
- stacks on top of #845 
- old checkpoints from LT-DETR used [0,1] normalization, but at some point we changed the fallback to ImageNet, which caused degraded performance in the benchmarks
- this PR fixes the fallback

**Note**: Does not influence new checkpoints trained with ImageNet normalization, since those will include `normalize_args` inside the checkpoint arguments.

## How has it been tested?
- Ran the OD benchmark command for all public `-coco` checkpoints, and they all got the expected mAP number

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
