### PR TITLE
Add ONNX and TensorRT export for LT-DETR instance segmentation

### DIFF
--- a/src/lightly_train/_export/tensorrt_helpers.py
+++ b/src/lightly_train/_export/tensorrt_helpers.py
@@ -50,6 +50,9 @@ def export_tensorrt(
     This loads the ONNX file, parses it with TensorRT, infers the static input
     shape (C, H, W) from the `"images"` input, and creates an engine with a
     dynamic batch dimension in the range `[min_batchsize, opt_batchsize, max_batchsize]`.
+    Any additional inputs (e.g. `"orig_target_size"`) that have a dynamic batch
+    dimension get a matching optimization profile over the same batch range; a
+    dynamic non-batch dimension on such an input is not supported and raises.
     Spatial dimensions must be static in the ONNX model (dynamic H/W are not yet supported).
 
     The engine is serialized and written to `out`.
@@ -229,6 +232,23 @@ def export_tensorrt(
         opt=(opt_batchsize, C, H, W),
         max=(max_batchsize, C, H, W),
     )
+    for i in range(network.num_inputs):
+        inp = network.get_input(i)
+        if inp.name == "images":
+            continue
+        input_shape = tuple(inp.shape)
+        if -1 not in input_shape:
+            continue
+        if any(dim == -1 for dim in input_shape[1:]):
+            raise ValueError(
+                f"Dynamic non-batch dimensions are not supported yet for input '{inp.name}'."
+            )
+        profile.set_shape(
+            inp.name,
+            min=(min_batchsize, *input_shape[1:]),
+            opt=(opt_batchsize, *input_shape[1:]),
+            max=(max_batchsize, *input_shape[1:]),
+        )
     config.add_optimization_profile(profile)
 
     logger.info("Building TensorRT engine...")

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -374,28 +374,16 @@ class LTDETRInstanceSegmentation(TaskModel):
         self.deploy()
         model_device = next(self.parameters()).device
 
-        # Try to infer num_channels if not provided.
+        # Infer num_channels if not provided. The model always consumes
+        # ``self._expected_input_channels`` channels (grayscale inputs are
+        # expanded to this count before batching), so use it rather than the
+        # normalization stats, whose length may not match the backbone's input.
         if num_channels is None:
-            if self.image_normalize is not None:
-                num_channels = len(self.image_normalize["mean"])
-                logger.info(
-                    f"Inferred num_channels={num_channels} from image_normalize."
-                )
-            else:
-                for module in self.modules():
-                    if isinstance(module, torch.nn.Conv2d):
-                        num_channels = module.in_channels
-                        logger.info(
-                            f"Inferred num_channels={num_channels} from first Conv. layer."
-                        )
-                        break
-                if num_channels is None:
-                    logger.error(
-                        "Could not infer num_channels. Please provide it explicitly."
-                    )
-                    raise ValueError(
-                        "num_channels must be provided for ONNX export if it cannot be inferred."
-                    )
+            num_channels = self._expected_input_channels
+            logger.info(
+                f"Inferred num_channels={num_channels} from the model's expected "
+                "input channels."
+            )
 
         if dynamic_batch_size:
             batch_size = 2
@@ -520,16 +508,16 @@ class LTDETRInstanceSegmentation(TaskModel):
                     def msg(s: str) -> str:
                         return f'ONNX validation failed for output "{output_name}": {s}'
 
-                    # Due to the presence of top-k operations in the model, the outputs may be
-                    # in different order but still valid. To account for this, we sum
-                    # over the query dimension before comparing.
-                    output_model = output_model.sum(dim=1)
-                    if output_onnx.is_floating_point():
-                        # Convert to fp32 to avoid overflow issues when summing in fp16.
-                        output_onnx = output_onnx.float()
-                    output_onnx = output_onnx.sum(dim=1)
-
+                    # Due to the presence of top-k operations in the model, the
+                    # outputs may be in a different order but still valid. To
+                    # compare in an order-invariant way we reduce along the query
+                    # dimension before comparing.
                     if output_model.is_floating_point():
+                        # Float outputs (boxes, masks, scores): sum over the query
+                        # dimension. Convert the ONNX output to fp32 first to avoid
+                        # overflow when summing in fp16.
+                        output_model = output_model.sum(dim=1)
+                        output_onnx = output_onnx.float().sum(dim=1)
                         # Absolute and relative tolerances are a bit arbitrary and taken from here:
                         # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
                         torch.testing.assert_close(
@@ -544,9 +532,18 @@ class LTDETRInstanceSegmentation(TaskModel):
                             rtol=1e-1,
                         )
                     else:
+                        # Integer outputs (labels): compare as order-invariant
+                        # multisets by sorting along the query dimension. Summing
+                        # would let an incorrect set such as [0, 2] match [1, 1].
+                        # Require an exact match (min_fraction=1.0): once sorted
+                        # there is no ordering slack to allow, and the default
+                        # 0.99 would let a few wrong class labels pass silently.
+                        output_model = output_model.sort(dim=1).values
+                        output_onnx = output_onnx.sort(dim=1).values
                         _torch_testing.assert_most_equal(
                             output_onnx,
                             output_model,
+                            min_fraction=1.0,
                             msg=msg,
                         )
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -22,6 +22,7 @@ from typing_extensions import Self, override
 from lightly_train import _logging, _torch_testing
 from lightly_train._commands import _warnings
 from lightly_train._data import file_helpers
+from lightly_train._export import tensorrt_helpers
 from lightly_train._export.onnx_helpers import (
     fix_topological_order,
     remove_redundant_casts,
@@ -550,6 +551,79 @@ class LTDETRInstanceSegmentation(TaskModel):
                         )
 
         logger.info(f"Successfully exported ONNX model to '{out}'")
+
+    def export_tensorrt(
+        self,
+        out: PathLike,
+        *,
+        precision: Literal["fp32", "fp16"] = "fp32",
+        onnx_args: dict[str, Any] | None = None,
+        max_batchsize: int = 1,
+        opt_batchsize: int = 1,
+        min_batchsize: int = 1,
+        verbose: bool = False,
+    ) -> None:
+        """Build a TensorRT engine from an ONNX model.
+
+        .. note::
+            TensorRT is not part of LightlyTrain’s dependencies and must be installed separately.
+            Installation depends on your OS, Python version, GPU, and NVIDIA driver/CUDA setup.
+            See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for more details.
+            On CUDA 12.x systems you can often install the Python package via `pip install tensorrt-cu12`.
+
+        This loads the ONNX file, parses it with TensorRT, infers the static input
+        shape (C, H, W) from the `"images"` input, and creates an engine with a
+        dynamic batch dimension in the range `[min_batchsize, opt_batchsize, max_batchsize]`.
+        Spatial dimensions must be static in the ONNX model (dynamic H/W are not yet supported).
+
+        The engine is serialized and written to `out`.
+
+        Args:
+            out:
+                Path where the TensorRT engine will be saved.
+            precision:
+                Precision for ONNX export and TensorRT engine building. Either
+                "fp32" or "fp16".
+            onnx_args:
+                Optional arguments to pass to `export_onnx` when exporting
+                the ONNX model prior to building the TensorRT engine. If None,
+                default arguments are used and the ONNX file is saved alongside
+                the TensorRT engine with the same name but `.onnx` extension.
+            max_batchsize:
+                Maximum supported batch size.
+            opt_batchsize:
+                Batch size TensorRT optimizes for.
+            min_batchsize:
+                Minimum supported batch size.
+            verbose:
+                Enable verbose TensorRT logging.
+
+        Raises:
+            FileNotFoundError: If the ONNX file does not exist.
+            RuntimeError: If the ONNX cannot be parsed or engine building fails.
+            ValueError: If batch size constraints are invalid or H/W are dynamic.
+        """
+        model_dtype = next(self.parameters()).dtype
+
+        onnx_args = dict(onnx_args) if onnx_args is not None else {}
+        onnx_args.setdefault("precision", precision)
+
+        tensorrt_helpers.export_tensorrt(
+            export_onnx_fn=self.export_onnx,
+            out=out,
+            precision=precision,
+            model_dtype=model_dtype,
+            onnx_args=onnx_args,
+            max_batchsize=max_batchsize,
+            opt_batchsize=opt_batchsize,
+            min_batchsize=min_batchsize,
+            # We convert the fp32 attention scores already during ONNX export, so we
+            # build a strongly-typed engine: TensorRT then honors those fp32 Cast nodes
+            # instead of forcing the whole attention into FP16 (which overflows to NaN).
+            fp32_attention_scores=False,
+            strongly_typed=True,
+            verbose=verbose,
+        )
 
     def load_train_state_dict(
         self, state_dict: dict[str, Any], strict: bool = True, assign: bool = False

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -512,6 +512,12 @@ class LTDETRInstanceSegmentation(TaskModel):
                     # outputs may be in a different order but still valid. To
                     # compare in an order-invariant way we reduce along the query
                     # dimension before comparing.
+                    # TODO(yutong, 07/2026): Reducing each output independently
+                    # only checks per-field marginals, so it cannot detect an
+                    # export that swaps labels or masks between boxes (the sums
+                    # and label multiset stay identical). Match detections per
+                    # image by box location and compare the full
+                    # (label, box, mask, score) tuples together instead.
                     if output_model.is_floating_point():
                         # Float outputs (boxes, masks, scores): sum over the query
                         # dimension. Convert the ONNX output to fp32 first to avoid

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -7,8 +7,10 @@
 #
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
-from typing import Any
+from copy import deepcopy
+from typing import Any, Literal
 
 import torch
 import torch.nn.functional as F
@@ -17,7 +19,13 @@ from torch import Tensor
 from torchvision.transforms.v2 import functional as transforms_functional
 from typing_extensions import Self, override
 
+from lightly_train import _logging, _torch_testing
+from lightly_train._commands import _warnings
 from lightly_train._data import file_helpers
+from lightly_train._export.onnx_helpers import (
+    fix_topological_order,
+    remove_redundant_casts,
+)
 from lightly_train._models import package_helpers
 from lightly_train._models.ecvit.ecvit import ECViTModelWrapper
 from lightly_train._models.ecvit.ecvit_package import EDGE_CRAFTER_PACKAGE
@@ -39,6 +47,8 @@ from lightly_train._task_models.object_detection_components.hybrid_encoder impor
 )
 from lightly_train._task_models.task_model import TaskModel
 from lightly_train.types import PathLike
+
+logger = logging.getLogger(__name__)
 
 
 class LTDETRInstanceSegmentation(TaskModel):
@@ -298,6 +308,248 @@ class LTDETRInstanceSegmentation(TaskModel):
             if hasattr(m, "convert_to_deploy"):
                 m.convert_to_deploy()  # type: ignore[operator]
         return self
+
+    @torch.no_grad()
+    def export_onnx(
+        self,
+        out: PathLike,
+        *,
+        precision: Literal["fp32", "fp16"] = "fp32",
+        batch_size: int = 1,
+        dynamic_batch_size: bool = True,
+        opset_version: int | None = None,
+        simplify: bool = True,
+        verify: bool = True,
+        format_args: dict[str, Any] | None = None,
+        num_channels: int | None = None,
+    ) -> None:
+        """Exports the model to ONNX for inference.
+
+        The export uses a dummy input of shape ``(batch_size, C, H, W)`` where
+        ``C`` is inferred and ``(H, W)`` come from ``self.image_size``. It also
+        exports ``orig_target_size`` as a second input of shape ``(batch_size, 2)``
+        in ``(H, W)`` format so boxes are scaled to caller-provided image sizes.
+
+        Optionally simplifies the exported model in-place using onnxslim and
+        verifies numerical closeness against a float32 CPU reference via
+        ONNX Runtime.
+
+        Args:
+            out:
+                Path where the ONNX model will be written.
+            precision:
+                Precision for the ONNX model. Either "fp32", or "fp16".
+            batch_size:
+                Batch size for the ONNX input.
+            dynamic_batch_size:
+                If True, the ONNX graph will have a dynamic batch dimension for the
+                inputs. If False, the batch dimension is fixed to ``batch_size``.
+            opset_version:
+                ONNX opset version to target. If None, PyTorch's default opset is used.
+            simplify:
+                If True, run onnxslim to simplify and overwrite the exported model.
+            verify:
+                If True, validate the ONNX file and compare outputs to a float32 CPU
+                reference forward pass.
+            format_args:
+                Optional extra keyword arguments forwarded to ``torch.onnx.export``.
+            num_channels:
+                Number of input channels. If None, will be inferred.
+        """
+        _warnings.filter_export_warnings()
+        _logging.set_up_console_logging()
+
+        self.eval()
+
+        if precision not in ("fp32", "fp16"):
+            raise ValueError(
+                f"Invalid precision '{precision}'. Must be one of 'fp32', 'fp16'."
+            )
+
+        # Always trace in fp32 to avoid dtype mismatches in the decoder's
+        # autocast(enabled=False) blocks. fp16 conversion is applied
+        # post-export via onnxruntime.transformers.
+        self.to(torch.float32)
+        self.deploy()
+        model_device = next(self.parameters()).device
+
+        # Try to infer num_channels if not provided.
+        if num_channels is None:
+            if self.image_normalize is not None:
+                num_channels = len(self.image_normalize["mean"])
+                logger.info(
+                    f"Inferred num_channels={num_channels} from image_normalize."
+                )
+            else:
+                for module in self.modules():
+                    if isinstance(module, torch.nn.Conv2d):
+                        num_channels = module.in_channels
+                        logger.info(
+                            f"Inferred num_channels={num_channels} from first Conv. layer."
+                        )
+                        break
+                if num_channels is None:
+                    logger.error(
+                        "Could not infer num_channels. Please provide it explicitly."
+                    )
+                    raise ValueError(
+                        "num_channels must be provided for ONNX export if it cannot be inferred."
+                    )
+
+        if dynamic_batch_size:
+            batch_size = 2
+            dynamic_axes = {
+                "images": {0: "N"},
+                "orig_target_size": {0: "N"},
+            }
+        else:
+            dynamic_axes = None
+
+        dummy_input = torch.randn(
+            batch_size,
+            num_channels,
+            self.image_size[0],
+            self.image_size[1],
+            requires_grad=False,
+            device=model_device,
+            dtype=torch.float32,
+        )
+        dummy_orig_target_size = torch.tensor(
+            [self.image_size],
+            device=model_device,
+            dtype=torch.int64,
+        ).repeat(batch_size, 1)
+
+        input_names = ["images", "orig_target_size"]
+        output_names = self.get_export_output_names()
+
+        torch.onnx.export(
+            self,
+            (dummy_input, dummy_orig_target_size),
+            str(out),
+            input_names=input_names,
+            output_names=output_names,
+            opset_version=opset_version,
+            dynamo=False,
+            dynamic_axes=dynamic_axes,
+            **(format_args or {}),
+        )
+
+        if precision == "fp16":
+            # convert_float_to_float16 creates nodes with duplicate names. In order to avoid downstream issues
+            # we require simplify to be True, as this correctly renames nodes.
+            if not simplify:
+                raise ValueError("fp16 precision requires simplify=True.")
+
+            import onnx
+            from onnxruntime.transformers import float16 as ort_float16
+
+            model_onnx = onnx.load(str(out))
+            # If the input to Softmax are too large the output of Softmax will be NaN values. Therefore we run
+            #  the Softmax computation in fp32. The nodes before Softmax are always MatMul.
+            # TODO (simon, 05/26) Ideally we would only block operators were a Matmul directly feeds into a Softmax.
+            op_block_list = list(ort_float16.DEFAULT_OP_BLOCK_LIST) + [
+                "Softmax",
+                "MatMul",
+            ]
+            model_fp16 = ort_float16.convert_float_to_float16(
+                model_onnx, op_block_list=op_block_list
+            )
+            # Using the op blocklist on a graph that looks like Softmax -> MatMul creates a graph that looks like
+            #  Cast32 -> MatMul -> Cast16 -> Cast32 -> Softmax -> Cast16. Therefore, we need to remove the middle
+            #  Cast16 -> Cast32.
+            remove_redundant_casts(model_fp16)
+            fix_topological_order(model_fp16)
+            onnx.save(model_fp16, str(out))
+
+        if simplify:
+            import onnxslim  # type: ignore[import-not-found,import-untyped]
+
+            onnxslim.slim(
+                str(out),
+                output_model=out,
+            )
+
+        if verify:
+            logger.info("Verifying ONNX model")
+            import onnx
+            import onnxruntime as ort
+
+            onnx.checker.check_model(out, full_check=True)
+
+            providers = ort.get_available_providers()
+            if precision == "fp16" and "CUDAExecutionProvider" not in providers:
+                logger.warning(
+                    "Skipping ONNX runtime verification for fp16 model because "
+                    "CUDAExecutionProvider is not available in onnxruntime. "
+                    "Install onnxruntime-gpu to enable full verification."
+                )
+            else:
+                # Always run the reference input in float32 and on cpu for consistency.
+                reference_model = deepcopy(self).cpu().to(torch.float32).eval()
+                reference_model.deploy()
+                reference_outputs: tuple[Tensor, ...] = reference_model(
+                    dummy_input.cpu().to(torch.float32),
+                    dummy_orig_target_size.cpu(),
+                )
+
+                # Get outputs from the ONNX model. Load from bytes to avoid
+                # ORT errors about missing external data when weights are inline.
+                with open(out, "rb") as f:
+                    session = ort.InferenceSession(f.read())
+                onnx_input = dummy_input.cpu()
+                if precision == "fp16":
+                    onnx_input = onnx_input.half()
+                input_feed = {
+                    "images": onnx_input.numpy(),
+                    "orig_target_size": dummy_orig_target_size.cpu().numpy(),
+                }
+                outputs_onnx = session.run(output_names=None, input_feed=input_feed)
+                outputs_onnx = tuple(torch.from_numpy(y) for y in outputs_onnx)
+
+                # Verify that the outputs from both models are close.
+                if len(outputs_onnx) != len(reference_outputs):
+                    raise AssertionError(
+                        f"Number of onnx outputs should be {len(reference_outputs)} but is {len(outputs_onnx)}"
+                    )
+                for output_onnx, output_model, output_name in zip(
+                    outputs_onnx, reference_outputs, output_names
+                ):
+
+                    def msg(s: str) -> str:
+                        return f'ONNX validation failed for output "{output_name}": {s}'
+
+                    # Due to the presence of top-k operations in the model, the outputs may be
+                    # in different order but still valid. To account for this, we sum
+                    # over the query dimension before comparing.
+                    output_model = output_model.sum(dim=1)
+                    if output_onnx.is_floating_point():
+                        # Convert to fp32 to avoid overflow issues when summing in fp16.
+                        output_onnx = output_onnx.float()
+                    output_onnx = output_onnx.sum(dim=1)
+
+                    if output_model.is_floating_point():
+                        # Absolute and relative tolerances are a bit arbitrary and taken from here:
+                        # https://github.com/pytorch/pytorch/blob/main/torch/onnx/_internal/exporter/_core.py#L1611-L1618
+                        torch.testing.assert_close(
+                            output_onnx,
+                            output_model,
+                            msg=msg,
+                            equal_nan=True,
+                            check_device=False,
+                            check_dtype=False,
+                            check_layout=False,
+                            atol=5e-3,
+                            rtol=1e-1,
+                        )
+                    else:
+                        _torch_testing.assert_most_equal(
+                            output_onnx,
+                            output_model,
+                            msg=msg,
+                        )
+
+        logger.info(f"Successfully exported ONNX model to '{out}'")
 
     def load_train_state_dict(
         self, state_dict: dict[str, Any], strict: bool = True, assign: bool = False

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -733,6 +733,11 @@ class LTDETRObjectDetection(TaskModel):
         model_device = next(self.parameters()).device
 
         # Try to infer num_channels if not provided.
+        # TODO(yutong, 07/2026): Inferring channels from the normalization stats
+        # is wrong when they don't match the backbone input (e.g. single-channel
+        # stats for a 3-channel model that expands grayscale before batching).
+        # Prefer self._expected_input_channels, as done in the LT-DETR instance
+        # segmentation export.
         if num_channels is None:
             if self.image_normalize is not None:
                 num_channels = len(self.image_normalize["mean"])
@@ -879,6 +884,12 @@ class LTDETRObjectDetection(TaskModel):
                     # Due to the presence of top-k operations in the model, the outputs may be
                     # in different order but still valid. To account for this, we sum
                     # over the query dimension before comparing.
+                    # TODO(yutong, 07/2026): Summing each output over the query
+                    # dimension only checks per-field marginals: it cannot detect
+                    # an export that swaps labels between boxes, and summing the
+                    # integer labels is weaker still (e.g. [0, 2] matches [1, 1]).
+                    # Match detections per image by box location and compare the
+                    # full (label, box, score) tuples together instead.
                     output_model = output_model.sum(dim=1)
                     if output_onnx.is_floating_point():
                         # Convert to fp32 to avoid overflow issues when summing in fp16.

--- a/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
@@ -7,14 +7,19 @@
 #
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import torch
+from lightning_utilities.core.imports import RequirementCache
 from pytest_mock import MockerFixture
 from torch import nn
 
 from lightly_train._task_models.ltdetr_instance_segmentation.task_model import (
     LTDETRInstanceSegmentation,
 )
+
+from ...helpers import assert_onnx_outputs_close
 
 
 def _is_module_frozen(m: nn.Module) -> bool:
@@ -265,3 +270,248 @@ def test_freeze_backbone_on_init() -> None:
 
     assert _is_module_frozen(model.backbone)
     assert not model.backbone.training
+
+
+def _run_seg_onnx(path: Path, images: object, orig_target_size: object) -> list:  # type: ignore[type-arg]
+    """Run the exported segmentation graph in ONNX Runtime on CPU."""
+    import onnxruntime as ort
+
+    session = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+    outputs: list = session.run(  # type: ignore[type-arg]
+        None, {"images": images, "orig_target_size": orig_target_size}
+    )
+    return outputs
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__dynamic_batch_size(
+    model: LTDETRInstanceSegmentation, tmp_path: Path
+) -> None:
+    import numpy as np
+    import onnx
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_param == "N"
+
+    # Use a batch size (3) different from the one used during tracing (2).
+    inputs = np.random.randn(3, 3, 256, 256).astype(np.float32)
+    orig_target_size = np.array([[256, 256]] * 3, dtype=np.int64)
+
+    onnx_outputs = _run_seg_onnx(out, inputs, orig_target_size)
+
+    with torch.no_grad():
+        torch_outputs = model(
+            torch.from_numpy(inputs), torch.from_numpy(orig_target_size)
+        )
+
+    assert_onnx_outputs_close(onnx_outputs, torch_outputs)
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__static_batch_size(
+    model: LTDETRInstanceSegmentation, tmp_path: Path
+) -> None:
+    import onnx
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(
+        out=out, batch_size=3, dynamic_batch_size=False, simplify=False, verify=True
+    )
+
+    onnx_model = onnx.load(out)
+    input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
+    assert input_batch_dim.dim_value == 3
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU.")
+def test_export_onnx__fp16(model: LTDETRInstanceSegmentation, tmp_path: Path) -> None:
+    import onnx
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, precision="fp16", simplify=True, verify=True)
+
+    model_onnx = onnx.load(str(out))
+    # Verify the model has fp16 tensors.
+    has_fp16 = any(
+        init.data_type == onnx.TensorProto.FLOAT16
+        for init in model_onnx.graph.initializer
+    )
+    assert has_fp16
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__simplify_matches_unsimplified(
+    model: LTDETRInstanceSegmentation, tmp_path: Path
+) -> None:
+    # onnxslim rewrites the graph in-place; the simplified model must produce
+    # the same outputs as the unsimplified one for the same input.
+    import numpy as np
+
+    simplified = tmp_path / "simplified.onnx"
+    unsimplified = tmp_path / "unsimplified.onnx"
+    model.export_onnx(out=simplified, simplify=True, verify=True)
+    model.export_onnx(out=unsimplified, simplify=False, verify=True)
+
+    inputs = np.random.randn(2, 3, 256, 256).astype(np.float32)
+    orig_target_size = np.array([[256, 256]] * 2, dtype=np.int64)
+
+    simplified_outputs = _run_seg_onnx(simplified, inputs, orig_target_size)
+    unsimplified_outputs = _run_seg_onnx(unsimplified, inputs, orig_target_size)
+
+    assert_onnx_outputs_close(
+        simplified_outputs,
+        tuple(torch.from_numpy(o) for o in unsimplified_outputs),
+    )
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+@pytest.mark.parametrize("model_name", LTDETR_V2_SEG_ALIAS_MODEL_NAMES)
+def test_export_onnx__aliases_and_non_square(model_name: str, tmp_path: Path) -> None:
+    # Every registered alias (s/m/l/x uses a different encoder/transformer
+    # config) must export at a non-square, non-default image size.
+    import numpy as np
+
+    image_size = (192, 256)
+    model = LTDETRInstanceSegmentation(
+        model_name=model_name,
+        classes={0: "background", 1: "car"},
+        image_size=image_size,
+        patch_size=16,
+        image_normalize={"mean": (0.485, 0.456, 0.406), "std": (0.229, 0.224, 0.225)},
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=True)
+
+    height, width = image_size
+    inputs = np.random.randn(1, 3, height, width).astype(np.float32)
+    orig_target_size = np.array([[height, width]], dtype=np.int64)
+
+    onnx_outputs = _run_seg_onnx(out, inputs, orig_target_size)
+    with torch.no_grad():
+        torch_outputs = model(
+            torch.from_numpy(inputs), torch.from_numpy(orig_target_size)
+        )
+    assert_onnx_outputs_close(onnx_outputs, torch_outputs)
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+@pytest.mark.parametrize("opset_version", [16, 17, 18, 19, 20, 21, 22, 23])
+def test_export_onnx__opset_version(
+    model: LTDETRInstanceSegmentation, tmp_path: Path, opset_version: int
+) -> None:
+    # The graph uses scaled_dot_product_attention (needs opset >= 14) and
+    # grid_sampler (needs opset >= 16), so opset 16 is the minimum supported.
+    import numpy as np
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, opset_version=opset_version, simplify=False, verify=True)
+    inputs = np.random.randn(1, 3, 256, 256).astype(np.float32)
+    orig_target_size = np.array([[256, 256]], dtype=np.int64)
+    onnx_outputs = _run_seg_onnx(out, inputs, orig_target_size)
+    with torch.no_grad():
+        torch_outputs = model(
+            torch.from_numpy(inputs), torch.from_numpy(orig_target_size)
+        )
+    assert_onnx_outputs_close(onnx_outputs, torch_outputs)
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
+def test_export_onnx__matches_predict(
+    model: LTDETRInstanceSegmentation, tmp_path: Path
+) -> None:
+    # The exported graph omits the normalization done in ``preprocess_batch`` and
+    # the mask upsampling / binarization / thresholding done in ``postprocess``.
+    # This test verifies that feeding a normalized input to the ONNX graph and
+    # replaying that documented post-processing reproduces ``predict``.
+    #
+    # Top-k ordering is not stable across backends for near-tied random scores,
+    # so the two prediction sets are compared order-invariantly.
+    import numpy as np
+    import torch.nn.functional as F
+    from torchvision.transforms.v2 import functional as transforms_functional
+
+    assert model.image_normalize is not None
+    threshold = 0.0  # Keep all queries so the comparison is deterministic.
+
+    # Reference prediction. The image already matches ``image_size`` so
+    # ``predict`` performs no resize and ``orig`` equals ``image_size``.
+    image = torch.rand(3, 256, 256)
+    prediction = model.predict(image, threshold=threshold)
+
+    out = tmp_path / "model.onnx"
+    model.export_onnx(out=out, simplify=False, verify=False)
+
+    # Replicate ``preprocess_batch``: the graph expects an already-normalized
+    # image (``preprocess_image`` already scaled it to ``[0, 1]``).
+    normalized = transforms_functional.normalize(
+        image,
+        mean=list(model.image_normalize["mean"]),
+        std=list(model.image_normalize["std"]),
+    )
+    inputs = normalized.unsqueeze(0).numpy().astype(np.float32)
+    orig_target_size = np.array([[256, 256]], dtype=np.int64)
+
+    labels, boxes, masks, scores = (
+        torch.from_numpy(o) for o in _run_seg_onnx(out, inputs, orig_target_size)
+    )
+
+    # Replicate ``postprocess``: threshold, upsample masks to the original size,
+    # and binarize.
+    keep = scores[0] > threshold
+    onnx_masks = (
+        F.interpolate(
+            masks[0][keep].unsqueeze(1),
+            size=(256, 256),
+            mode="bilinear",
+            align_corners=False,
+        ).squeeze(1)
+        > 0.0
+    )
+
+    # Same number of predictions and matching (order-invariant) score/label sets.
+    assert int(keep.sum()) == prediction["scores"].numel()
+    torch.testing.assert_close(
+        torch.sort(scores[0][keep]).values,
+        torch.sort(prediction["scores"]).values,
+        atol=2e-2,
+        rtol=1e-1,
+    )
+    assert torch.equal(
+        torch.sort(labels[0][keep]).values,
+        torch.sort(prediction["labels"]).values,
+    )
+    # Masks have the original resolution, are boolean, and cover the same area
+    # (order-invariant proxy for per-instance agreement).
+    assert onnx_masks.shape == prediction["masks"].shape
+    assert onnx_masks.dtype == torch.bool == prediction["masks"].dtype
+    onnx_area = int(onnx_masks.sum())
+    predict_area = int(prediction["masks"].sum())
+    assert abs(onnx_area - predict_area) <= max(1, round(0.01 * predict_area))

