### PR TITLE
Add model registry for eomt instance segmentation

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/config.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from lightly_train._configs.config import ConfigsNamespace, PydanticConfig
+from lightly_train._configs.model_registry import ModelRegistry
+
+
+class EoMTInstanceSegmentationConfig(PydanticConfig):
+    backbone_name: str
+
+
+DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY: ModelRegistry[
+    EoMTInstanceSegmentationConfig
+] = ModelRegistry()
+
+
+class DINOv2EoMTInstanceSegmentationConfigRegistry(ConfigsNamespace):
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov2/_vittest14-eomt")
+    class ViTTest(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/_vittest14"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vits14-eomt")
+    class ViTSmall(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vits14"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitb14-eomt")
+    class ViTBase(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vitb14"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitl14-eomt")
+    class ViTLarge(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vitl14"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitg14-eomt")
+    class ViTGiant(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vitg14"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vits14-notpretrained-eomt"
+    )
+    class ViTSmallNotPretrained(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vits14-notpretrained"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vitb14-notpretrained-eomt"
+    )
+    class ViTBaseNotPretrained(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vitb14-notpretrained"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vitl14-notpretrained-eomt"
+    )
+    class ViTLargeNotPretrained(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vitl14-notpretrained"
+
+    @DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vitg14-notpretrained-eomt"
+    )
+    class ViTGiantNotPretrained(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov2/vitg14-notpretrained"

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -30,6 +30,10 @@ from lightly_train._models.dinov2_vit.dinov2_vit_src.layers.attention import Att
 from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
     DinoVisionTransformer,
 )
+from lightly_train._task_models.dinov2_eomt_instance_segmentation.config import (
+    DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY,
+    EoMTInstanceSegmentationConfig,
+)
 from lightly_train._task_models.dinov2_eomt_semantic_segmentation.scale_block import (
     ScaleBlock,
 )
@@ -194,10 +198,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return [
-            f"{name}-{cls.model_suffix}"
-            for name in DINOV2_VIT_PACKAGE.list_model_names()
-        ]
+        return list(DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.list_aliases())
 
     @classmethod
     def is_supported_model(cls, model: str) -> bool:
@@ -217,30 +218,54 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
                 "more information: https://docs.lightly.ai/train/stable/instance_segmentation.html"
             )
 
-        if not model_name.endswith(f"-{cls.model_suffix}"):
-            raise_invalid_name()
-
-        backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
-
+        config: EoMTInstanceSegmentationConfig | None = None
         try:
-            package_name, backbone_name = package_helpers.parse_model_name(
-                backbone_name
-            )
-        except ValueError:
-            raise_invalid_name()
+            config = DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
+                alias=model_name
+            )()
+        except KeyError:
+            pass
 
-        if package_name != DINOV2_VIT_PACKAGE.name:
-            raise_invalid_name()
+        if config is None:
+            if not model_name.endswith(f"-{cls.model_suffix}"):
+                raise_invalid_name()
 
