### PR TITLE
Fix yaml data loading for object detection

### DIFF
--- a/src/lightly_train/_commands/benchmark_types.py
+++ b/src/lightly_train/_commands/benchmark_types.py
@@ -288,12 +288,10 @@ class BenchmarkObjectDetectionConfig(PydanticConfig):
     @field_validator("data", mode="before")
     @classmethod
     def _prepare_data(cls, v: Any) -> Any:
-        # Load the data config from a YAML file if a path is given, then default the
-        # format to "yolo" if none is specified. This mirrors the behavior of
-        # train_object_detection so that the data config is consistent across both.
-        v = data_helpers.load_data_yaml_if_path(v, cls.model_fields["data"].annotation)
-        v = data_helpers.set_default_data_format(v)
-        return v
+        # Keep data config handling consistent with train_object_detection.
+        return data_helpers.prepare_object_detection_data(
+            v, cls.model_fields["data"].annotation
+        )
 
 
 _SIZE_SUFFIXES = {"small", "medium", "large"}

--- a/src/lightly_train/_commands/data_helpers.py
+++ b/src/lightly_train/_commands/data_helpers.py
@@ -12,63 +12,89 @@ from typing import Any, Union, get_args, get_origin
 
 import fsspec
 import yaml
+from typing_extensions import Annotated
 
 
-def _resolve_path_relative_to_yaml(value: Any, yaml_path: Path) -> Any:
-    """Resolve a relative top-level data path against the YAML file location."""
-    if not isinstance(value, dict) or "path" not in value:
+def _iter_model_fields(data_annotation: Any) -> set[str]:
+    if get_origin(data_annotation) is Annotated:
+        data_annotation = get_args(data_annotation)[0]
+    if get_origin(data_annotation) is Union:
+        members = get_args(data_annotation)
+    else:
+        members = (data_annotation,)
+    return {
+        name
+        for member in members
+        for name in member.model_fields  # type: ignore[attr-defined]
+    }
+
+
+def _filter_data_attributes(value: Any, data_annotation: Any) -> Any:
+    if not isinstance(value, dict):
         return value
-    path = value["path"]
+    data_attributes = _iter_model_fields(data_annotation)
+    return {name: val for name, val in value.items() if name in data_attributes}
+
+
+def _resolve_relative_path(path: Any, base_dir: Path) -> Any:
     if not isinstance(path, (str, Path)):
-        return value
+        return path
     path = Path(path)
     if path.is_absolute():
+        return path
+    return base_dir / path
+
+
+def _resolve_object_detection_paths_relative_to_yaml(
+    value: Any, yaml_path: Path
+) -> Any:
+    if not isinstance(value, dict):
         return value
-    return {**value, "path": yaml_path.parent / path}
+
+    data_format = value.get("format", "yolo")
+    base_dir = yaml_path.parent
+    if data_format == "yolo":
+        if "path" not in value:
+            return value
+        return {**value, "path": _resolve_relative_path(value["path"], base_dir)}
+    if data_format == "coco":
+        value = {**value}
+        for split in ("train", "val", "test"):
+            split_value = value.get(split)
+            if isinstance(split_value, dict) and "annotations" in split_value:
+                value[split] = {
+                    **split_value,
+                    "annotations": _resolve_relative_path(
+                        split_value["annotations"], base_dir
+                    ),
+                }
+        return value
+    return value
 
 
-def load_data_yaml_if_path(value: Any, data_annotation: Any) -> Any:
-    """Loads a data config from a YAML file if ``value`` is a path.
+def prepare_object_detection_data(value: Any, data_annotation: Any) -> Any:
+    """Prepare object detection data configs.
 
