### PR TITLE
Use LT-DETRv2 models in task training tests

### DIFF
--- a/src/lightly_train/_configs/model_registry.py
+++ b/src/lightly_train/_configs/model_registry.py
@@ -34,8 +34,13 @@ class ModelRegistry(Generic[ConfigT]):
     def __init__(self) -> None:
         self._registry: dict[str, Type[ConfigT]] = {}
         self._alias_metadata: dict[str, ModelAlias] = {}
+        self._aliases_excluded_from_model_list: set[str] = set()
 
-    def register(self, *aliases: AliasT) -> Callable[[Type[ConfigT]], Type[ConfigT]]:
+    def register(
+        self,
+        *aliases: AliasT,
+        include_in_model_list: bool = True,
+    ) -> Callable[[Type[ConfigT]], Type[ConfigT]]:
         def decorator(cls: Type[ConfigT]) -> Type[ConfigT]:
             for alias in aliases:
                 alias_name = alias.name if isinstance(alias, ModelAlias) else alias
@@ -48,6 +53,8 @@ class ModelRegistry(Generic[ConfigT]):
                 self._registry[alias_name] = cls
                 if isinstance(alias, ModelAlias):
                     self._alias_metadata[alias_name] = alias
+                if not include_in_model_list:
+                    self._aliases_excluded_from_model_list.add(alias_name)
             return cls
 
         return decorator
@@ -67,6 +74,13 @@ class ModelRegistry(Generic[ConfigT]):
 
     def list_aliases(self) -> dict[str, str]:
         return {alias: cls.__name__ for alias, cls in self._registry.items()}
+
+    def list_model_names(self) -> list[str]:
+        return [
+            alias
+            for alias in self._registry
+            if alias not in self._aliases_excluded_from_model_list
+        ]
 
     def get_alias_metadata(self, alias: str) -> ModelAlias:
         if alias not in self._alias_metadata:

--- a/src/lightly_train/_models/ecvit/ecvit_package.py
+++ b/src/lightly_train/_models/ecvit/ecvit_package.py
@@ -15,7 +15,6 @@ import torch
 
 from lightly_train._env import Env
 from lightly_train._models.ecvit.ecvit import (
-    ECVIT_PRESETS,
     ECVIT_PRETRAINED_URLS,
     ECViTModelWrapper,
 )
@@ -121,11 +120,6 @@ class EdgeCrafterPackage(Package):
         model_name = cls.parse_model_name(model_name=model_name)
         model_info = MODEL_NAME_TO_INFO[model_name]
         preset_name = model_info["preset_name"]
-        if preset_name not in ECVIT_PRESETS:
-            raise ValueError(
-                f"Unknown ECViT preset: '{preset_name}'. Available presets: "
-                f"{list(ECVIT_PRESETS)}."
-            )
 
         weights_path: PathLike | None = None
         if load_weights and model_info["default_weights"] is not None:

--- a/src/lightly_train/_models/ecvit/ecvit_package.py
+++ b/src/lightly_train/_models/ecvit/ecvit_package.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class _ECViTModelInfo(TypedDict):
+    preset_name: str
     default_weights: str | None
     local_path: str | None
     list: bool