-        try:
-            backbone_name = DINOV2_VIT_PACKAGE.parse_model_name(
-                model_name=backbone_name
+            backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
+
+            try:
+                package_name, backbone_name = package_helpers.parse_model_name(
+                    backbone_name
+                )
+            except ValueError:
+                raise_invalid_name()
+
+            if package_name != DINOV2_VIT_PACKAGE.name:
+                raise_invalid_name()
+
+            try:
+                backbone_name = DINOV2_VIT_PACKAGE.parse_model_name(
+                    model_name=backbone_name
+                )
+            except ValueError:
+                raise_invalid_name()
+
+            normalized_model_name = (
+                f"{DINOV2_VIT_PACKAGE.name}/{backbone_name}-{cls.model_suffix}"
             )
-        except ValueError:
-            raise_invalid_name()
+            try:
+                config = DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
+                    alias=normalized_model_name
+                )()
+            except KeyError:
+                raise_invalid_name()
+
+        assert config is not None
+        package_name, backbone_name = package_helpers.parse_model_name(
+            config.backbone_name
+        )
 
         return {
-            "model_name": f"{DINOV2_VIT_PACKAGE.name}/{backbone_name}-{cls.model_suffix}",
+            "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
             "backbone_name": backbone_name,
         }
 

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/task_model.py
@@ -32,7 +32,6 @@ from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer i
 )
 from lightly_train._task_models.dinov2_eomt_instance_segmentation.config import (
     DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY,
-    EoMTInstanceSegmentationConfig,
 )
 from lightly_train._task_models.dinov2_eomt_semantic_segmentation.scale_block import (
     ScaleBlock,
@@ -100,7 +99,7 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
                 If False, then no pretrained weights are loaded.
         """
         super().__init__(locals(), ignore_args={"backbone_weights", "load_weights"})
-        parsed_name = self.parse_model_name(model_name=model_name)
+        parsed_name = self._resolve_model_name(model_name=model_name)
         self.model_name = parsed_name["model_name"]
         self.classes = classes
         self.image_size = image_size
@@ -202,64 +201,21 @@ class DINOv2EoMTInstanceSegmentation(TaskModel):
 
     @classmethod
     def is_supported_model(cls, model: str) -> bool:
-        try:
-            cls.parse_model_name(model_name=model)
-        except ValueError:
-            return False
-        else:
-            return True
+        return model in DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.list_aliases()
 
     @classmethod
-    def parse_model_name(cls, model_name: str) -> dict[str, str]:
-        def raise_invalid_name() -> None:
-            raise ValueError(
-                f"Model name '{model_name}' is not supported. Available "
-                f"models are: {cls.list_model_names()}. See the documentation for "
-                "more information: https://docs.lightly.ai/train/stable/instance_segmentation.html"
-            )
-
-        config: EoMTInstanceSegmentationConfig | None = None
+    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
         try:
             config = DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
                 alias=model_name
             )()
         except KeyError:
-            pass
+            raise ValueError(
+                f"Model name '{model_name}' is not supported. Available "
+                f"models are: {cls.list_model_names()}. See the documentation for "
+                "more information: https://docs.lightly.ai/train/stable/instance_segmentation.html"
+            ) from None
 
-        if config is None:
-            if not model_name.endswith(f"-{cls.model_suffix}"):
-                raise_invalid_name()
-
-            backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
-
-            try:
-                package_name, backbone_name = package_helpers.parse_model_name(
-                    backbone_name
-                )
-            except ValueError:
-                raise_invalid_name()
-
-            if package_name != DINOV2_VIT_PACKAGE.name:
-                raise_invalid_name()
-
-            try:
-                backbone_name = DINOV2_VIT_PACKAGE.parse_model_name(
-                    model_name=backbone_name
-                )
-            except ValueError:
-                raise_invalid_name()
-
-            normalized_model_name = (
-                f"{DINOV2_VIT_PACKAGE.name}/{backbone_name}-{cls.model_suffix}"
-            )
-            try:
-                config = DINOV2_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
-                    alias=normalized_model_name
-                )()
-            except KeyError:
-                raise_invalid_name()
-
-        assert config is not None
         package_name, backbone_name = package_helpers.parse_model_name(
             config.backbone_name
         )

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/config.py
@@ -1,0 +1,182 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from lightly_train._configs.config import ConfigsNamespace, PydanticConfig
+from lightly_train._configs.model_registry import (
+    DownloadableCheckpoint,
+    ModelAlias,
+    ModelRegistry,
+)
+
+
+class EoMTInstanceSegmentationConfig(PydanticConfig):
+    backbone_name: str
+
+
+DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY: ModelRegistry[
+    EoMTInstanceSegmentationConfig
+] = ModelRegistry()
+
+_DINOV3_VITT16_INST_COCO_URL = "dinov3_vitt16_eomt_inst_coco_260109_45e0aff8.pt"
+_DINOV3_VITT16_INST_COCO_SHA256 = (
+    "45e0aff8c5c8054a3240fcbc368b4e7f87e8066c1e100e3ef9d9c60c7d949a17"
+)
+_DINOV3_VITT16PLUS_INST_COCO_URL = "dinov3_vitt16plus_eomt_inst_coco_260109_0e20aa05.pt"
+_DINOV3_VITT16PLUS_INST_COCO_SHA256 = (
+    "0e20aa05ef15003d7d9462400d32ecc671e7a8d256ae061d42dd4f8978feb621"
+)
+_DINOV3_VITS16_INST_COCO_URL = "/dinov3_eomt/dinov3_vits16_eomt_inst_coco.pt"
+_DINOV3_VITS16_INST_COCO_SHA256 = (
+    "b54dafb12d550958cc5c9818b061fba0d8b819423581d02080221d0199e1cc37"
+)
+_DINOV3_VITB16_INST_COCO_URL = "/dinov3_eomt/dinov3_vitb16_eomt_inst_coco.pt"
+_DINOV3_VITB16_INST_COCO_SHA256 = (
+    "a57b5e7afd5cd64422d74d400f30693f80f96fa63184960250fb0878afd3c7f6"
+)
+_DINOV3_VITL16_INST_COCO_URL = "/dinov3_eomt/dinov3_vitl16_eomt_inst_coco.pt"
+_DINOV3_VITL16_INST_COCO_SHA256 = (
+    "1aac5ac16dcbc1a12cc6f8d4541bea5e7940937a49f0b1dcea7394956b6e46e5"
+)
+
+
+class DINOv3EoMTInstanceSegmentationConfigRegistry(ConfigsNamespace):
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov3/_vittest16-eomt")
+    class ViTTest(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/_vittest16"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitt16-eomt-inst-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITT16_INST_COCO_URL,
+                sha256=_DINOV3_VITT16_INST_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitt16-eomt",
+    )
+    class ViTTiny(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitt16plus-eomt-inst-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITT16PLUS_INST_COCO_URL,
+                sha256=_DINOV3_VITT16PLUS_INST_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitt16plus-eomt",
+    )
+    class ViTTinyPlus(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16plus"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vits16-eomt-inst-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITS16_INST_COCO_URL,
+                sha256=_DINOV3_VITS16_INST_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vits16-eomt",
+    )
+    class ViTSmall(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vits16"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitb16-eomt-inst-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITB16_INST_COCO_URL,
+                sha256=_DINOV3_VITB16_INST_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitb16-eomt",
+    )
+    class ViTBase(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitb16"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitl16-eomt-inst-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITL16_INST_COCO_URL,
+                sha256=_DINOV3_VITL16_INST_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitl16-eomt",
+    )
+    class ViTLarge(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitl16"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16-notpretrained-eomt"
+    )
+    class ViTTinyNotPretrained(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16-notpretrained"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16plus-notpretrained-eomt"
+    )
+    class ViTTinyPlusNotPretrained(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16plus-notpretrained"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16-distillationv1-eomt"
+    )
+    class ViTTinyDistillationV1(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16-distillationv1"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16plus-distillationv1-eomt"
+    )
+    class ViTTinyPlusDistillationV1(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16plus-distillationv1"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vits16plus-eomt")
+    class ViTSmallPlus(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vits16plus"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vith16plus-eomt")
+    class ViTHugePlus(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vith16plus"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vit7b16-eomt")
+    class ViT7B(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vit7b16"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitl16-sat493m-eomt"
+    )
+    class ViTLargeSAT493M(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitl16-sat493m"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vit7b16-sat493m-eomt"
+    )
+    class ViT7BSAT493M(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vit7b16-sat493m"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16-eupe-eomt"
+    )
+    class ViTTinyEUPE(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16-eupe"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vits16-eupe-eomt"
+    )
+    class ViTSmallEUPE(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vits16-eupe"
+
+    @DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitb16-eupe-eomt"
+    )
+    class ViTBaseEUPE(EoMTInstanceSegmentationConfig):
+        backbone_name: str = "dinov3/vitb16-eupe"

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -32,6 +32,10 @@ from lightly_train._models.dinov3.dinov3_src.layers.attention import (
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
 )
+from lightly_train._task_models.dinov3_eomt_instance_segmentation.config import (
+    DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY,
+    EoMTInstanceSegmentationConfig,
+)
 from lightly_train._task_models.dinov3_eomt_instance_segmentation.scale_block import (
     ScaleBlock,
 )
@@ -195,9 +199,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return [
-            f"{name}-{cls.model_suffix}" for name in DINOV3_PACKAGE.list_model_names()
-        ]
+        return list(DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.list_aliases())
 
     @classmethod
     def is_supported_model(cls, model: str) -> bool:
@@ -217,28 +219,54 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
                 "more information: https://docs.lightly.ai/train/stable/instance_segmentation.html"
             )
 
-        if not model_name.endswith(f"-{cls.model_suffix}"):
-            raise_invalid_name()
-
-        backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
-
+        config: EoMTInstanceSegmentationConfig | None = None
         try:
-            package_name, backbone_name = package_helpers.parse_model_name(
-                backbone_name
+            config = DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
+                alias=model_name
+            )()
+        except KeyError:
+            pass
+
+        if config is None:
+            if not model_name.endswith(f"-{cls.model_suffix}"):
+                raise_invalid_name()
+
+            backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
+
+            try:
+                package_name, backbone_name = package_helpers.parse_model_name(
+                    backbone_name
+                )
+            except ValueError:
+                raise_invalid_name()
+
+            if package_name != DINOV3_PACKAGE.name:
+                raise_invalid_name()
+
+            try:
+                backbone_name = DINOV3_PACKAGE.parse_model_name(
+                    model_name=backbone_name
+                )
+            except ValueError:
+                raise_invalid_name()
+
+            normalized_model_name = (
+                f"{DINOV3_PACKAGE.name}/{backbone_name}-{cls.model_suffix}"
             )
-        except ValueError:
-            raise_invalid_name()
+            try:
+                config = DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
+                    alias=normalized_model_name
+                )()
+            except KeyError:
+                raise_invalid_name()
 
-        if package_name != DINOV3_PACKAGE.name:
-            raise_invalid_name()
-
-        try:
-            backbone_name = DINOV3_PACKAGE.parse_model_name(model_name=backbone_name)
-        except ValueError:
-            raise_invalid_name()
+        assert config is not None
+        package_name, backbone_name = package_helpers.parse_model_name(
+            config.backbone_name
+        )
 
         return {
-            "model_name": f"{DINOV3_PACKAGE.name}/{backbone_name}-{cls.model_suffix}",
+            "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
             "backbone_name": backbone_name,
         }
 

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/task_model.py
@@ -34,7 +34,6 @@ from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
 )
 from lightly_train._task_models.dinov3_eomt_instance_segmentation.config import (
     DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY,
-    EoMTInstanceSegmentationConfig,
 )
 from lightly_train._task_models.dinov3_eomt_instance_segmentation.scale_block import (
     ScaleBlock,
@@ -102,7 +101,7 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
                 If False, then no pretrained weights are loaded.
         """
         super().__init__(locals(), ignore_args={"backbone_weights", "load_weights"})
-        parsed_name = self.parse_model_name(model_name=model_name)
+        parsed_name = self._resolve_model_name(model_name=model_name)
         self.model_name = parsed_name["model_name"]
         self.classes = classes
         self.image_size = image_size
@@ -203,64 +202,21 @@ class DINOv3EoMTInstanceSegmentation(TaskModel):
 
     @classmethod
     def is_supported_model(cls, model: str) -> bool:
-        try:
-            cls.parse_model_name(model_name=model)
-        except ValueError:
-            return False
-        else:
-            return True
+        return model in DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.list_aliases()
 
     @classmethod
-    def parse_model_name(cls, model_name: str) -> dict[str, str]:
-        def raise_invalid_name() -> None:
-            raise ValueError(
-                f"Model name '{model_name}' is not supported. Available "
-                f"models are: {cls.list_model_names()}. See the documentation for "
-                "more information: https://docs.lightly.ai/train/stable/instance_segmentation.html"
-            )
-
-        config: EoMTInstanceSegmentationConfig | None = None
+    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
         try:
             config = DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
                 alias=model_name
             )()
         except KeyError:
-            pass
+            raise ValueError(
+                f"Model name '{model_name}' is not supported. Available "
+                f"models are: {cls.list_model_names()}. See the documentation for "
+                "more information: https://docs.lightly.ai/train/stable/instance_segmentation.html"
+            ) from None
 
-        if config is None:
-            if not model_name.endswith(f"-{cls.model_suffix}"):
-                raise_invalid_name()
-
-            backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
-
-            try:
-                package_name, backbone_name = package_helpers.parse_model_name(
-                    backbone_name
-                )
-            except ValueError:
-                raise_invalid_name()
-
-            if package_name != DINOV3_PACKAGE.name:
-                raise_invalid_name()
-
-            try:
-                backbone_name = DINOV3_PACKAGE.parse_model_name(
-                    model_name=backbone_name
-                )
-            except ValueError:
-                raise_invalid_name()
-
-            normalized_model_name = (
-                f"{DINOV3_PACKAGE.name}/{backbone_name}-{cls.model_suffix}"
-            )
-            try:
-                config = DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get(
-                    alias=normalized_model_name
-                )()
-            except KeyError:
-                raise_invalid_name()
-
-        assert config is not None
         package_name, backbone_name = package_helpers.parse_model_name(
             config.backbone_name
         )

--- a/src/lightly_train/_task_models/task_model_helpers.py
+++ b/src/lightly_train/_task_models/task_model_helpers.py
@@ -19,7 +19,11 @@ from typing import Any, Literal, NoReturn
 import torch
 
 from lightly_train._commands import common_helpers