-    If ``value`` is a string or ``Path`` it is interpreted as the path to a YAML file
-    that is loaded and returned as a dictionary. For local YAML files, a relative
-    top-level path value is resolved against the YAML file's parent directory.
-    All keys that are not part of the Pydantic model are ignored. As the data
-    config can be a ``Union``, it would be
-    impossible to figure out which keys to exclude, so in that case the fields of all
-    union members are included. If ``value`` is not a path it is returned unchanged.
-
-    Args:
-        value:
-            The value of the ``data`` field. Either a path to a YAML file or an
-            already-parsed config (dict or model instance).
-        data_annotation:
-            The type annotation of the ``data`` field. Usually obtained via
-            ``cls.model_fields["data"].annotation``.
+    Supports either an already parsed data config or a path to a YAML file. Local
+    YAML file paths are used as the base for relative YOLO path values and
+    relative COCO annotation file paths. Unknown YAML keys are ignored.
     """
     if isinstance(value, (str, Path)):
         yaml_path_or_url = str(value)
         with fsspec.open(value, "r") as file:
             value = yaml.safe_load(file)
         if fsspec.utils.infer_storage_options(yaml_path_or_url)["protocol"] == "file":
-            value = _resolve_path_relative_to_yaml(value, Path(yaml_path_or_url))
-        if get_origin(data_annotation) is Union:
-            members = get_args(data_annotation)
-        else:
-            members = (data_annotation,)
-        data_attributes = {
-            name
-            for m in members
-            for name in m.model_fields  # type: ignore[attr-defined]
-        }
-        value = {name: val for name, val in value.items() if name in data_attributes}
-    return value
+            value = _resolve_object_detection_paths_relative_to_yaml(
+                value, Path(yaml_path_or_url)
+            )
+        value = _filter_data_attributes(value, data_annotation)
+    return set_default_data_format(value)
 
 
 def set_default_data_format(value: Any, default: str = "yolo") -> Any:
-    """Sets a default ``format`` on a data config dict if none is given.
+    """Sets a default format on a data config dict if none is given.
 
-    Returns ``value`` unchanged if it is not a dict or already has a ``format`` key.
+    Returns value unchanged if it is not a dict or already has a format key.
     """
     if isinstance(value, dict) and "format" not in value:
         value = {**value, "format": default}

--- a/src/lightly_train/_commands/data_helpers.py
+++ b/src/lightly_train/_commands/data_helpers.py
@@ -14,12 +14,27 @@ import fsspec
 import yaml
 
 
+def _resolve_path_relative_to_yaml(value: Any, yaml_path: Path) -> Any:
+    """Resolve a relative top-level data path against the YAML file location."""
+    if not isinstance(value, dict) or "path" not in value:
+        return value
+    path = value["path"]
+    if not isinstance(path, (str, Path)):
+        return value
+    path = Path(path)
+    if path.is_absolute():
+        return value
+    return {**value, "path": yaml_path.parent / path}
+
+
 def load_data_yaml_if_path(value: Any, data_annotation: Any) -> Any:
     """Loads a data config from a YAML file if ``value`` is a path.
 
     If ``value`` is a string or ``Path`` it is interpreted as the path to a YAML file
-    that is loaded and returned as a dictionary. All keys that are not part of the
-    Pydantic model are ignored. As the data config can be a ``Union``, it would be
+    that is loaded and returned as a dictionary. For local YAML files, a relative
+    top-level path value is resolved against the YAML file's parent directory.
+    All keys that are not part of the Pydantic model are ignored. As the data
+    config can be a ``Union``, it would be
     impossible to figure out which keys to exclude, so in that case the fields of all
     union members are included. If ``value`` is not a path it is returned unchanged.
 
@@ -32,8 +47,11 @@ def load_data_yaml_if_path(value: Any, data_annotation: Any) -> Any:
             ``cls.model_fields["data"].annotation``.
     """
     if isinstance(value, (str, Path)):
+        yaml_path_or_url = str(value)
         with fsspec.open(value, "r") as file:
             value = yaml.safe_load(file)
+        if fsspec.utils.infer_storage_options(yaml_path_or_url)["protocol"] == "file":
+            value = _resolve_path_relative_to_yaml(value, Path(yaml_path_or_url))
         if get_origin(data_annotation) is Union:
             members = get_args(data_annotation)
         else:

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -2093,7 +2093,8 @@ class ObjectDetectionTrainTaskConfig(TrainTaskConfig):
 
     @field_validator("data", mode="before")
     @classmethod
