### PR TITLE
Apply all EdgeCrafter spatial feature blocks

### DIFF
--- a/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_decoder.py
+++ b/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_decoder.py
@@ -20,6 +20,10 @@ Copyright (c) 2023 lyuwenyu. All Rights Reserved.
 # - Added EdgeCrafter instance segmentation mask output support.
 # - Kept encoder auxiliary outputs box/class-only (matching EdgeCrafter, whose
 #   ``enc_aux_outputs`` carry no masks).
+# - Added a deploy-only deferred mask path (``convert_to_deploy`` sets
+#   ``_deploy_masks``) that emits the mask-head operands instead of the full
+#   mask tensor; training and validation keep the materialized-mask path so the
+#   mask-aware matcher and mask losses still receive per-query masks.
 from __future__ import annotations
 
 from typing import Any
@@ -55,6 +59,13 @@ class ECSegTransformer(DFINETransformer):
         kwargs["eval_spatial_size"] = eval_spatial_size
         super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
 
+        # The deferred-einsum mask path is deploy-only. Training and validation
+        # both run ``_forward_train`` (validation in eval mode) and need
+        # materialized ``pred_masks`` for the mask-aware matcher and the mask
+        # losses; gating on ``self.training`` would wrongly drop masks during
+        # validation. ``TaskModel.deploy()`` flips this via ``convert_to_deploy``.
+        self._deploy_masks = False
+
         # The mask head consumes one decoder query state per block. The decoder
         # can only emit ``hidden_dim``-width query states; wider post-``eval_idx``
         # layers (``layer_scale > 1`` with ``eval_idx < num_layers - 1``) are
@@ -83,6 +94,13 @@ class ECSegTransformer(DFINETransformer):
             image_size=eval_spatial_size,
             layer_scale_init_value=mask_layer_scale_init_value,
         )
+
+    def convert_to_deploy(self) -> None:
+        # Invoked by ``TaskModel.deploy()`` (ONNX/TensorRT export and inference).
+        # Enables the deferred-einsum mask path; training/validation keep the
+        # materialized-mask path.
+        super().convert_to_deploy()  # type: ignore[no-untyped-call]
+        self._deploy_masks = True
 
     def forward(
         self,
@@ -154,6 +172,25 @@ class ECSegTransformer(DFINETransformer):
             dn_meta=dn_meta,
             return_query_states=True,
         )