+from lightly_train._configs.model_registry import ModelRegistry
 from lightly_train._env import Env
+from lightly_train._task_models.dinov3_eomt_instance_segmentation.config import (
+    DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY,
+)
 from lightly_train._task_models.ltdetr_object_detection.config import (
     LTDETR_MODEL_REGISTRY,
 )
@@ -52,11 +56,13 @@ _GENERIC_LTDETR_OBJECT_DETECTION_CLASS_PATH = (
 )
 
 
-def _get_ltdetr_downloadable_model_url_and_hashes() -> dict[str, tuple[str, str]]:
+def _get_downloadable_model_url_and_hashes(
+    registry: ModelRegistry[Any],
+) -> dict[str, tuple[str, str]]:
     downloadable_model_url_and_hashes = {}
-    for alias in LTDETR_MODEL_REGISTRY.list_aliases():
+    for alias in registry.list_aliases():
         try:
-            checkpoint = LTDETR_MODEL_REGISTRY.get_alias_metadata(
+            checkpoint = registry.get_alias_metadata(
                 alias=alias
             ).downloadable_checkpoint
         except KeyError:
@@ -81,27 +87,6 @@ DOWNLOADABLE_MODEL_URL_AND_HASH: dict[str, tuple[str, str]] = {
     "picodet-l-coco": (
         "picodet_l_coco_640_260303_b1a16990.pt",
         "b1a16990fe4f86fe60aefb2dcb4bf97ead9cc616f6c14ce4638aa2b838351fff",
-    ),
-    #### Instance Segmentation
-    "dinov3/vitt16-eomt-inst-coco": (  # 6x schedule
-        "dinov3_vitt16_eomt_inst_coco_260109_45e0aff8.pt",
-        "45e0aff8c5c8054a3240fcbc368b4e7f87e8066c1e100e3ef9d9c60c7d949a17",
-    ),
-    "dinov3/vitt16plus-eomt-inst-coco": (  # 6x schedule
-        "dinov3_vitt16plus_eomt_inst_coco_260109_0e20aa05.pt",
-        "0e20aa05ef15003d7d9462400d32ecc671e7a8d256ae061d42dd4f8978feb621",
-    ),
-    "dinov3/vits16-eomt-inst-coco": (
-        "/dinov3_eomt/dinov3_vits16_eomt_inst_coco.pt",
-        "b54dafb12d550958cc5c9818b061fba0d8b819423581d02080221d0199e1cc37",
-    ),
-    "dinov3/vitb16-eomt-inst-coco": (
-        "/dinov3_eomt/dinov3_vitb16_eomt_inst_coco.pt",
-        "a57b5e7afd5cd64422d74d400f30693f80f96fa63184960250fb0878afd3c7f6",
-    ),
-    "dinov3/vitl16-eomt-inst-coco": (
-        "/dinov3_eomt/dinov3_vitl16_eomt_inst_coco.pt",
-        "1aac5ac16dcbc1a12cc6f8d4541bea5e7940937a49f0b1dcea7394956b6e46e5",
     ),
     #### Panoptic Segmentation
     # Trained with 4x schedule (360k steps and the masking schedule of 90K steps)
@@ -218,7 +203,14 @@ DOWNLOADABLE_MODEL_URL_AND_HASH: dict[str, tuple[str, str]] = {
         "d59577016e01635c285fac76f44685d7a0878545e0b8d560da45c0cf4d058548",
     ),
 }
-DOWNLOADABLE_MODEL_URL_AND_HASH.update(_get_ltdetr_downloadable_model_url_and_hashes())
+DOWNLOADABLE_MODEL_URL_AND_HASH.update(
+    _get_downloadable_model_url_and_hashes(
+        DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY
+    )
+)
+DOWNLOADABLE_MODEL_URL_AND_HASH.update(
+    _get_downloadable_model_url_and_hashes(LTDETR_MODEL_REGISTRY)
+)
 
 
 def load_model(

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
@@ -40,9 +40,16 @@ def test_list_model_names__uses_registry() -> None:
     assert "dinov2/vits14-notpretrained-eomt" in names
 
 
-def test_parse_model_name__uses_registry() -> None:
-    parsed = DINOv2EoMTInstanceSegmentation.parse_model_name("dinov2/vits14-eomt")
+def test_is_supported_model__uses_registry() -> None:
+    assert DINOv2EoMTInstanceSegmentation.is_supported_model("dinov2/vits14-eomt")
+    assert DINOv2EoMTInstanceSegmentation.is_supported_model(
+        "dinov2/vits14-notpretrained-eomt"
+    )
+    assert not DINOv2EoMTInstanceSegmentation.is_supported_model(
+        "dinov2/vits14_pretrain-eomt"
+    )
 
+    parsed = DINOv2EoMTInstanceSegmentation._resolve_model_name("dinov2/vits14-eomt")
     assert parsed == {
         "model_name": "dinov2/vits14-eomt",
         "backbone_name": "vits14",

--- a/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_instance_segmentation/test_task_model.py
@@ -32,6 +32,23 @@ def model() -> DINOv2EoMTInstanceSegmentation:
     )
 
 
+def test_list_model_names__uses_registry() -> None:
+    names = DINOv2EoMTInstanceSegmentation.list_model_names()
+
+    assert "dinov2/_vittest14-eomt" in names
+    assert "dinov2/vits14-eomt" in names
+    assert "dinov2/vits14-notpretrained-eomt" in names
+
+
+def test_parse_model_name__uses_registry() -> None:
+    parsed = DINOv2EoMTInstanceSegmentation.parse_model_name("dinov2/vits14-eomt")
+
+    assert parsed == {
+        "model_name": "dinov2/vits14-eomt",
+        "backbone_name": "vits14",
+    }
+
+
 def test_predict_batch__composes_stages_in_order(
     model: DINOv2EoMTInstanceSegmentation, mocker: MockerFixture
 ) -> None:

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -36,6 +36,26 @@ def model() -> DINOv3EoMTInstanceSegmentation:
     )
 
 
+def test_list_model_names__uses_registry() -> None:
+    names = DINOv3EoMTInstanceSegmentation.list_model_names()
+
+    assert "dinov3/_vittest16-eomt" in names
+    assert "dinov3/vits16-eomt" in names
+    assert "dinov3/vits16-eomt-inst-coco" in names
+    assert "dinov3/convnext-tiny-eomt" not in names
+
+
+def test_parse_model_name__hosted_alias_uses_canonical_model_name() -> None:
+    parsed = DINOv3EoMTInstanceSegmentation.parse_model_name(
+        "dinov3/vits16-eomt-inst-coco"
+    )
+
+    assert parsed == {
+        "model_name": "dinov3/vits16-eomt",
+        "backbone_name": "vits16",
+    }
+
+
 def test_predict_batch__composes_stages_in_order(
     model: DINOv3EoMTInstanceSegmentation, mocker: MockerFixture
 ) -> None:

--- a/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_instance_segmentation/test_task_model.py
@@ -45,11 +45,18 @@ def test_list_model_names__uses_registry() -> None:
     assert "dinov3/convnext-tiny-eomt" not in names
 
 
-def test_parse_model_name__hosted_alias_uses_canonical_model_name() -> None:
-    parsed = DINOv3EoMTInstanceSegmentation.parse_model_name(
+def test_is_supported_model__uses_registry() -> None:
+    assert DINOv3EoMTInstanceSegmentation.is_supported_model("dinov3/vits16-eomt")
+    assert DINOv3EoMTInstanceSegmentation.is_supported_model(
         "dinov3/vits16-eomt-inst-coco"
     )
+    assert not DINOv3EoMTInstanceSegmentation.is_supported_model(
+        "dinov3/convnext-tiny-eomt"
+    )
 
+    parsed = DINOv3EoMTInstanceSegmentation._resolve_model_name(
+        "dinov3/vits16-eomt-inst-coco"
+    )
     assert parsed == {
         "model_name": "dinov3/vits16-eomt",
         "backbone_name": "vits16",

--- a/tests/_task_models/test_task_model_helpers.py
+++ b/tests/_task_models/test_task_model_helpers.py
@@ -17,6 +17,9 @@ from torch.hub import download_url_to_file
 
 from lightly_train import load_model
 from lightly_train._task_models import task_model_helpers
+from lightly_train._task_models.dinov3_eomt_instance_segmentation.config import (
+    DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY,
+)
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model import (
     DINOv3EoMTSemanticSegmentation,
 )
@@ -71,6 +74,27 @@ def test_downloadable_model__ltdetrv2_s_coco_alias() -> None:
     # identical file regardless of which name the user passes.
     d = task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH
     assert d["ltdetrv2-s-coco"] == d["edgecrafter/ecvitt-ltdetr-coco"]
+
+
+def test_downloadable_model__dinov3_eomt_instance_aliases_from_registry() -> None:
+    aliases = [
+        "dinov3/vitt16-eomt-inst-coco",
+        "dinov3/vitt16plus-eomt-inst-coco",
+        "dinov3/vits16-eomt-inst-coco",
+        "dinov3/vitb16-eomt-inst-coco",
+        "dinov3/vitl16-eomt-inst-coco",
+    ]
+
+    for alias in aliases:
+        checkpoint = (
+            DINOV3_EOMT_INSTANCE_SEGMENTATION_MODEL_REGISTRY.get_alias_metadata(
+                alias
+            ).downloadable_checkpoint
+        )
+        assert task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH[alias] == (
+            checkpoint.url,
+            checkpoint.sha256,
+        )
 
 
 def test_download_checkpoint__non_hosted_dav2__raises_convert_guidance() -> None:


### PR DESCRIPTION
## What has changed and why?
- adds `config.py` files with model registries to the DINOv2 and DINOv3 EoMT instance segmentation models

## How has it been tested?
- unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