-    def _set_default_format(cls, v: Any) -> Any:
+    def _prepare_data(cls, v: Any) -> Any:
+        v = data_helpers.load_data_yaml_if_path(v, cls.model_fields["data"].annotation)
         return data_helpers.set_default_data_format(v)
 
 

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -2048,13 +2048,6 @@ class TrainTaskConfig(PydanticConfig):
     # Allow arbitrary field types such as Module, Dataset, Accelerator, ...
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    @field_validator("data", mode="before")
-    @classmethod
-    def _load_yaml_if_path(cls, v: Any) -> Any:
-        return data_helpers.load_data_yaml_if_path(
-            v, cls.model_fields["data"].annotation
-        )
-
 
 class ImageClassificationMulticlassTrainTaskConfig(TrainTaskConfig):
     data: ImageClassificationMulticlassDataArgs
@@ -2094,8 +2087,9 @@ class ObjectDetectionTrainTaskConfig(TrainTaskConfig):
     @field_validator("data", mode="before")
     @classmethod
     def _prepare_data(cls, v: Any) -> Any:
-        v = data_helpers.load_data_yaml_if_path(v, cls.model_fields["data"].annotation)
-        return data_helpers.set_default_data_format(v)
+        return data_helpers.prepare_object_detection_data(
+            v, cls.model_fields["data"].annotation
+        )
 
 
 class SemanticSegmentationTrainTaskConfig(TrainTaskConfig):

--- a/tests/_commands/test_benchmark_task.py
+++ b/tests/_commands/test_benchmark_task.py
@@ -269,11 +269,13 @@ class TestBenchmarkObjectDetectionConfig:
 
     def test_loads_data_from_yaml_path(self, tmp_path: Path) -> None:
         # A path to a YAML file is loaded automatically and unknown keys are ignored.
