### PR TITLE
Model registry for EoMT Semantic Segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- Remove the DINOv3 EoMT semantic segmentation training `model_args.patch_size` option.
+  The patch size is now determined by the selected model name; use a
+  `dinov3/vit*32-eomt` model, such as `dinov3/vits32-eomt-coco`, to train with patch
+  size 32.
+
 ### Fixed
 
 - Fix ONNX export verification for task models: `Tensor.is_floating_point` was

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -206,8 +206,10 @@ if __name__ == "__main__":
 
 ### Changing the Patch Size
 
-Increasing the patch size is an effective way to speed up inference and training. You
-can change the patch size via the `model_args` parameter:
+Increasing the patch size is an effective way to speed up inference and training. The
+patch size is encoded in the model name: for DINOv3 ViT models, `dinov3/vits16-eomt`
+uses a patch size of 16, while `dinov3/vits32-eomt` uses a patch size of 32. To train at
+a larger patch size, simply select a `vit*32` model:
 
 ```python
 import lightly_train
@@ -216,18 +218,16 @@ if __name__ == "__main__":
 
     lightly_train.train_semantic_segmentation(
         out="out/my_experiment",
-        model="dinov3/vits16-eomt-coco",
-        model_args={"patch_size": 32},
+        model="dinov3/vits32-eomt-coco",
         # ...,
     )
 ```
 
