### PR TITLE
Fix uncalled `Tensor.is_floating_point` in ONNX export verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix ONNX export verification for task models: `Tensor.is_floating_point` was
+  referenced without calling it, so the always-truthy bound method forced integer
+  outputs (e.g. labels) through the float comparison path instead of the intended
+  exact-match check.
+
 ### Security
 
 ## [0.16.2] - 2026-07-10

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -1024,7 +1024,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -1048,7 +1048,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
@@ -1162,7 +1162,7 @@ class DINOv2EoMTPanopticSegmentation(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_panoptic_segmentation/task_model.py
@@ -1186,7 +1186,7 @@ class DINOv2EoMTPanopticSegmentation(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -953,7 +953,7 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -929,7 +929,7 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -988,7 +988,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -1012,7 +1012,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
@@ -1140,7 +1140,7 @@ class DINOv3EoMTPanopticSegmentation(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_panoptic_segmentation/task_model.py
@@ -1116,7 +1116,7 @@ class DINOv3EoMTPanopticSegmentation(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -924,7 +924,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -948,7 +948,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/image_classification/task_model.py
+++ b/src/lightly_train/_task_models/image_classification/task_model.py
@@ -584,7 +584,7 @@ class ImageClassification(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     # Absolute and relative tolerances are a bit arbitrary and taken from here:
                     # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                     torch.testing.assert_close(

--- a/src/lightly_train/_task_models/image_classification/task_model.py
+++ b/src/lightly_train/_task_models/image_classification/task_model.py
@@ -560,7 +560,7 @@ class ImageClassification(TaskModel):
 
             # Always run the reference input in float32 and on cpu for consistency.
             reference_model = copy.deepcopy(self).cpu().to(torch.float32).eval()
-            reference_outputs = reference_model(
+            reference_outputs: tuple[Tensor, ...] = reference_model(
                 dummy_input.cpu().to(torch.float32),
             )
 

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -847,7 +847,7 @@ class LTDETRObjectDetection(TaskModel):
                 # Always run the reference input in float32 and on cpu for consistency.
                 reference_model = deepcopy(self).cpu().to(torch.float32).eval()
                 reference_model.deploy()
-                reference_outputs = reference_model(
+                reference_outputs: tuple[Tensor, ...] = reference_model(
                     dummy_input.cpu().to(torch.float32),
                 )
 

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -880,12 +880,12 @@ class LTDETRObjectDetection(TaskModel):
                     # in different order but still valid. To account for this, we sum
                     # over the query dimension before comparing.
                     output_model = output_model.sum(dim=1)
-                    if output_onnx.is_floating_point:
+                    if output_onnx.is_floating_point():
                         # Convert to fp32 to avoid overflow issues when summing in fp16.
                         output_onnx = output_onnx.float()
                     output_onnx = output_onnx.sum(dim=1)
 
-                    if output_model.is_floating_point:
+                    if output_model.is_floating_point():
                         # Absolute and relative tolerances are a bit arbitrary and taken from here:
                         # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                         torch.testing.assert_close(

--- a/src/lightly_train/_task_models/picodet_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/task_model.py
@@ -786,7 +786,7 @@ class PicoDetObjectDetection(TaskModel):
                 def msg(s: str) -> str:
                     return f'ONNX validation failed for output "{output_name}": {s}'
 
-                if output_model.is_floating_point:
+                if output_model.is_floating_point():
                     torch.testing.assert_close(
                         output_onnx,
                         output_model,

--- a/src/lightly_train/_task_models/picodet_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/picodet_object_detection/task_model.py
@@ -764,7 +764,7 @@ class PicoDetObjectDetection(TaskModel):
 
             reference_model = deepcopy(self).cpu().to(torch.float32).eval()
             reference_export_model = _PicoDetExportWrapper(reference_model)
-            reference_outputs = reference_export_model(
+            reference_outputs: tuple[Tensor, ...] = reference_export_model(
                 dummy_input.cpu().to(torch.float32),
             )
 


### PR DESCRIPTION
## What has changed and why?

The ONNX export verification in the task models checked `tensor.is_floating_point` (the method object) instead of calling it `tensor.is_floating_point()`. A bound method is always truthy, so the check always took the float branch:

- Integer outputs (e.g. `labels`) were force-cast to float and compared with `torch.testing.assert_close` (tolerance-based) instead of the intended exact-match `assert_most_equal` path — the discrete-output check was dead code.

This fixes the call in all 9 task models that have an `export_onnx` verification block (EoMT semantic/instance/panoptic for DINOv2 and DINOv3, PicoDet and LTDETR object detection, and image classification). The correct `dtype.is_floating_point` usages (a genuine property) were left untouched.

## How has it been tested?

Static change only. Verified there are no remaining uncalled `Tensor.is_floating_point` references via grep, and that the correct `dtype.is_floating_point` property usages were not touched. No behavioral change other than the verification path now selecting the correct comparison for integer vs float outputs.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)