-        yaml_path = tmp_path / "data.yaml"
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        yaml_path = config_dir / "data.yaml"
         with yaml_path.open("w") as file:
             yaml.safe_dump(
                 {
-                    "path": str(tmp_path),
+                    "path": "../dataset",
                     "train": "images/train",
                     "val": "images/val",
                     "names": {0: "class_a"},
@@ -297,6 +299,7 @@ class TestBenchmarkObjectDetectionConfig:
         )
         assert isinstance(config.data, YOLOObjectDetectionDataArgs)
         assert config.data.format == "yolo"
+        assert config.data.path == tmp_path / "configs" / "../dataset"
         assert config.data.names == {0: "class_a"}
 
 

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 from lightning_utilities.core.imports import RequirementCache
 from pytest import LogCaptureFixture
 
@@ -39,7 +40,10 @@ import torch
 import yaml
 
 import lightly_train
-from lightly_train._commands.train_task import ObjectDetectionTrainTaskConfig
+from lightly_train._commands.train_task import (
+    ObjectDetectionTrainTaskConfig,
+    PanopticSegmentationTrainTaskConfig,
+)
 
 from .. import helpers
 
@@ -961,8 +965,8 @@ def test_create_object_detection_train_task_config__data_is_yaml(
         data=path_type(data_yaml),
     )
     assert isinstance(config.data, COCOObjectDetectionDataArgs)
-    assert config.data.train.annotations == "train.json"
-    assert config.data.val.annotations == "val.json"
+    assert config.data.train.annotations == tmp_path / "train.json"
+    assert config.data.val.annotations == tmp_path / "val.json"
 
 
 @pytest.mark.parametrize("path_type", [str, Path])
@@ -1033,3 +1037,33 @@ def test_create_object_detection_train_task_config__yolo_yaml_path_is_relative_t
     assert len(val_info) == 1
     assert Path(train_info[0]["image_path"]).exists()
     assert Path(val_info[0]["image_path"]).exists()
+
+
+def test_create_panoptic_segmentation_train_task_config__data_yaml_path_not_supported(
+    tmp_path: Path,
+) -> None:
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "train": {
+                    "images": "train/images",
+                    "masks": "train/masks",
+                    "annotations": "train.json",
+                },
+                "val": {
+                    "images": "val/images",
+                    "masks": "val/masks",
+                    "annotations": "val.json",
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ValidationError):
+        PanopticSegmentationTrainTaskConfig(
+            out="out",
+            model="some/model",
+            task="panoptic_segmentation",
+            data=data_yaml,
+        )

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
 from lightning_utilities.core.imports import RequirementCache
+from pydantic import ValidationError
 from pytest import LogCaptureFixture
 
 from lightly_train._data.coco_object_detection_dataset import (

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -17,6 +17,9 @@ from pytest import LogCaptureFixture
 from lightly_train._data.coco_object_detection_dataset import (
     COCOObjectDetectionDataArgs,
 )
+from lightly_train._data.yolo_object_detection_dataset import (
+    YOLOObjectDetectionDataArgs,
+)
 
 if RequirementCache("albumentations<1.4.0"):
     # Skip test if albumentations version is too old. This can happen on Python 3.8.
@@ -960,3 +963,73 @@ def test_create_object_detection_train_task_config__data_is_yaml(
     assert isinstance(config.data, COCOObjectDetectionDataArgs)
     assert config.data.train.annotations == "train.json"
     assert config.data.val.annotations == "val.json"
+
+
+@pytest.mark.parametrize("path_type", [str, Path])
+def test_create_object_detection_train_task_config__yolo_yaml_without_format(
+    tmp_path: Path, path_type: type
+) -> None:
+    data_yaml = tmp_path / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": ".",
+                "train": "train/images",
+                "val": "val/images",
+                "names": {0: "class_0", 1: "class_1"},
+                "extra_field_123": "extra_field_123",
+            }
+        )
+    )
+
+    config = ObjectDetectionTrainTaskConfig(
+        out="out",
+        model="some/model",
+        task="object_detection",
+        data=path_type(data_yaml),
+    )
+
+    assert isinstance(config.data, YOLOObjectDetectionDataArgs)
+    assert config.data.format == "yolo"
+    assert config.data.path == tmp_path
+    assert config.data.names == {0: "class_0", 1: "class_1"}
+
+
+def test_create_object_detection_train_task_config__yolo_yaml_path_is_relative_to_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "configs"
+    dataset_dir = tmp_path / "dataset"
+    run_dir = tmp_path / "run"
+    config_dir.mkdir()
+    run_dir.mkdir()
+    helpers.create_yolo_object_detection_dataset(
+        tmp_path=dataset_dir, split_first=True, num_files=1
+    )
+    data_yaml = config_dir / "data.yaml"
+    data_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "path": "../dataset",
+                "train": "train/images",
+                "val": "val/images",
+                "names": {0: "class_0", 1: "class_1"},
+            }
+        )
+    )
+    monkeypatch.chdir(run_dir)
+
+    config = ObjectDetectionTrainTaskConfig(
+        out="out",
+        model="some/model",
+        task="object_detection",
+        data=data_yaml,
+    )
+
+    assert isinstance(config.data, YOLOObjectDetectionDataArgs)
+    train_info = list(config.data.get_train_args().list_image_info())
+    val_info = list(config.data.get_val_args().list_image_info())
+    assert len(train_info) == 1
+    assert len(val_info) == 1
+    assert Path(train_info[0]["image_path"]).exists()
+    assert Path(val_info[0]["image_path"]).exists()


### PR DESCRIPTION
## What has changed and why?
- yaml file loading was broken for 2 reasons
  1. path resolution was relative to script location instead of yaml location
  2. required the `"format"` key inside the yaml file which is non-standard
- this PR also uses yaml now in the quickstart, which makes the docs much cleaner imo

## How has it been tested?
- unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