+
+        if self._deploy_masks:
+            # Deploy only: defer the mask einsum to the postprocessor so it can
+            # gather the selected queries (a small (B, Q, C) gather) instead of
+            # gathering the full (B, Q, Hm, Wm) mask tensor. Produces identical
+            # masks because the per-query einsum commutes with the query gather.
+            # Training and validation keep the materialized-mask path below so
+            # the matcher and criterion still see ``pred_masks``.
+            final_query = query_states.unbind(0)[-1]
+            mask_spatial, mask_query = self.mask_head.forward_deploy(
+                spatial_feat, final_query
+            )
+            return {
+                "pred_logits": out_logits[-1],
+                "pred_boxes": out_bboxes[-1],
+                "pred_mask_spatial": mask_spatial,
+                "pred_mask_query": mask_query,
+                "pred_mask_bias": self.mask_head.bias,
+            }
 
         mask_logits = torch.stack(
             self.mask_head(

--- a/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_head.py
+++ b/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_head.py
@@ -18,6 +18,9 @@ Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # - Added typed interfaces.
 # - Renamed the head to EdgeCrafterInstanceSegmentationHead.
 # - Removed exporting.
+# - Added ``forward_deploy`` returning the mask-einsum operands (projected
+#   spatial and query features) so the postprocessor can gather the selected
+#   queries before the einsum instead of gathering the full mask tensor.
 
 from __future__ import annotations
 
@@ -185,3 +188,35 @@ class EdgeCrafterInstanceSegmentationHead(nn.Module):
                 + self.bias
             )
         return mask_logits
+
+    def forward_deploy(
+        self,
+        spatial_features: Tensor,
+        query_feature: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Returns the mask-einsum operands for the deployed single-query path.
+
+        Instead of computing the full ``(B, Q, Hm, Wm)`` mask tensor, this returns
+        the projected spatial features ``(B, Ci, Hm, Wm)`` and projected query
+        features ``(B, Q, Ci)``. The postprocessor gathers the selected query rows
+        (a cheap ``(B, Q, Ci)`` gather) and only then runs the einsum, avoiding a
+        ``GatherElements`` over the full-resolution mask tensor. This reproduces
+        the deployed ``forward`` path (final query paired with the first block),
+        because the per-query einsum commutes with the query gather.
+        """
+        target_size = (
+            self.image_size[0] // self.downsample_ratio,
+            self.image_size[1] // self.downsample_ratio,
+        )
+        spatial_features = F.interpolate(
+            spatial_features,
+            size=target_size,
+            mode="bilinear",
+            align_corners=False,
+        )
+        spatial_features = self.blocks[0](spatial_features)
+        spatial_features_proj = self.spatial_features_proj(spatial_features)
+        query_feature = self.query_features_proj(
+            self.query_features_block(query_feature)
+        )
+        return spatial_features_proj, query_feature

--- a/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_head.py
+++ b/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_head.py
@@ -21,6 +21,7 @@ Licensed under the Apache License, Version 2.0 [see LICENSE for details]
 # - Added ``forward_deploy`` returning the mask-einsum operands (projected
 #   spatial and query features) so the postprocessor can gather the selected
 #   queries before the einsum instead of gathering the full mask tensor.
+# - Applied all spatial feature blocks instead of only the first block.
 
 from __future__ import annotations
 
@@ -214,7 +215,8 @@ class EdgeCrafterInstanceSegmentationHead(nn.Module):
             mode="bilinear",
             align_corners=False,
         )
-        spatial_features = self.blocks[0](spatial_features)
+        for block in self.blocks:
+            spatial_features = block(spatial_features)
         spatial_features_proj = self.spatial_features_proj(spatial_features)
         query_feature = self.query_features_proj(
             self.query_features_block(query_feature)

--- a/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_postprocessor.py
+++ b/src/lightly_train/_task_models/instance_segmentation_components/edgecrafter_postprocessor.py
@@ -16,6 +16,9 @@ Copyright (c) 2023 lyuwenyu. All Rights Reserved.
 # Modifications Copyright 2026 Lightly AG:
 # - Added typed interfaces.
 # - Renamed the postprocessor to EdgeCrafterInstanceSegmentationPostProcessor.
+# - Added a deferred-einsum mask path that gathers the selected query features
+#   before the mask einsum, avoiding a GatherElements over the full-resolution
+#   mask tensor. The materialized-mask gather is kept as a fallback.
 
 from __future__ import annotations
 
@@ -57,6 +60,12 @@ class ECSegPostProcessor(RTDETRPostProcessor):
         logits = outputs["pred_logits"]
         boxes = outputs["pred_boxes"]
         mask_pred = outputs.get("pred_masks", None)
+        # Deferred-einsum operands (deploy/eval path): the mask head returns the
+        # projected spatial and query features instead of the full mask tensor so
+        # the query gather happens before the einsum (see forward_deploy).
+        mask_spatial = outputs.get("pred_mask_spatial", None)
+        mask_query = outputs.get("pred_mask_query", None)
+        mask_bias = outputs.get("pred_mask_bias", None)
 
         bbox_pred = torchvision.ops.box_convert(boxes, in_fmt="cxcywh", out_fmt="xyxy")
         bbox_pred *= orig_target_sizes.repeat(1, 2).unsqueeze(1)
@@ -71,7 +80,20 @@ class ECSegPostProcessor(RTDETRPostProcessor):
                 dim=1,
                 index=index.unsqueeze(-1).repeat(1, 1, bbox_pred.shape[-1]),
             )
-            if mask_pred is not None:
+            if mask_spatial is not None:
+                # Gather the selected query embeddings (small (B, Q, Ci) index),
+                # then run the einsum — instead of gathering the full-resolution
+                # mask tensor with a (B, Q, Hm, Wm) index. The deploy decoder
+                # always emits the spatial/query/bias operands together.
+                assert mask_query is not None
+                selected_query = mask_query.gather(
+                    dim=1,
+                    index=index.unsqueeze(-1).expand(-1, -1, mask_query.shape[-1]),
+                )
+                masks = torch.einsum("bchw,bqc->bqhw", mask_spatial, selected_query)
+                if mask_bias is not None:
+                    masks = masks + mask_bias
+            elif mask_pred is not None:
                 masks = mask_pred.gather(
                     dim=1,
                     index=index.unsqueeze(-1)
@@ -79,7 +101,7 @@ class ECSegPostProcessor(RTDETRPostProcessor):
                     .repeat(1, 1, mask_pred.shape[-2], mask_pred.shape[-1]),
                 )
         else:
-            if mask_pred is not None:
+            if mask_pred is not None or mask_spatial is not None:
                 # EdgeCrafter only gathers masks in the focal-loss branch; its
                 # softmax branch has no mask path. Fail loudly instead of
                 # silently dropping the predicted masks.


### PR DESCRIPTION
## What has changed and why?

This fixes two related problems in the exported ECSeg segmentation-mask path.

### Segmentation-head deploy path

During ONNX export, the ECSeg transformer was not switched to a segmentation-specific deploy path because it did not implement the expected `convert_to_deploy()` method. The exported path receives only the final decoder query state, but the segmentation head processed the spatial features with only `self.blocks[0]`. The other three trained spatial blocks were skipped, producing incorrect segmentation behavior in the exported model. The stashed `seg head` change reproduces this behavior in the LightlyTrain ECSeg implementation.

The ECSeg transformer now implements `convert_to_deploy()` and enables a deploy-only deferred-mask path. `forward_deploy()` applies every spatial block before projecting the spatial features and pairing them with the final decoder query state. Training and validation retain the existing materialized-mask path used by the matcher and mask losses.

### Expensive `GatherElements` mask path

The previous ONNX mask-output chain was approximately:

```
einsum
→ torch.stack([one element])
→ Gather[-1]
→ GatherElements(index = Tile → (1, 300, 160, 160), int64, approximately 61 MB)
→ masks
```

In the LightlyTrain TensorRT graph this path costs approximately 1.24 ms—around 6× the corresponding EdgeCrafter path. The likely cause is the 61 MB tiled-index `GatherElements`, together with the stack-of-one `Unsqueeze` / `Concat` / `Gather` chain, landing on a slow FP32 or uncoalesced path instead of being fused or folded.

The deploy path now defers the mask einsum. The segmentation head returns projected spatial features, projected query features, and the mask bias. The postprocessor first gathers the selected compact query embeddings and only then computes the mask einsum. This avoids `GatherElements` over the full `(B, Q, Hm, Wm)` mask tensor while preserving the resulting selected masks.

This `GatherElements` fix is based on the `fix gather element` commit from the `debug-instance-segmentation-benchmark` branch.

## How has it been tested?

- The inference benchmarks.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)