-As shown above, the patch size can be set to a value different from the one used in the
-pretrained model without harming compatibility of the pretrained weights. For DINOv3 ViT
-models, the patch size encoded in the model name is just the default;
-`model_args["patch_size"]` overrides it and LightlyTrain logs a warning if they differ.
-Internally, the patch embedding weights are automatically resized to the requested patch
-size using the method introduced in [FlexiViT](https://arxiv.org/pdf/2212.08013).
+The patch-32 checkpoints are derived from the corresponding patch-16 pretrained weights
+by resizing the patch embedding using the method introduced in
+[FlexiViT](https://arxiv.org/pdf/2212.08013), so the pretrained weights remain
+compatible. The available models are listed
+[here](#semantic-segmentation-benchmark-results) in the "Model" column of the tables.
 
 As illustrated in this {ref}`figure <fig-miou-latency>`, increasing the patch size leads
 to a significant speed-up with only a moderate impact on performance.

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/config.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/config.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from lightly_train._configs.config import ConfigsNamespace, PydanticConfig
+from lightly_train._configs.model_registry import ModelRegistry
+
+
+class EoMTSemanticSegmentationConfig(PydanticConfig):
+    backbone_name: str
+    patch_size: int
+
+
+DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY: ModelRegistry[
+    EoMTSemanticSegmentationConfig
+] = ModelRegistry()
+
+
+class DINOv2EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/_vittest14-eomt")
+    class ViTTest(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/_vittest14"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vits14-eomt")
+    class ViTSmall(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vits14"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitb14-eomt")
+    class ViTBase(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vitb14"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitl14-eomt")
+    class ViTLarge(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vitl14"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitg14-eomt")
+    class ViTGiant(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vitg14"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vits14-notpretrained-eomt"
+    )
+    class ViTSmallNotPretrained(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vits14-notpretrained"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vitb14-notpretrained-eomt"
+    )
+    class ViTBaseNotPretrained(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vitb14-notpretrained"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vitl14-notpretrained-eomt"
+    )
+    class ViTLargeNotPretrained(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vitl14-notpretrained"
+        patch_size: int = 14
+
+    @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov2/vitg14-notpretrained-eomt"
+    )
+    class ViTGiantNotPretrained(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov2/vitg14-notpretrained"
+        patch_size: int = 14

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/config.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/config.py
@@ -13,7 +13,6 @@ from lightly_train._configs.model_registry import ModelRegistry
 
 class EoMTSemanticSegmentationConfig(PydanticConfig):
     backbone_name: str
-    patch_size: int
 
 
 DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY: ModelRegistry[
@@ -25,52 +24,43 @@ class DINOv2EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/_vittest14-eomt")
     class ViTTest(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/_vittest14"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vits14-eomt")
     class ViTSmall(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vits14"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitb14-eomt")
     class ViTBase(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vitb14"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitl14-eomt")
     class ViTLarge(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vitl14"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov2/vitg14-eomt")
     class ViTGiant(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vitg14"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov2/vits14-notpretrained-eomt"
     )
     class ViTSmallNotPretrained(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vits14-notpretrained"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov2/vitb14-notpretrained-eomt"
     )
     class ViTBaseNotPretrained(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vitb14-notpretrained"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov2/vitl14-notpretrained-eomt"
     )
     class ViTLargeNotPretrained(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vitl14-notpretrained"
-        patch_size: int = 14
 
     @DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov2/vitg14-notpretrained-eomt"
     )
     class ViTGiantNotPretrained(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov2/vitg14-notpretrained"
-        patch_size: int = 14

--- a/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_semantic_segmentation/task_model.py
@@ -30,6 +30,9 @@ from lightly_train._models.dinov2_vit.dinov2_vit_src.layers.attention import Att
 from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
     DinoVisionTransformer,
 )
+from lightly_train._task_models.dinov2_eomt_semantic_segmentation.config import (
+    DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
+)
 from lightly_train._task_models.dinov2_eomt_semantic_segmentation.scale_block import (
     ScaleBlock,
 )
@@ -97,7 +100,7 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
                 If False, then no pretrained weights are loaded.
         """
         super().__init__(locals(), ignore_args={"backbone_weights", "load_weights"})
-        parsed_name = self.parse_model_name(model_name=model_name)
+        parsed_name = self._resolve_model_name(model_name=model_name)
         self.model_name = parsed_name["model_name"]
         self.classes = classes
         self.class_ignore_index = class_ignore_index
@@ -203,55 +206,37 @@ class DINOv2EoMTSemanticSegmentation(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return [
-            f"{name}-{cls.model_suffix}"
-            for name in DINOV2_VIT_PACKAGE.list_model_names()
-        ]
+        return list(DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.list_aliases())
 
     @classmethod
     def is_supported_model(cls, model: str) -> bool:
-        try:
-            cls.parse_model_name(model_name=model)
-        except ValueError:
-            return False
-        else:
-            return True
+        return model in DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.list_aliases()
 
     @classmethod
-    def parse_model_name(cls, model_name: str) -> dict[str, str]:
-        def raise_invalid_name() -> None:
+    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
+        try:
+            config = DINOV2_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.get(
+                alias=model_name
+            )()
+        except KeyError:
             raise ValueError(
                 f"Model name '{model_name}' is not supported. Available "
                 f"models are: {cls.list_model_names()}. See the documentation for "
                 "more information: https://docs.lightly.ai/train/stable/semantic_segmentation.html"
-            )
+            ) from None
 
-        if not model_name.endswith(f"-{cls.model_suffix}"):
-            raise_invalid_name()
-
-        backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
-
-        try:
-            package_name, backbone_name = package_helpers.parse_model_name(
-                backbone_name
-            )
-        except ValueError:
-            raise_invalid_name()
-
-        if package_name != DINOV2_VIT_PACKAGE.name:
-            raise_invalid_name()
-
-        try:
-            backbone_name = DINOV2_VIT_PACKAGE.parse_model_name(
-                model_name=backbone_name
-            )
-        except ValueError:
-            raise_invalid_name()
+        package_name, backbone_name = package_helpers.parse_model_name(
+            config.backbone_name
+        )
 
         return {
-            "model_name": f"{DINOV2_VIT_PACKAGE.name}/{backbone_name}-{cls.model_suffix}",
+            "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
             "backbone_name": backbone_name,
         }
+
+    @classmethod
+    def parse_model_name(cls, model_name: str) -> dict[str, str]:
+        return cls._resolve_model_name(model_name=model_name)
 
     @torch.no_grad()
     def predict(self, image: PathLike | PILImage | Tensor) -> Tensor:

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/config.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/config.py
@@ -1,0 +1,367 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from lightly_train._configs.config import ConfigsNamespace, PydanticConfig
+from lightly_train._configs.model_registry import (
+    DownloadableCheckpoint,
+    ModelAlias,
+    ModelRegistry,
+)
+
+
+class EoMTSemanticSegmentationConfig(PydanticConfig):
+    backbone_name: str
+    patch_size: int
+
+
+DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY: ModelRegistry[
+    EoMTSemanticSegmentationConfig
+] = ModelRegistry()
+
+_DINOV3_VITT16_COCO_URL = "dinov3_vitt16_eomt_coco_260106_104e563e.pt"
+_DINOV3_VITT16_COCO_SHA256 = (
+    "104e563ebcd8b7d2842db5f0cc6f8d0e67f1607a063ab818725e9af6f6fe7c27"
+)
+_DINOV3_VITT16PLUS_COCO_URL = "dinov3_vitt16plus_eomt_coco_260106_68339a7d.pt"
+_DINOV3_VITT16PLUS_COCO_SHA256 = (
+    "68339a7d5baa0dd6fdd88660410939eb78fc8a8c9332145b9b8ac91a2291950b"
+)
+_DINOV3_VITS16_COCO_URL = "dinov3_vits16_eomt_coco_260105_11be50b5.pt"
+_DINOV3_VITS16_COCO_SHA256 = (
+    "11be50b578251c974b1fdb413c76e2cd7cfe1e154f6118556bd87477ea205d5a"
+)
+_DINOV3_VITB16_COCO_URL = "dinov3_vitb16_eomt_coco_260105_92de5e05.pt"
+_DINOV3_VITB16_COCO_SHA256 = (
+    "92de5e0550f51647e201eef3537a35a8bba75b4e41323b9a7df3c54e6ab400b9"
+)
+_DINOV3_VITL16_COCO_URL = "dinov3_vitl16_eomt_coco_260105_6169fdd8.pt"
+_DINOV3_VITL16_COCO_SHA256 = (
+    "6169fdd8edf7d4648c45c6aa1d09b9a4e917ba51dcbd36acf8fbf04a25d1e516"
+)
+_DINOV3_VITT32_COCO_URL = "dinov3_vitt32_eomt_coco_260106_3ce75c95.pt"
+_DINOV3_VITT32_COCO_SHA256 = (
+    "3ce75c958aa0d31e3ac14d0bc1e0ca34ccb5b9ab5b141ec40c7f83c1950a2186"
+)
+_DINOV3_VITT32PLUS_COCO_URL = "dinov3_vitt32plus_eomt_coco_260106_68e19609.pt"
+_DINOV3_VITT32PLUS_COCO_SHA256 = (
+    "68e196093301bc8a4e73005cebe1cccca75f5c14e58e732d1d9c555ea44e2088"
+)
+_DINOV3_VITS32_COCO_URL = "dinov3_vits32_eomt_coco_260106_06595b53.pt"
+_DINOV3_VITS32_COCO_SHA256 = (
+    "06595b53b0ee63032e8f7882a2d1e877c84b996c8313727a6694abf42e871d05"
+)
+_DINOV3_VITB32_COCO_URL = "dinov3_vitb32_eomt_coco_260106_62cf509e.pt"
+_DINOV3_VITB32_COCO_SHA256 = (
+    "62cf509e156257347274837087592f27743ba51722c4949bec90688859cc6b6a"
+)
+_DINOV3_VITL32_COCO_URL = "dinov3_vitl32_eomt_coco_260106_f51348fb.pt"
+_DINOV3_VITL32_COCO_SHA256 = (
+    "f51348fb4c794889ae35b8d9e2cfe383b42e09e975d2854f2e96fed155edd7d9"
+)
+_DINOV3_VITS16_CITYSCAPES_URL = (
+    "dinov3_eomt/lightlytrain_dinov3_eomt_vits16_cityscapes.pt"
+)
+_DINOV3_VITS16_CITYSCAPES_SHA256 = (
+    "ef7d54eac202bb0a6707fd7115b689a748d032037eccaa3a6891b57b83f18b7e"
+)
+_DINOV3_VITB16_CITYSCAPES_URL = (
+    "dinov3_eomt/lightlytrain_dinov3_eomt_vitb16_cityscapes.pt"
+)
+_DINOV3_VITB16_CITYSCAPES_SHA256 = (
+    "e78e6b1f372ac15c860f64445d8265fd5e9d60271509e106a92b7162096c9560"
+)
+_DINOV3_VITL16_CITYSCAPES_URL = (
+    "dinov3_eomt/lightlytrain_dinov3_eomt_vitl16_cityscapes.pt"
+)
+_DINOV3_VITL16_CITYSCAPES_SHA256 = (
+    "3f397e6ca0af4555adb1da9efa489b734e35fbeac15b4c18e408c63922b41f6c"
+)
+_DINOV3_VITS16_ADE20K_URL = (
+    "dinov3_eomt/lightlytrain_dinov3_eomt_vits16_autolabel_sun397.pt"
+)
+_DINOV3_VITS16_ADE20K_SHA256 = (
+    "f9f002e5adff875e0a97a3b310c26fe5e10c26d69af4e830a4a67aa7dda330aa"
+)
+_DINOV3_VITB16_ADE20K_URL = (
+    "dinov3_eomt/lightlytrain_dinov3_eomt_vitb16_autolabel_sun397.pt"
+)
+_DINOV3_VITB16_ADE20K_SHA256 = (
+    "400f7a1b42a7b67babf253d6aade0be334173d70e7351a01159698ac2d2335ca"
+)
+_DINOV3_VITL16_ADE20K_URL = "dinov3_eomt/lightlytrain_dinov3_eomt_vitl16_ade20k.pt"
+_DINOV3_VITL16_ADE20K_SHA256 = (
+    "eb31183c70edd4df8923cba54ce2eefa517ae328cf3caf0106d2795e34382f8f"
+)
+
+
+class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/_vittest16-eomt")
+    class ViTTest(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/_vittest16"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitt16-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITT16_COCO_URL,
+                sha256=_DINOV3_VITT16_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitt16-eomt",
+    )
+    class ViTTiny16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitt16plus-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITT16PLUS_COCO_URL,
+                sha256=_DINOV3_VITT16PLUS_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitt16plus-eomt",
+    )
+    class ViTTinyPlus16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16plus"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16-notpretrained-eomt"
+    )
+    class ViTTinyNotPretrained16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16-notpretrained"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16plus-notpretrained-eomt"
+    )
+    class ViTTinyPlusNotPretrained16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16plus-notpretrained"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16-distillationv1-eomt"
+    )
+    class ViTTinyDistillationV116(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16-distillationv1"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16plus-distillationv1-eomt"
+    )
+    class ViTTinyPlusDistillationV116(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16plus-distillationv1"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vits16-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITS16_COCO_URL,
+                sha256=_DINOV3_VITS16_COCO_SHA256,
+            ),
+        ),
+        ModelAlias(
+            name="dinov3/vits16-eomt-cityscapes",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITS16_CITYSCAPES_URL,
+                sha256=_DINOV3_VITS16_CITYSCAPES_SHA256,
+            ),
+        ),
+        ModelAlias(
+            name="dinov3/vits16-eomt-ade20k",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITS16_ADE20K_URL,
+                sha256=_DINOV3_VITS16_ADE20K_SHA256,
+            ),
+        ),
+        "dinov3/vits16-eomt",
+    )
+    class ViTSmall16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vits16"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vits16plus-eomt")
+    class ViTSmallPlus16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vits16plus"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitb16-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITB16_COCO_URL,
+                sha256=_DINOV3_VITB16_COCO_SHA256,
+            ),
+        ),
+        ModelAlias(
+            name="dinov3/vitb16-eomt-cityscapes",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITB16_CITYSCAPES_URL,
+                sha256=_DINOV3_VITB16_CITYSCAPES_SHA256,
+            ),
+        ),
+        ModelAlias(
+            name="dinov3/vitb16-eomt-ade20k",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITB16_ADE20K_URL,
+                sha256=_DINOV3_VITB16_ADE20K_SHA256,
+            ),
+        ),
+        "dinov3/vitb16-eomt",
+    )
+    class ViTBase16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitb16"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitl16-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITL16_COCO_URL,
+                sha256=_DINOV3_VITL16_COCO_SHA256,
+            ),
+        ),
+        ModelAlias(
+            name="dinov3/vitl16-eomt-cityscapes",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITL16_CITYSCAPES_URL,
+                sha256=_DINOV3_VITL16_CITYSCAPES_SHA256,
+            ),
+        ),
+        ModelAlias(
+            name="dinov3/vitl16-eomt-ade20k",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITL16_ADE20K_URL,
+                sha256=_DINOV3_VITL16_ADE20K_SHA256,
+            ),
+        ),
+        "dinov3/vitl16-eomt",
+    )
+    class ViTLarge16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitl16"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vith16plus-eomt")
+    class ViTHugePlus16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vith16plus"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vit7b16-eomt")
+    class ViT7B16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vit7b16"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitl16-sat493m-eomt"
+    )
+    class ViTLargeSAT493M16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitl16-sat493m"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vit7b16-sat493m-eomt"
+    )
+    class ViT7BSAT493M16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vit7b16-sat493m"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitt16-eupe-eomt"
+    )
+    class ViTTinyEUPE16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt16-eupe"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vits16-eupe-eomt"
+    )
+    class ViTSmallEUPE16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vits16-eupe"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        "dinov3/vitb16-eupe-eomt"
+    )
+    class ViTBaseEUPE16(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitb16-eupe"
+        patch_size: int = 16
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitt32-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITT32_COCO_URL,
+                sha256=_DINOV3_VITT32_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitt32-eomt",
+    )
+    class ViTTiny32(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt32"
+        patch_size: int = 32
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitt32plus-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITT32PLUS_COCO_URL,
+                sha256=_DINOV3_VITT32PLUS_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitt32plus-eomt",
+    )
+    class ViTTinyPlus32(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitt32plus"
+        patch_size: int = 32
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vits32-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITS32_COCO_URL,
+                sha256=_DINOV3_VITS32_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vits32-eomt",
+    )
+    class ViTSmall32(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vits32"
+        patch_size: int = 32
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitb32-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITB32_COCO_URL,
+                sha256=_DINOV3_VITB32_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitb32-eomt",
+    )
+    class ViTBase32(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitb32"
+        patch_size: int = 32
+
+    @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
+        ModelAlias(
+            name="dinov3/vitl32-eomt-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_DINOV3_VITL32_COCO_URL,
+                sha256=_DINOV3_VITL32_COCO_SHA256,
+            ),
+        ),
+        "dinov3/vitl32-eomt",
+    )
+    class ViTLarge32(EoMTSemanticSegmentationConfig):
+        backbone_name: str = "dinov3/vitl32"
+        patch_size: int = 32

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/config.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/config.py
@@ -7,6 +7,8 @@
 #
 from __future__ import annotations
 
+from pydantic import Field
+
 from lightly_train._configs.config import ConfigsNamespace, PydanticConfig
 from lightly_train._configs.model_registry import (
     DownloadableCheckpoint,
@@ -15,9 +17,13 @@ from lightly_train._configs.model_registry import (
 )
 
 
+class BackboneArgs(PydanticConfig):
+    patch_size: int = 16
+
+
 class EoMTSemanticSegmentationConfig(PydanticConfig):
     backbone_name: str
-    patch_size: int
+    backbone_args: BackboneArgs = Field(default_factory=BackboneArgs)
 
 
 DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY: ModelRegistry[
@@ -104,7 +110,6 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/_vittest16-eomt")
     class ViTTest(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/_vittest16"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -118,7 +123,6 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTTiny16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -132,35 +136,30 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTTinyPlus16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16plus"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitt16-notpretrained-eomt"
     )
     class ViTTinyNotPretrained16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16-notpretrained"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitt16plus-notpretrained-eomt"
     )
     class ViTTinyPlusNotPretrained16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16plus-notpretrained"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitt16-distillationv1-eomt"
     )
     class ViTTinyDistillationV116(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16-distillationv1"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitt16plus-distillationv1-eomt"
     )
     class ViTTinyPlusDistillationV116(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16plus-distillationv1"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -188,12 +187,10 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTSmall16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vits16"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vits16plus-eomt")
     class ViTSmallPlus16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vits16plus"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -221,7 +218,6 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTBase16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitb16"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -249,52 +245,44 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTLarge16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitl16"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vith16plus-eomt")
     class ViTHugePlus16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vith16plus"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register("dinov3/vit7b16-eomt")
     class ViT7B16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vit7b16"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitl16-sat493m-eomt"
     )
     class ViTLargeSAT493M16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitl16-sat493m"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vit7b16-sat493m-eomt"
     )
     class ViT7BSAT493M16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vit7b16-sat493m"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitt16-eupe-eomt"
     )
     class ViTTinyEUPE16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt16-eupe"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vits16-eupe-eomt"
     )
     class ViTSmallEUPE16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vits16-eupe"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         "dinov3/vitb16-eupe-eomt"
     )
     class ViTBaseEUPE16(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitb16-eupe"
-        patch_size: int = 16
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -308,7 +296,9 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTTiny32(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt32"
-        patch_size: int = 32
+        backbone_args: BackboneArgs = Field(
+            default_factory=lambda: BackboneArgs(patch_size=32)
+        )
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -322,7 +312,9 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTTinyPlus32(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitt32plus"
-        patch_size: int = 32
+        backbone_args: BackboneArgs = Field(
+            default_factory=lambda: BackboneArgs(patch_size=32)
+        )
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -336,7 +328,9 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTSmall32(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vits32"
-        patch_size: int = 32
+        backbone_args: BackboneArgs = Field(
+            default_factory=lambda: BackboneArgs(patch_size=32)
+        )
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -350,7 +344,9 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTBase32(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitb32"
-        patch_size: int = 32
+        backbone_args: BackboneArgs = Field(
+            default_factory=lambda: BackboneArgs(patch_size=32)
+        )
 
     @DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.register(
         ModelAlias(
@@ -364,4 +360,6 @@ class DINOv3EoMTSemanticSegmentationConfigRegistry(ConfigsNamespace):
     )
     class ViTLarge32(EoMTSemanticSegmentationConfig):
         backbone_name: str = "dinov3/vitl32"
-        patch_size: int = 32
+        backbone_args: BackboneArgs = Field(
+            default_factory=lambda: BackboneArgs(patch_size=32)
+        )

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -114,8 +114,10 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
             locals(), ignore_args={"backbone_weights", "backbone_url", "load_weights"}
         )
         config = self._get_config(model_name=model_name)
-        parsed_name = self._resolve_model_name(model_name=model_name)
-        self.model_name = parsed_name["model_name"]
+        package_name, backbone_name = package_helpers.parse_model_name(
+            config.backbone_name
+        )
+        self.model_name = f"{package_name}/{backbone_name}-{self.model_suffix}"
         self.classes = classes
         self.class_ignore_index = class_ignore_index
         self.image_size = image_size
@@ -164,7 +166,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
 
         # Get the backbone.
         backbone = DINOV3_PACKAGE.get_model(
-            model_name=parsed_name["backbone_name"],
+            model_name=backbone_name,
             num_input_channels=len(self.image_normalize["mean"]),
             model_args=backbone_model_args,
             load_weights=load_weights,
@@ -247,23 +249,6 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
                 f"models are: {cls.list_model_names()}. See the documentation for "
                 "more information: https://docs.lightly.ai/train/stable/semantic_segmentation.html"
             ) from None
-
-    @classmethod
-    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
-        config = cls._get_config(model_name=model_name)
-
-        package_name, backbone_name = package_helpers.parse_model_name(
-            config.backbone_name
-        )
-
-        return {
-            "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
-            "backbone_name": backbone_name,
-        }
-
-    @classmethod
-    def parse_model_name(cls, model_name: str) -> dict[str, str]:
-        return cls._resolve_model_name(model_name=model_name)
 
     @torch.no_grad()
     def predict(self, image: PathLike | PILImage | Tensor) -> Tensor:

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -32,6 +32,9 @@ from lightly_train._models.dinov3.dinov3_src.layers.attention import (
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
 )
+from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import (
+    DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
+)
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.scale_block import (
     ScaleBlock,
 )
@@ -109,7 +112,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         super().__init__(
             locals(), ignore_args={"backbone_weights", "backbone_url", "load_weights"}
         )
-        parsed_name = self.parse_model_name(model_name=model_name)
+        parsed_name = self._resolve_model_name(model_name=model_name)
         self.model_name = parsed_name["model_name"]
         self.classes = classes
         self.class_ignore_index = class_ignore_index
@@ -222,52 +225,37 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return [
-            f"{name}-{cls.model_suffix}" for name in DINOV3_PACKAGE.list_model_names()
-        ]
+        return list(DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.list_aliases())
 
     @classmethod
     def is_supported_model(cls, model: str) -> bool:
-        try:
-            cls.parse_model_name(model_name=model)
-        except ValueError:
-            return False
-        else:
-            return True
+        return model in DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.list_aliases()
 
     @classmethod
-    def parse_model_name(cls, model_name: str) -> dict[str, str]:
-        def raise_invalid_name() -> None:
+    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
+        try:
+            config = DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.get(
+                alias=model_name
+            )()
+        except KeyError:
             raise ValueError(
                 f"Model name '{model_name}' is not supported. Available "
                 f"models are: {cls.list_model_names()}. See the documentation for "
                 "more information: https://docs.lightly.ai/train/stable/semantic_segmentation.html"
-            )
+            ) from None
 
-        if not model_name.endswith(f"-{cls.model_suffix}"):
-            raise_invalid_name()
-
-        backbone_name = model_name[: -len(f"-{cls.model_suffix}")]
-
-        try:
-            package_name, backbone_name = package_helpers.parse_model_name(
-                backbone_name
-            )
-        except ValueError:
-            raise_invalid_name()
-
-        if package_name != DINOV3_PACKAGE.name:
-            raise_invalid_name()
-
-        try:
-            backbone_name = DINOV3_PACKAGE.parse_model_name(model_name=backbone_name)
-        except ValueError:
-            raise_invalid_name()
+        package_name, backbone_name = package_helpers.parse_model_name(
+            config.backbone_name
+        )
 
         return {
-            "model_name": f"{DINOV3_PACKAGE.name}/{backbone_name}-{cls.model_suffix}",
+            "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
             "backbone_name": backbone_name,
         }
+
+    @classmethod
+    def parse_model_name(cls, model_name: str) -> dict[str, str]:
+        return cls._resolve_model_name(model_name=model_name)
 
     @torch.no_grad()
     def predict(self, image: PathLike | PILImage | Tensor) -> Tensor:

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -34,6 +34,7 @@ from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
 )
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import (
     DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
+    EoMTSemanticSegmentationConfig,
 )
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.scale_block import (
     ScaleBlock,
@@ -112,6 +113,7 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         super().__init__(
             locals(), ignore_args={"backbone_weights", "backbone_url", "load_weights"}
         )
+        config = self._get_config(model_name=model_name)
         parsed_name = self._resolve_model_name(model_name=model_name)
         self.model_name = parsed_name["model_name"]
         self.classes = classes
@@ -148,11 +150,11 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
 
         # NOTE(Guarin, 08/25): We don't set drop_path_rate=0 here because it is already
         # set by DINOv3.
-        backbone_model_args: dict[str, Any] = {}
+        # The registry config is the single, typed source of truth for the backbone
+        # args (e.g. patch size). Caller-provided backbone_args override the defaults.
+        backbone_model_args: dict[str, Any] = config.backbone_args.model_dump()
         if backbone_args is not None:
             backbone_model_args.update(backbone_args)
-        # The registry config is the single source of truth for the patch size.
-        backbone_model_args.setdefault("patch_size", int(parsed_name["patch_size"]))
         if backbone_url is not None:
             # For backwards compatibility. We prioritize backbone_weights over
             # backbone_url as the former is the new standard.
@@ -234,9 +236,9 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         return model in DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.list_aliases()
 
     @classmethod
-    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
+    def _get_config(cls, model_name: str) -> EoMTSemanticSegmentationConfig:
         try:
-            config = DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.get(
+            return DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.get(
                 alias=model_name
             )()
         except KeyError:
@@ -246,6 +248,10 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
                 "more information: https://docs.lightly.ai/train/stable/semantic_segmentation.html"
             ) from None
 
+    @classmethod
+    def _resolve_model_name(cls, model_name: str) -> dict[str, str]:
+        config = cls._get_config(model_name=model_name)
+
         package_name, backbone_name = package_helpers.parse_model_name(
             config.backbone_name
         )
@@ -253,8 +259,6 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         return {
             "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
             "backbone_name": backbone_name,
-            # The registry config is the single source of truth for the patch size.
-            "patch_size": str(config.patch_size),
         }
 
     @classmethod

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/task_model.py
@@ -151,6 +151,8 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         backbone_model_args: dict[str, Any] = {}
         if backbone_args is not None:
             backbone_model_args.update(backbone_args)
+        # The registry config is the single source of truth for the patch size.
+        backbone_model_args.setdefault("patch_size", int(parsed_name["patch_size"]))
         if backbone_url is not None:
             # For backwards compatibility. We prioritize backbone_weights over
             # backbone_url as the former is the new standard.
@@ -251,6 +253,8 @@ class DINOv3EoMTSemanticSegmentation(TaskModel):
         return {
             "model_name": f"{package_name}/{backbone_name}-{cls.model_suffix}",
             "backbone_name": backbone_name,
+            # The registry config is the single source of truth for the patch size.
+            "patch_size": str(config.patch_size),
         }
 
     @classmethod

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
@@ -34,9 +34,6 @@ from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
 )
 from lightly_train._optim import optimizer_helpers
-from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import (
-    DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
-)
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.scheduler import (
     TwoStageWarmupPolySchedule,
 )
@@ -78,8 +75,6 @@ class DINOv3EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
     # Corresponds to L_2 in the paper and network.num_blocks in the EoMT code.
     # Defaults in paper: base=3, large=4, giant=5.
     num_joint_blocks: int | Literal["auto"] = "auto"
-    # Backbone args, e.g., patch size.
-    patch_size: int | Literal["auto"] = "auto"
     fix_num_upscale_blocks: bool = True
 
     # Loss terms
@@ -118,24 +113,6 @@ class DINOv3EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
         model_init_args: dict[str, Any],
         data_args: TaskDataArgs,
     ) -> None:
-        # Set the patch size.
-        if self.patch_size == "auto":
-            patch_size = model_init_args.get("patch_size", None)
-            if patch_size is not None:
-                self.patch_size = int(patch_size)
-            else:
-                try:
-                    config = DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.get(
-                        alias=model_name
-                    )()
-                except KeyError:
-                    raise ValueError(
-                        f"Unknown model name '{model_name}', "
-                        "see https://docs.lightly.ai/train/stable/semantic_segmentation.html#model "
-                        "for all supported models."
-                    ) from None
-                self.patch_size = config.patch_size
-
         if self.num_queries == "auto":
             num_queries = model_init_args.get("num_queries", 100)
             assert isinstance(num_queries, int)  # for mypy
@@ -227,9 +204,6 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
 
         normalize = no_auto(val_transform_args.normalize)
 
-        # Prepare backbone args.
-        backbone_args = {"patch_size": model_args.patch_size}
-
         self.model = DINOv3EoMTSemanticSegmentation(
             model_name=model_name,
             classes=data_args.included_classes,
@@ -243,8 +217,6 @@ class DINOv3EoMTSemanticSegmentationTrain(TrainModel):
             backbone_freeze=self.model_args.backbone_freeze,
             backbone_weights=model_args.backbone_weights,
             backbone_url=model_args.backbone_url,
-            backbone_args=backbone_args,
-            # TODO (Lionel, 10/25): Pass backbone args.
             load_weights=load_weights,
             fix_num_upscale_blocks=model_args.fix_num_upscale_blocks,
         )

--- a/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_semantic_segmentation/train_model.py
@@ -34,6 +34,9 @@ from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer,
 )
 from lightly_train._optim import optimizer_helpers
+from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import (
+    DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
+)
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.scheduler import (
     TwoStageWarmupPolySchedule,
 )
@@ -119,19 +122,19 @@ class DINOv3EoMTSemanticSegmentationTrainArgs(TrainModelArgs):
         if self.patch_size == "auto":
             patch_size = model_init_args.get("patch_size", None)
             if patch_size is not None:
-                self.patch_size = patch_size
+                self.patch_size = int(patch_size)
             else:
-                match = re.match(
-                    r"dinov3/(?P<model_size>vit(t|s|l|b|g|h|7b))(?P<patch_size>\d+).*",
-                    model_name,
-                )
-                if match is None:
+                try:
+                    config = DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY.get(
+                        alias=model_name
+                    )()
+                except KeyError:
                     raise ValueError(
                         f"Unknown model name '{model_name}', "
                         "see https://docs.lightly.ai/train/stable/semantic_segmentation.html#model "
                         "for all supported models."
-                    )
-                self.patch_size = int(match.group("patch_size"))
+                    ) from None
+                self.patch_size = config.patch_size
 
         if self.num_queries == "auto":
             num_queries = model_init_args.get("num_queries", 100)

--- a/src/lightly_train/_task_models/task_model_helpers.py
+++ b/src/lightly_train/_task_models/task_model_helpers.py
@@ -19,7 +19,11 @@ from typing import Any, Literal, NoReturn
 import torch
 
 from lightly_train._commands import common_helpers
+from lightly_train._configs.model_registry import ModelRegistry
 from lightly_train._env import Env
+from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import (
+    DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
+)
 from lightly_train._task_models.ltdetr_object_detection.config import (
     LTDETR_MODEL_REGISTRY,
 )
@@ -52,11 +56,13 @@ _GENERIC_LTDETR_OBJECT_DETECTION_CLASS_PATH = (
 )
 
 
-def _get_ltdetr_downloadable_model_url_and_hashes() -> dict[str, tuple[str, str]]:
+def _get_downloadable_model_url_and_hashes(
+    registry: ModelRegistry[Any],
+) -> dict[str, tuple[str, str]]:
     downloadable_model_url_and_hashes = {}
-    for alias in LTDETR_MODEL_REGISTRY.list_aliases():
+    for alias in registry.list_aliases():
         try:
-            checkpoint = LTDETR_MODEL_REGISTRY.get_alias_metadata(
+            checkpoint = registry.get_alias_metadata(
                 alias=alias
             ).downloadable_checkpoint
         except KeyError:
@@ -131,71 +137,6 @@ DOWNLOADABLE_MODEL_URL_AND_HASH: dict[str, tuple[str, str]] = {
         "dinov3_vitl16_eomt_panoptic_coco_1280_251209_3da0b210.pt",
         "3da0b21000bba3747bcb3e4ac4ee1e38641614022281f4b710d7442c643182f2",
     ),
-    #### Semantic Segmentation
-    "dinov3/vitt16-eomt-coco": (
-        "dinov3_vitt16_eomt_coco_260106_104e563e.pt",
-        "104e563ebcd8b7d2842db5f0cc6f8d0e67f1607a063ab818725e9af6f6fe7c27",
-    ),
-    "dinov3/vitt16plus-eomt-coco": (
-        "dinov3_vitt16plus_eomt_coco_260106_68339a7d.pt",
-        "68339a7d5baa0dd6fdd88660410939eb78fc8a8c9332145b9b8ac91a2291950b",
-    ),
-    "dinov3/vits16-eomt-coco": (
-        "dinov3_vits16_eomt_coco_260105_11be50b5.pt",
-        "11be50b578251c974b1fdb413c76e2cd7cfe1e154f6118556bd87477ea205d5a",
-    ),
-    "dinov3/vitb16-eomt-coco": (
-        "dinov3_vitb16_eomt_coco_260105_92de5e05.pt",
-        "92de5e0550f51647e201eef3537a35a8bba75b4e41323b9a7df3c54e6ab400b9",
-    ),
-    "dinov3/vitl16-eomt-coco": (
-        "dinov3_vitl16_eomt_coco_260105_6169fdd8.pt",
-        "6169fdd8edf7d4648c45c6aa1d09b9a4e917ba51dcbd36acf8fbf04a25d1e516",
-    ),
-    "dinov3/vitt32-eomt-coco": (
-        "dinov3_vitt32_eomt_coco_260106_3ce75c95.pt",
-        "3ce75c958aa0d31e3ac14d0bc1e0ca34ccb5b9ab5b141ec40c7f83c1950a2186",
-    ),
-    "dinov3/vitt32plus-eomt-coco": (
-        "dinov3_vitt32plus_eomt_coco_260106_68e19609.pt",
-        "68e196093301bc8a4e73005cebe1cccca75f5c14e58e732d1d9c555ea44e2088",
-    ),
-    "dinov3/vits32-eomt-coco": (
-        "dinov3_vits32_eomt_coco_260106_06595b53.pt",
-        "06595b53b0ee63032e8f7882a2d1e877c84b996c8313727a6694abf42e871d05",
-    ),
-    "dinov3/vitb32-eomt-coco": (
-        "dinov3_vitb32_eomt_coco_260106_62cf509e.pt",
-        "62cf509e156257347274837087592f27743ba51722c4949bec90688859cc6b6a",
-    ),
-    "dinov3/vitl32-eomt-coco": (
-        "dinov3_vitl32_eomt_coco_260106_f51348fb.pt",
-        "f51348fb4c794889ae35b8d9e2cfe383b42e09e975d2854f2e96fed155edd7d9",
-    ),
-    "dinov3/vits16-eomt-cityscapes": (
-        "dinov3_eomt/lightlytrain_dinov3_eomt_vits16_cityscapes.pt",
-        "ef7d54eac202bb0a6707fd7115b689a748d032037eccaa3a6891b57b83f18b7e",
-    ),
-    "dinov3/vitb16-eomt-cityscapes": (
-        "dinov3_eomt/lightlytrain_dinov3_eomt_vitb16_cityscapes.pt",
-        "e78e6b1f372ac15c860f64445d8265fd5e9d60271509e106a92b7162096c9560",
-    ),
-    "dinov3/vitl16-eomt-cityscapes": (
-        "dinov3_eomt/lightlytrain_dinov3_eomt_vitl16_cityscapes.pt",
-        "3f397e6ca0af4555adb1da9efa489b734e35fbeac15b4c18e408c63922b41f6c",
-    ),
-    "dinov3/vits16-eomt-ade20k": (
-        "dinov3_eomt/lightlytrain_dinov3_eomt_vits16_autolabel_sun397.pt",
-        "f9f002e5adff875e0a97a3b310c26fe5e10c26d69af4e830a4a67aa7dda330aa",
-    ),
-    "dinov3/vitb16-eomt-ade20k": (
-        "dinov3_eomt/lightlytrain_dinov3_eomt_vitb16_autolabel_sun397.pt",
-        "400f7a1b42a7b67babf253d6aade0be334173d70e7351a01159698ac2d2335ca",
-    ),
-    "dinov3/vitl16-eomt-ade20k": (
-        "dinov3_eomt/lightlytrain_dinov3_eomt_vitl16_ade20k.pt",
-        "eb31183c70edd4df8923cba54ce2eefa517ae328cf3caf0106d2795e34382f8f",
-    ),
     #### Depth Estimation
     "dinov2/dav3-relative-large": (
         "dinov2_dav3_relative_large_260629_9c2e9320.pt",
@@ -218,7 +159,14 @@ DOWNLOADABLE_MODEL_URL_AND_HASH: dict[str, tuple[str, str]] = {
         "d59577016e01635c285fac76f44685d7a0878545e0b8d560da45c0cf4d058548",
     ),
 }
-DOWNLOADABLE_MODEL_URL_AND_HASH.update(_get_ltdetr_downloadable_model_url_and_hashes())
+DOWNLOADABLE_MODEL_URL_AND_HASH.update(
+    _get_downloadable_model_url_and_hashes(
+        DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY
+    )
+)
+DOWNLOADABLE_MODEL_URL_AND_HASH.update(
+    _get_downloadable_model_url_and_hashes(LTDETR_MODEL_REGISTRY)
+)
 
 
 def load_model(

--- a/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov2_eomt_semantic_segmentation/test_task_model.py
@@ -33,6 +33,30 @@ def model() -> DINOv2EoMTSemanticSegmentation:
     )
 
 
+def test_list_model_names__uses_registry() -> None:
+    names = DINOv2EoMTSemanticSegmentation.list_model_names()
+
+    assert "dinov2/_vittest14-eomt" in names
+    assert "dinov2/vits14-eomt" in names
+    assert "dinov2/vits14-notpretrained-eomt" in names
+
+
+def test_is_supported_model__uses_registry() -> None:
+    assert DINOv2EoMTSemanticSegmentation.is_supported_model("dinov2/vits14-eomt")
+    assert DINOv2EoMTSemanticSegmentation.is_supported_model(
+        "dinov2/vits14-notpretrained-eomt"
+    )
+    assert not DINOv2EoMTSemanticSegmentation.is_supported_model(
+        "dinov2/vits14_pretrain-eomt"
+    )
+
+    parsed = DINOv2EoMTSemanticSegmentation._resolve_model_name("dinov2/vits14-eomt")
+    assert parsed == {
+        "model_name": "dinov2/vits14-eomt",
+        "backbone_name": "vits14",
+    }
+
+
 def test_predict_batch__composes_stages_in_order(
     model: DINOv2EoMTSemanticSegmentation, mocker: MockerFixture
 ) -> None:

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -14,18 +14,12 @@ import torch
 from lightning_utilities.core.imports import RequirementCache
 from pytest_mock import MockerFixture
 
-from lightly_train._data.mask_semantic_segmentation_dataset import (
-    MaskSemanticSegmentationDataArgs,
-)
 from lightly_train._export.onnx_helpers import (
     _TORCH_DYNAMO_AVAILABLE,
     _TORCH_DYNAMO_MIN_VERSION,
 )
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model import (
     DINOv3EoMTSemanticSegmentation,
-)
-from lightly_train._task_models.dinov3_eomt_semantic_segmentation.train_model import (
-    DINOv3EoMTSemanticSegmentationTrainArgs,
 )
 
 
@@ -40,21 +34,6 @@ def model() -> DINOv3EoMTSemanticSegmentation:
         num_queries=2,
         num_joint_blocks=1,
         load_weights=False,
-    )
-
-
-@pytest.fixture()
-def data_args(tmp_path: Path) -> MaskSemanticSegmentationDataArgs:
-    return MaskSemanticSegmentationDataArgs(
-        train={
-            "images": tmp_path / "train" / "images",
-            "masks": tmp_path / "train" / "masks",
-        },
-        val={
-            "images": tmp_path / "val" / "images",
-            "masks": tmp_path / "val" / "masks",
-        },
-        classes={0: {"name": "background", "labels": {0}}},
     )
 
 
@@ -85,47 +64,14 @@ def test_is_supported_model__uses_registry() -> None:
     assert parsed == {
         "model_name": "dinov3/vits16-eomt",
         "backbone_name": "vits16",
+        "patch_size": "16",
     }
 
 
-@pytest.mark.parametrize(
-    ("model_name", "expected_patch_size"),
-    [("dinov3/vits16-eomt-coco", 16), ("dinov3/vits32-eomt-coco", 32)],
-)
-def test_train_args_resolve_auto__uses_registry_patch_size(
-    model_name: str,
-    expected_patch_size: int,
-    data_args: MaskSemanticSegmentationDataArgs,
-) -> None:
-    model_args = DINOv3EoMTSemanticSegmentationTrainArgs()
-
-    model_args.resolve_auto(
-        total_steps=1000,
-        gradient_accumulation_steps=1,
-        train_num_batches=100,
-        model_name=model_name,
-        model_init_args={},
-        data_args=data_args,
-    )
-
-    assert model_args.patch_size == expected_patch_size
-
-
-def test_train_args_resolve_auto__model_init_args_patch_size_wins(
-    data_args: MaskSemanticSegmentationDataArgs,
-) -> None:
-    model_args = DINOv3EoMTSemanticSegmentationTrainArgs()
-
-    model_args.resolve_auto(
-        total_steps=1000,
-        gradient_accumulation_steps=1,
-        train_num_batches=100,
-        model_name="dinov3/vits16-eomt-coco",
-        model_init_args={"patch_size": 32},
-        data_args=data_args,
-    )
-
-    assert model_args.patch_size == 32
+def test_init__uses_registry_patch_size(model: DINOv3EoMTSemanticSegmentation) -> None:
+    # The patch size comes from the registry config, not from the train model.
+    assert model.patch_size == 16
+    assert model.backbone.patch_size == 16
 
 
 def test_predict_batch__composes_stages_in_order(

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -14,12 +14,18 @@ import torch
 from lightning_utilities.core.imports import RequirementCache
 from pytest_mock import MockerFixture
 
+from lightly_train._data.mask_semantic_segmentation_dataset import (
+    MaskSemanticSegmentationDataArgs,
+)
 from lightly_train._export.onnx_helpers import (
     _TORCH_DYNAMO_AVAILABLE,
     _TORCH_DYNAMO_MIN_VERSION,
 )
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model import (
     DINOv3EoMTSemanticSegmentation,
+)
+from lightly_train._task_models.dinov3_eomt_semantic_segmentation.train_model import (
+    DINOv3EoMTSemanticSegmentationTrainArgs,
 )
 
 
@@ -35,6 +41,91 @@ def model() -> DINOv3EoMTSemanticSegmentation:
         num_joint_blocks=1,
         load_weights=False,
     )
+
+
+@pytest.fixture()
+def data_args(tmp_path: Path) -> MaskSemanticSegmentationDataArgs:
+    return MaskSemanticSegmentationDataArgs(
+        train={
+            "images": tmp_path / "train" / "images",
+            "masks": tmp_path / "train" / "masks",
+        },
+        val={
+            "images": tmp_path / "val" / "images",
+            "masks": tmp_path / "val" / "masks",
+        },
+        classes={0: {"name": "background", "labels": {0}}},
+    )
+
+
+def test_list_model_names__uses_registry() -> None:
+    names = DINOv3EoMTSemanticSegmentation.list_model_names()
+
+    assert "dinov3/_vittest16-eomt" in names
+    assert "dinov3/vits16-eomt" in names
+    assert "dinov3/vits16-eomt-coco" in names
+    assert "dinov3/vits32-eomt-coco" in names
+    assert "dinov3/vitt16-eupe-eomt" in names
+    assert "dinov3/vitt16-notpretrained-eomt" in names
+    assert "dinov3/convnext-tiny-eomt" not in names
+
+
+def test_is_supported_model__uses_registry() -> None:
+    assert DINOv3EoMTSemanticSegmentation.is_supported_model("dinov3/vits16-eomt")
+    assert DINOv3EoMTSemanticSegmentation.is_supported_model("dinov3/vits16-eomt-coco")
+    assert DINOv3EoMTSemanticSegmentation.is_supported_model("dinov3/vits32-eomt-coco")
+    assert DINOv3EoMTSemanticSegmentation.is_supported_model("dinov3/vitt16-eupe-eomt")
+    assert not DINOv3EoMTSemanticSegmentation.is_supported_model(
+        "dinov3/convnext-tiny-eomt"
+    )
+
+    parsed = DINOv3EoMTSemanticSegmentation._resolve_model_name(
+        "dinov3/vits16-eomt-coco"
+    )
+    assert parsed == {
+        "model_name": "dinov3/vits16-eomt",
+        "backbone_name": "vits16",
+    }
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_patch_size"),
+    [("dinov3/vits16-eomt-coco", 16), ("dinov3/vits32-eomt-coco", 32)],
+)
+def test_train_args_resolve_auto__uses_registry_patch_size(
+    model_name: str,
+    expected_patch_size: int,
+    data_args: MaskSemanticSegmentationDataArgs,
+) -> None:
+    model_args = DINOv3EoMTSemanticSegmentationTrainArgs()
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        gradient_accumulation_steps=1,
+        train_num_batches=100,
+        model_name=model_name,
+        model_init_args={},
+        data_args=data_args,
+    )
+
+    assert model_args.patch_size == expected_patch_size
+
+
+def test_train_args_resolve_auto__model_init_args_patch_size_wins(
+    data_args: MaskSemanticSegmentationDataArgs,
+) -> None:
+    model_args = DINOv3EoMTSemanticSegmentationTrainArgs()
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        gradient_accumulation_steps=1,
+        train_num_batches=100,
+        model_name="dinov3/vits16-eomt-coco",
+        model_init_args={"patch_size": 32},
+        data_args=data_args,
+    )
+
+    assert model_args.patch_size == 32
 
 
 def test_predict_batch__composes_stages_in_order(

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -58,17 +58,10 @@ def test_is_supported_model__uses_registry() -> None:
         "dinov3/convnext-tiny-eomt"
     )
 
-    parsed = DINOv3EoMTSemanticSegmentation._resolve_model_name(
-        "dinov3/vits16-eomt-coco"
-    )
-    assert parsed == {
-        "model_name": "dinov3/vits16-eomt",
-        "backbone_name": "vits16",
-    }
-
 
 def test_init__uses_registry_patch_size(model: DINOv3EoMTSemanticSegmentation) -> None:
     # The patch size comes from the registry config, not from the train model.
+    assert model.model_name == "dinov3/_vittest16-eomt"
     assert model.patch_size == 16
     assert model.backbone.patch_size == 16
 

--- a/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
+++ b/tests/_task_models/dinov3_eomt_semantic_segmentation/test_task_model.py
@@ -64,7 +64,6 @@ def test_is_supported_model__uses_registry() -> None:
     assert parsed == {
         "model_name": "dinov3/vits16-eomt",
         "backbone_name": "vits16",
-        "patch_size": "16",
     }
 
 

--- a/tests/_task_models/test_task_model_helpers.py
+++ b/tests/_task_models/test_task_model_helpers.py
@@ -73,6 +73,23 @@ def test_downloadable_model__ltdetrv2_s_coco_alias() -> None:
     assert d["ltdetrv2-s-coco"] == d["edgecrafter/ecvitt-ltdetr-coco"]
 
 
+def test_downloadable_model__dinov3_eomt_semantic_aliases_from_registry() -> None:
+    d = task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH
+
+    assert d["dinov3/vits16-eomt-coco"] == (
+        "dinov3_vits16_eomt_coco_260105_11be50b5.pt",
+        "11be50b578251c974b1fdb413c76e2cd7cfe1e154f6118556bd87477ea205d5a",
+    )
+    assert d["dinov3/vits32-eomt-coco"] == (
+        "dinov3_vits32_eomt_coco_260106_06595b53.pt",
+        "06595b53b0ee63032e8f7882a2d1e877c84b996c8313727a6694abf42e871d05",
+    )
+    assert d["dinov3/vitl16-eomt-ade20k"] == (
+        "dinov3_eomt/lightlytrain_dinov3_eomt_vitl16_ade20k.pt",
+        "eb31183c70edd4df8923cba54ce2eefa517ae328cf3caf0106d2795e34382f8f",
+    )
+
+
 def test_download_checkpoint__non_hosted_dav2__raises_convert_guidance() -> None:
     model_name = "dinov2/dav2-relative-large"
 


### PR DESCRIPTION
## What has changed and why?
- adds model registry for semantic segmentation eomt models

**Note**: Breaking change since we remove the option to pass the patch size via the training command. I don't think anyone was using this and it was a really poor architectural choice to have the patch size in the `train_model.py`, because it has 0 influence on the training recip.

## How has it been tested?
- unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