--- a/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
@@ -420,7 +420,7 @@ def test_export_onnx__aliases_and_non_square(model_name: str, tmp_path: Path) ->
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
 )
-@pytest.mark.parametrize("opset_version", [16, 17, 18, 19, 20, 21, 22, 23])
+@pytest.mark.parametrize("opset_version", [16, 17, 18, 19, 20])
 def test_export_onnx__opset_version(
     model: LTDETRInstanceSegmentation, tmp_path: Path, opset_version: int
 ) -> None:

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -53,6 +53,8 @@ from lightly_train._task_models.object_detection_components.rtdetrv2_decoder imp
     RTDETRTransformerv2,
 )
 
+from ...helpers import assert_onnx_outputs_close
+
 
 def _is_module_frozen(m: nn.Module) -> bool:
     return all(not param.requires_grad for param in m.parameters())
@@ -701,13 +703,10 @@ def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
     with torch.no_grad():
         torch_outputs = model(torch.from_numpy(inputs))
 
-    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
-        onnx_tensor = torch.from_numpy(onnx_out)
-        if torch_out.is_floating_point():
-            close = torch.isclose(onnx_tensor, torch_out, atol=2e-2, rtol=1e-1)
-            assert close.float().mean() > 0.95
-        else:
-            assert (onnx_tensor == torch_out).float().mean() > 0.95
+    # Compare via the shared helper: it sums over the query dim before comparing
+    # floats (order-invariant, since the postprocessor's top-k can reorder
+    # queries across backends) and treats labels as sorted multisets.
+    assert_onnx_outputs_close(onnx_outputs, torch_outputs)
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,7 +14,7 @@ import random
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Literal
+from typing import Any, Callable, Iterable, Literal, Sequence
 
 import numpy as np
 import torch