@@ -34,21 +35,31 @@ class _ECViTModelInfo(TypedDict):
 
 MODEL_NAME_TO_INFO: dict[str, _ECViTModelInfo] = {
     "ecvitt": _ECViTModelInfo(
+        preset_name="ecvitt",
         default_weights=ECVIT_PRETRAINED_URLS["ecvitt"],
         local_path="ecvitt.pth",
         list=True,
     ),
+    "_ecvitt-notpretrained": _ECViTModelInfo(
+        preset_name="ecvitt",
+        default_weights=None,
+        local_path=None,
+        list=False,
+    ),
     "ecvittplus": _ECViTModelInfo(
+        preset_name="ecvittplus",
         default_weights=ECVIT_PRETRAINED_URLS["ecvittplus"],
         local_path="ecvittplus.pth",
         list=True,
     ),
     "ecvits": _ECViTModelInfo(
+        preset_name="ecvits",
         default_weights=ECVIT_PRETRAINED_URLS["ecvits"],
         local_path="ecvits.pth",
         list=True,
     ),
     "ecvitsplus": _ECViTModelInfo(
+        preset_name="ecvitsplus",
         default_weights=ECVIT_PRETRAINED_URLS["ecvitsplus"],
         local_path="ecvitsplus.pth",
         list=True,
@@ -107,18 +118,19 @@ class EdgeCrafterPackage(Package):
                 f"num_input_channels={num_input_channels}."
             )
 
-        preset_name = cls.parse_model_name(model_name=model_name)
+        model_name = cls.parse_model_name(model_name=model_name)
+        model_info = MODEL_NAME_TO_INFO[model_name]
+        preset_name = model_info["preset_name"]
         if preset_name not in ECVIT_PRESETS:
-            # Defensive: parse_model_name already enforces this.
             raise ValueError(
                 f"Unknown ECViT preset: '{preset_name}'. Available presets: "
                 f"{list(ECVIT_PRESETS)}."
             )
 
         weights_path: PathLike | None = None
-        if load_weights:
+        if load_weights and model_info["default_weights"] is not None:
             weights_path = _maybe_download_weights(
-                preset_name=preset_name, model_info=MODEL_NAME_TO_INFO[preset_name]
+                preset_name=preset_name, model_info=model_info
             )
 
         return ECViTModelWrapper(

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
@@ -172,6 +172,10 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
             default_factory=lambda: {"patch_size": 16}
         )
 
+    @LTDETR_SEG_MODEL_REGISTRY.register("_ltdetrv2-seg-s-notpretrained")
+    class EdgeCrafterECViTTinyNotPretrained(EdgeCrafterECViTTiny):
+        backbone_name: str = "edgecrafter/_ecvitt-notpretrained"
+
     @LTDETR_SEG_MODEL_REGISTRY.register(
         "edgecrafter/ecvittplus-ltdetr-seg", "ltdetrv2-seg-m"
     )

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
@@ -172,7 +172,9 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
             default_factory=lambda: {"patch_size": 16}
         )
 
