### PR TITLE
Use weakly typed networks by default for TensorRT export

### DIFF
--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -620,11 +620,8 @@ class LTDETRInstanceSegmentation(TaskModel):
             max_batchsize=max_batchsize,
             opt_batchsize=opt_batchsize,
             min_batchsize=min_batchsize,
-            # We convert the fp32 attention scores already during ONNX export, so we
-            # build a strongly-typed engine: TensorRT then honors those fp32 Cast nodes
-            # instead of forcing the whole attention into FP16 (which overflows to NaN).
             fp32_attention_scores=False,
-            strongly_typed=True,
+            strongly_typed=False,
             verbose=verbose,
         )
 

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -34,6 +34,7 @@ from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer i
     DinoVisionTransformer as DINOv2VisionTransformer,
 )
 from lightly_train._models.dinov3.dinov3_convnext import DINOv3VConvNeXtModelWrapper
+from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.models.convnext import ConvNeXt
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer as DINOv3VisionTransformer,
@@ -173,6 +174,8 @@ class LTDETRObjectDetection(TaskModel):
         self.image_size = image_size
         self.classes = classes
         self.backbone_freeze = backbone_freeze
+        self._backbone_package_name = package_name
+        self._backbone_name = short_backbone
 
         if backbone_freeze:
             config.backbone_wrapper.finetune = False
@@ -975,6 +978,22 @@ class LTDETRObjectDetection(TaskModel):
         onnx_args = dict(onnx_args) if onnx_args is not None else {}
         onnx_args.setdefault("precision", precision)
 
+        strongly_typed = (
+            precision == "fp16"
+            and self._backbone_package_name == DINOV3_PACKAGE.name
+            and self._backbone_name == "vits16"
+        )
+        if strongly_typed:
+            logger.info(
+                "Using a strongly-typed TensorRT network for DINOv3 ViT-S to "
+                "preserve FP32 attention scores and prevent FP16 overflow."
+            )
+        else:
+            logger.info(
+                "Using a weakly-typed TensorRT network so TensorRT can optimize "
+                "layer precision."
+            )
+
         tensorrt_helpers.export_tensorrt(
             export_onnx_fn=self.export_onnx,
             out=out,
@@ -984,10 +1003,7 @@ class LTDETRObjectDetection(TaskModel):
             max_batchsize=max_batchsize,
             opt_batchsize=opt_batchsize,
             min_batchsize=min_batchsize,
-            # We convert the fp32 attention scores already during ONNX export, so we
-            # build a strongly-typed engine: TensorRT then honors those fp32 Cast nodes
-            # instead of forcing the whole attention into FP16 (which overflows to NaN).
             fp32_attention_scores=False,
-            strongly_typed=True,
+            strongly_typed=strongly_typed,
             verbose=verbose,
         )


### PR DESCRIPTION
## What has changed and why?

TensorRT export now uses weakly typed networks by default so TensorRT can optimize layer precision.

FP16 LT-DETR object-detection exports with a DINOv3 ViT-S/16 backbone continue to use a strongly typed network. This preserves FP32 attention scores for that configuration and prevents FP16 overflow. LT-DETR instance-segmentation exports now use the weakly typed default.

## How has it been tested?

- `make static-checks`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)