@@ -1076,3 +1076,48 @@ def dummy_dinov3_vit_model(patch_size: int = 2, **kwargs: Any) -> DINOv3ViTModel
 
 def dummy_dinov3_convnext_model(**kwargs: Any) -> DINOv3VConvNeXtModelWrapper:
     return DINOv3VConvNeXtModelWrapper(model=_dinov3_convnext_test(**kwargs))
+
+
+def assert_onnx_outputs_close(
+    onnx_outputs: Sequence[np.ndarray],
+    torch_outputs: Sequence[Tensor],
+    *,
+    atol: float = 5e-3,
+    rtol: float = 1e-1,
+    min_close_fraction: float = 0.95,
+) -> None:
+    """Assert ONNX Runtime outputs match a PyTorch reference for LT-DETR exports.
+
+    The LT-DETR postprocessors apply a top-k over queries, so the per-query order
+    is not stable across backends when scores are near-tied. Float outputs are
+    therefore compared after summing over the query dim (dim=1), which makes the
+    comparison order-invariant, and integer ``labels`` are compared as sorted
+    multisets. This mirrors the summing done by the model's own
+    ``export_onnx(verify=True)`` check.
+
+    Args:
+        onnx_outputs:
+            Outputs from ``onnxruntime.InferenceSession.run``, in the model's
+            ``get_export_output_names`` order.
+        torch_outputs:
+            Reference outputs from the eager model's ``forward``, same order.
+        atol:
+            Absolute tolerance for the float comparison.
+        rtol:
+            Relative tolerance for the float comparison.
+        min_close_fraction:
+            Minimum fraction of elements that must be close for float outputs.
+    """
+    assert len(onnx_outputs) == len(torch_outputs)
+    for onnx_out, torch_out in zip(onnx_outputs, torch_outputs):
+        onnx_tensor = torch.from_numpy(onnx_out)
+        assert onnx_tensor.shape == torch_out.shape
+        if torch_out.is_floating_point():
+            onnx_summed = onnx_tensor.float().sum(dim=1)
+            torch_summed = torch_out.float().sum(dim=1)
+            close = torch.isclose(onnx_summed, torch_summed, atol=atol, rtol=rtol)
+            assert close.float().mean() > min_close_fraction
+        else:
+            assert np.array_equal(
+                np.sort(onnx_out.ravel()), np.sort(torch_out.numpy().ravel())
+            )


### PR DESCRIPTION
## What has changed and why?

Add ONNX and TensorRT export support for LT-DETR instance segmentation.

Note: it now exports both `images` and `orig_target_size` inputs so predicted boxes and masks can be scaled to the caller-provided image size - something listed as TODO in object detection. The TensorRT helper now configures matching optimization profiles for additional inputs with dynamic batch dimensions, such as `orig_target_size`, while rejecting unsupported dynamic non-batch dimensions.

## How has it been tested?

1. Unit tests covering
- static and dynamic batch export
- FP16
- simplification
- opset selection (ranging from 16 to 20 on CI)
- model aliases and non-square inputs
- prediction parity

3. A vibe-coded verification script that checks:
- Both inputs have a dynamic batch dimension.
- TensorRT accepts configured batch sizes, resolves output shapes, and produces finite outputs with the expected dimensions.
- TensorRT and ONNX Runtime produce compatible detections for identical random inputs.
Detections are aligned order-independently using labels, boxes, and scores.
- Boxes and scores are numerically close after alignment.
- Labels match exactly.
- Raw mask-logit error statistics are reported.
- Thresholded masks are compared using pixel agreement, IoU, and agreement away from the zero-logit boundary.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)