-    @LTDETR_SEG_MODEL_REGISTRY.register("_ltdetrv2-seg-s-notpretrained")
+    @LTDETR_SEG_MODEL_REGISTRY.register(
+        "_ltdetrv2-seg-s-notpretrained", include_in_model_list=False
+    )
     class EdgeCrafterECViTTinyNotPretrained(EdgeCrafterECViTTiny):
         backbone_name: str = "edgecrafter/_ecvitt-notpretrained"
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -182,7 +182,11 @@ class LTDETRInstanceSegmentation(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return list(LTDETR_SEG_MODEL_REGISTRY.list_aliases())
+        return [
+            name
+            for name in LTDETR_SEG_MODEL_REGISTRY.list_aliases()
+            if not name.startswith("_")
+        ]
 
     @classmethod
     def parse_model_name(cls, model_name: str) -> dict[str, str]:

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -182,11 +182,7 @@ class LTDETRInstanceSegmentation(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return [
-            name
-            for name in LTDETR_SEG_MODEL_REGISTRY.list_aliases()
-            if not name.startswith("_")
-        ]
+        return LTDETR_SEG_MODEL_REGISTRY.list_model_names()
 
     @classmethod
     def parse_model_name(cls, model_name: str) -> dict[str, str]:

--- a/src/lightly_train/_task_models/ltdetr_object_detection/config.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/config.py
@@ -1087,6 +1087,10 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
             default_factory=lambda: {"patch_size": 16}
         )
 
+    @LTDETR_MODEL_REGISTRY.register("_ltdetrv2-s-notpretrained")
+    class EdgeCrafterECViTTinyNotPretrained(EdgeCrafterECViTTiny):
+        backbone_name: str = "edgecrafter/_ecvitt-notpretrained"
+
     @LTDETR_MODEL_REGISTRY.register(
         "edgecrafter/ecvittplus-ltdetr",
         "ltdetrv2-m",

--- a/src/lightly_train/_task_models/ltdetr_object_detection/config.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/config.py
@@ -1087,7 +1087,9 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
             default_factory=lambda: {"patch_size": 16}
         )
 
-    @LTDETR_MODEL_REGISTRY.register("_ltdetrv2-s-notpretrained")
+    @LTDETR_MODEL_REGISTRY.register(
+        "_ltdetrv2-s-notpretrained", include_in_model_list=False
+    )
     class EdgeCrafterECViTTinyNotPretrained(EdgeCrafterECViTTiny):
         backbone_name: str = "edgecrafter/_ecvitt-notpretrained"
 

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -308,11 +308,7 @@ class LTDETRObjectDetection(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return [
-            name
-            for name in LTDETR_MODEL_REGISTRY.list_aliases()
-            if not name.startswith("_")
-        ]
+        return LTDETR_MODEL_REGISTRY.list_model_names()
 
     @classmethod
     def parse_model_name(cls, model_name: str) -> dict[str, str]:

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -308,7 +308,11 @@ class LTDETRObjectDetection(TaskModel):
 
     @classmethod
     def list_model_names(cls) -> list[str]:
-        return list(LTDETR_MODEL_REGISTRY.list_aliases())
+        return [
+            name
+            for name in LTDETR_MODEL_REGISTRY.list_aliases()
+            if not name.startswith("_")
+        ]
 
     @classmethod
     def parse_model_name(cls, model_name: str) -> dict[str, str]:

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -232,7 +232,7 @@ def test_train_object_detection_yolo(tmp_path: Path) -> None:
     # Check training
     lightly_train.train_object_detection(
         out=out,
-        model="dinov3/vitt16-notpretrained-ltdetr",
+        model="_ltdetrv2-s-notpretrained",
         data={
             "path": data,
             "train": Path("train", "images"),
@@ -306,8 +306,8 @@ def test_train_instance_segmentation(
             "train": {"annotations": str(data / "train.json"), "images": "train"},
             "val": {"annotations": str(data / "val.json"), "images": "val"},
         },
-        model="dinov3/vitt16-notpretrained-eomt",
-        model_args={"num_joint_blocks": 1},
+        model="_ltdetrv2-seg-s-notpretrained",
+        model_args={"scheduler_name": "linear"},
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,

--- a/tests/_models/ecvit/test_ecvit_package.py
+++ b/tests/_models/ecvit/test_ecvit_package.py
@@ -1,0 +1,19 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from lightly_train._models.ecvit import ECVIT_PRESETS
+from lightly_train._models.ecvit.ecvit_package import MODEL_NAME_TO_INFO
+
+
+def test_model_info_presets_match_ecvit_presets() -> None:
+    preset_names = {
+        model_info["preset_name"] for model_info in MODEL_NAME_TO_INFO.values()
+    }
+
+    assert preset_names == set(ECVIT_PRESETS)


### PR DESCRIPTION
## What has changed and why?

Use lightweight, non-pretrained LT-DETRv2 presets in the object-detection and instance-segmentation training smoke tests.

This adds internal ECViT-Tiny-backed model aliases for both tasks, keeps those aliases out of the public model-name listings, and lets the ECViT package resolve an internal non-pretrained preset without downloading weights. The task training tests now exercise the LT-DETRv2 object-detection and instance-segmentation paths directly instead of using unrelated DINOv3/EoMT models.

## How has it been tested?

- `pytest tests/_commands/test_train_task.py::test_train_object_detection_yolo tests/_commands/test_train_task.py::test_train_instance_segmentation -q` (`2 passed`)
- `make static-checks`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)