### PR TITLE
docs: document distillation default teacher per version (TRN-2293)

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -96,10 +96,10 @@ LightlyTrain offers several advantages over other self-supervised learning (SSL)
 - **Seamless workflow**: LightlyTrain automatically pretrains the correct layers and exports 
   models in the right format for fine-tuning, reducing risks when moving from pretraining to 
   fine-tuning.
-- **DINOv2 distillation**: Lightly has developed a unique distillation method that allows
-  you to pretrain smaller models with the knowledge of larger DINOv2 models without the need for
-  large compute resources.
-- **DINOv2 pretraining**: LightlyTrain supports DINOv2 pretraining out of the box,
+- **Distillation**: Lightly has developed a unique distillation method that allows
+  you to pretrain smaller models with the knowledge of larger foundation models,
+  such as DINOv2 or DINOv3, without the need for large compute resources.
+- **DINOv2 method**: LightlyTrain supports the DINOv2 training method out of the box,
   allowing you to train state-of-the-art vision foundation models on your own datasets.
 ```
 
@@ -355,8 +355,8 @@ appropriate for your downstream task.
 
 ```{dropdown} <h6>Which pretraining methods are supported?<a class="headerlink" id="which-pretraining-methods-are-supported" href="#which-pretraining-methods-are-supported" title="Link to this heading">¶</a></h6>
 LightlyTrain supports different methods such as:
-- DINOv2 distillation
-- DINOv2
+- Distillation (with a foundation model teacher, such as DINOv2 or DINOv3)
+- DINOv2 (self-supervised training method)
 - DINO
 - SimCLR
 
@@ -387,22 +387,27 @@ model guides the training of your student model.
 
 During distillation, the student model learns to produce similar feature representations as the 
 teacher model for the same input images. This allows smaller models to benefit from the knowledge 
-of larger, more powerful models like vision transformers pretrained with DINOv2, without requiring
+of larger, more powerful foundation models, such as DINOv2 or DINOv3, without requiring
 the same computational resources for training.
 ```
 
 ```{dropdown} <h6>What is DINOv2?<a class="headerlink" id="what-is-dinov2" href="#what-is-dinov2" title="Link to this heading">¶</a></h6>
-DINOv2 is a self-supervised learning method developed by Facebook AI Research (FAIR) that produces 
-state-of-the-art visual representations. It builds upon the original DINO (Self-Distillation with 
-No Labels) method and uses a Vision Transformer (ViT) architecture.
+DINOv2 is a self-supervised **training method** developed by Facebook AI Research (FAIR)
+that produces state-of-the-art visual representations. It builds upon the original DINO
+(Self-Distillation with No Labels) method and uses a Vision Transformer (ViT)
+architecture.
 
-DINOv2 models are pretrained on a diverse set of image data and have shown remarkable performance 
-across various visual tasks, from classification to dense prediction tasks. The resulting 
-representations exhibit strong semantic understanding and work well for zero-shot and few-shot 
-learning scenarios.
+Models pretrained with the DINOv2 method are called DINOv2 models. They are pretrained
+on a diverse set of image data and have shown remarkable performance across various
+visual tasks, from classification to dense prediction tasks. The resulting
+representations exhibit strong semantic understanding and work well for zero-shot and
+few-shot learning scenarios.
 
-In LightlyTrain, DINOv2-pretrained ViT models serve as teacher models for the distillation method, 
-transferring their knowledge to your chosen backbone architecture.
+In LightlyTrain, DINOv2 models serve as teacher models for the distillation method,
+transferring their knowledge to your chosen backbone architecture. They also serve
+as a starting point for fine-tuning downstream task models, including LT-DETR (object
+detection) and EoMT (semantic segmentation, instance segmentation, panoptic
+segmentation).
 ```
 
 ## Deployment

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -217,6 +217,14 @@ LightlyTrain supports the following model and workflow combinations.
 | YOLOv12                                    |              ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)              |    ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)    |
 | Custom PyTorch Model                       |           ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html)           | ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html) |
 
+```{note}
+For DINOv2/DINOv3, the model is paired with the matching training method or serves as
+distillation teacher (e.g. the DINOv2 model with `method="dinov2"` for pretraining, or
+as teacher for the `distillation` method). For all other models, the listed model is the
+student: "Pretraining" trains that model directly, and "Distillation" distills a default
+teacher's knowledge into it.
+```
+
 [Contact us](https://www.lightly.ai/contact) if you need support for additional models.
 
 ## Usage Events

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -11,15 +11,15 @@ data**. LightlyTrain offers three main functionalities for this:
 
    Pretraining lets you train a model on unlabeled data with self-supervised learning
    (SSL) methods. This is ideal if you want to train your own vision foundation models
-   like DINOv2.
+   using a method like [DINOv2](#methods-dinov2).
 
 1. **[Distillation](#methods-distillation)**
 
    Distillation is a special form of pretraining where a large, pretrained teacher
-   model, like DINOv2 or DINOv3, is used to guide the training of a smaller student
-   model. This is the ideal starting point if you want to improve performance of any
-   model that is not already a large vision foundation model, like YOLO, ConvNet, or
-   special transformer architectures.
+   model, like [DINOv2](#models-dinov2) or [DINOv3](#models-dinov3), is used to guide
+   the training of a smaller student model. This is the ideal starting point if you want
+   to improve performance of any model that is not already a large vision foundation
+   model, like YOLO, ConvNet, or special transformer architectures.
 
 1. **[Autolabeling](#predict-autolabel)**
 
@@ -54,7 +54,9 @@ if __name__ == "__main__":
     lightly_train.pretrain(
         out="out/my_experiment",
         data="my_data_dir",
+        # Examples: "edgecrafter/ecvitt", "timm/vits14", CustomModel(), ...
         model="torchvision/resnet50",
+        # Examples: "dinov2", "simclr", "dino", ...
         method="distillation",
         epochs=100,
         batch_size=128,
@@ -67,19 +69,23 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 ````
 
 ```{important}
-The default pretraining method `distillation` is recommended, as it consistently
-outperforms others in extensive experiments. Batch sizes between `128` and `1536` strike
+The default pretraining method [distillation](#methods-distillation) is
+recommended, as it consistently outperforms others in extensive experiments. Batch
+sizes between `128` and `1536` strike
 a good balance between speed and performance. Moreover, long training runs, such as
 2,000 epochs on COCO, significantly improve results. Check the [Methods](#methods-comparison)
-page for more details why `distillation` is the best choice.
+page for more details why [distillation](#methods-distillation) is the best
+choice.
 ```
 
-This will pretrain a ResNet-50 model from TorchVision using images from `my_data_dir`
-and the DINOv2 distillation pretraining method. All training logs, model exports, and
+This will distill a TorchVision ResNet-50 student model using images from `my_data_dir`
+and the default [distillation](#methods-distillation) setup, which uses a
+[DINOv3](#models-dinov3) teacher by default. All training logs, model exports, and
 checkpoints are saved to the output directory at `out/my_experiment`.
 
 ```{tip}
-See {meth}`lightly_train.train` for a complete list of available arguments.
+See {meth}`lightly_train.pretrain` for the complete Python API and run
+`lightly-train pretrain --help` for all command line arguments.
 ```
 
 (train-output)=
@@ -195,17 +201,28 @@ lightly-train pretrain out="out/my_experiment" data='["image2.jpg", "image3.jpg"
 
 See [supported libraries](#models-supported-libraries) in the Models page for a detailed
 list of all supported libraries and their respective docs pages for all supported
-models.
+models. You can also pass a pre-instantiated wrapper for a
+[custom model](#custom-models) when using Python.
 
 ## Method
 
-See [](#methods) for a list of all supported methods.
+The `method` argument selects the self-supervised learning recipe, not the model
+library. For example, `method="dinov2"` trains supported [DINOv2](#methods-dinov2) ViTs
+with the DINOv2 recipe, while `method="distillation"` trains a student model from a
+teacher and is the recommended default. [DINOv3](#models-dinov3) models are currently
+used through [distillation](#methods-distillation) or as fine-tuning backbones, not
+through a standalone `method="dinov3"` recipe. See [Methods](#methods) for a list of all
+supported methods.
 
 (logging)=
 
 ## Loggers
 
-Logging is configured with the `loggers` argument. The following loggers are supported:
+Logging is configured with the `loggers` argument passed to `lightly_train.pretrain()`
+or the `lightly-train pretrain` command. In Python, pass a nested dictionary such as
+`loggers={"jsonl": {"flush_logs_every_n_steps": 10}}`. On the command line, use dot
+notation such as `loggers.jsonl.flush_logs_every_n_steps=10`. The following loggers are
+supported:
 
 - [`jsonl`](#jsonl): Logs training metrics to a .jsonl file (enabled by default)
 - [`mlflow`](#mlflow): Logs training metrics to MLflow (disabled by default, requires
@@ -220,18 +237,39 @@ Logging is configured with the `loggers` argument. The following loggers are sup
 ### JSONL
 
 The JSONL logger is enabled by default and logs training metrics to a .jsonl file at
-`out/my_experiment/metrics.jsonl`.
-
-Disable the JSONL logger with:
+`out/my_experiment/metrics.jsonl`. Configure its arguments under the `jsonl` logger key:
 
 ````{tab} Python
 ```python
-loggers={"jsonl": None}
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"jsonl": {"flush_logs_every_n_steps": 10}},
+    )
 ````
 
 ````{tab} Command Line
 ```bash
-loggers.jsonl=null
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.jsonl.flush_logs_every_n_steps=10
+````
+
+Disable the JSONL logger with:
+
+````{tab} Python
+```python skip_ruff
+lightly_train.pretrain(
+    ...,
+    loggers={"jsonl": None},
+)
+````
+
+````{tab} Command Line
+```bash
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.jsonl=null
 ````
 
 (mlflow)=
@@ -242,7 +280,7 @@ loggers.jsonl=null
 MLflow must be installed with `pip install "lightly-train[mlflow]"`.
 ```
 
-The mlflow logger can be configured with the following arguments:
+Configure MLflow under the `mlflow` logger key:
 
 ````{tab} Python
 ```python
@@ -274,8 +312,28 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 
 ### TensorBoard
 
-TensorBoard logs are automatically saved to the output directory. Run TensorBoard in a
-new terminal to visualize the training progress:
+TensorBoard is enabled by default and its logs are automatically saved to the output
+directory. Configure TensorBoard under the `tensorboard` logger key:
+
+````{tab} Python
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"tensorboard": {"name": "my_experiment"}},
+    )
+````
+
+````{tab} Command Line
+```bash
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.tensorboard.name="my_experiment"
+````
+
+Run TensorBoard in a new terminal to visualize the training progress:
 
 ```bash
 tensorboard --logdir out/my_experiment
@@ -284,13 +342,16 @@ tensorboard --logdir out/my_experiment
 Disable the TensorBoard logger with:
 
 ````{tab} Python
-```python
-loggers={"tensorboard": None}
+```python skip_ruff
+lightly_train.pretrain(
+    ...,
+    loggers={"tensorboard": None},
+)
 ````
 
 ````{tab} Command Line
 ```bash
-loggers.tensorboard=null
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.tensorboard=null
 ````
 
 (wandb)=
@@ -301,7 +362,7 @@ loggers.tensorboard=null
 Weights & Biases must be installed with `pip install "lightly-train[wandb]"`.
 ```
 
-The Weights & Biases logger can be configured with the following arguments:
+Configure Weights & Biases under the `wandb` logger key:
 
 ````{tab} Python
 ```python
@@ -335,13 +396,16 @@ for more information.
 Disable the Weights & Biases logger with:
 
 ````{tab} Python
-```python
-loggers={"wandb": None}
+```python skip_ruff
+lightly_train.pretrain(
+    ...,
+    loggers={"wandb": None},
+)
 ````
 
 ````{tab} Command Line
 ```bash
-loggers.wandb=null
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.wandb=null
 ````
 
 ## Resume Training
@@ -451,8 +515,8 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 ```{tip}
 The default teacher for `distillation` / `distillationv3` is `dinov3/vitb16`. See
 {ref}`methods-distillation-default-teacher` for the per-version default table
-and the full list of supported teachers. Use a DINOv2 teacher (e.g.
-`dinov2/vitl14`) for a permissive Apache 2.0 license.
+and the full list of supported teachers. Use a [DINOv2](#models-dinov2) teacher
+(e.g. `dinov2/vitl14`) for a permissive Apache 2.0 license.
 ```
 
 Each pretraining method has its own set of arguments that can be configured.

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -435,8 +435,8 @@ if __name__ == "__main__":
         data="my_data_dir",                 # Directory with images
         model="torchvision/resnet18",       # Model to train
         method="distillation",              # Pretraining method
-        method_args={                       # Override the default teacher model
-            "teacher": "dinov2/vitl14",
+        method_args={                       # Override the default teacher model (default: dinov3/vitb16)
+            "teacher": "dinov3/vitl16",
         },
     )
 ```
@@ -444,9 +444,16 @@ if __name__ == "__main__":
 
 ````{tab} Command Line
 ```bash
-lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet18" method="distillation" method_args.teacher="dinov2/vitl14"
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet18" method="distillation" method_args.teacher="dinov3/vitl16"
 ```
 ````
+
+```{tip}
+The default teacher for `distillation` / `distillationv3` is `dinov3/vitb16`. See
+{ref}`methods-distillation-default-teacher` for the per-version default table
+and the full list of supported teachers. Use a DINOv2 teacher (e.g.
+`dinov2/vitl14`) for a permissive Apache 2.0 license.
+```
 
 Each pretraining method has its own set of arguments that can be configured.
 LightlyTrain provides sensible defaults that are adjusted depending on the dataset and

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -30,11 +30,11 @@ Each distillation version ships with a default teacher so you can start training
 specifying `method_args={"teacher": ...}`. Override the default via {ref}`method-args`
 if you want a different teacher.
 
-| Method                            | Default teacher       | License           | Notes                                          |
-| --------------------------------- | --------------------- | ----------------- | ---------------------------------------------- |
-| `distillation` / `distillationv3` | `dinov3/vitb16`       | DINOv3 (research) | Recommended default since LightlyTrain 0.15.0. |
-| `distillationv1`                  | `dinov2/vitb14-noreg` | Apache 2.0        | Global tasks (e.g. classification).            |
-| `distillationv2`                  | `dinov2/vitb14-noreg` | Apache 2.0        | Dense tasks; DINOv2 teacher only.              |
+| Method                            | Default teacher       | License    | Notes                                          |
+| --------------------------------- | --------------------- | ---------- | ---------------------------------------------- |
+| `distillation` / `distillationv3` | `dinov3/vitb16`       | DINOv3     | Recommended default since LightlyTrain 0.15.0. |
+| `distillationv1`                  | `dinov2/vitb14-noreg` | Apache 2.0 | Global tasks (e.g. classification).            |
+| `distillationv2`                  | `dinov2/vitb14-noreg` | Apache 2.0 | Dense tasks; DINOv2 teacher only.              |
 
 ```{tip}
 If you need a permissive Apache 2.0 license, switch the teacher to a DINOv2 model

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -24,7 +24,7 @@ Three distillation versions are available. Choose based on your downstream task:
 
 (methods-distillation-default-teacher)=
 
-### Default Teacher by Version
+## Default Teacher by Version
 
 Each distillation version ships with a default teacher so you can start training
 without specifying `method_args={"teacher": ...}`. Override the default via

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -26,15 +26,15 @@ Three distillation versions are available. Choose based on your downstream task:
 
 ## Default Teacher by Version
 
-Each distillation version ships with a default teacher so you can start training
-without specifying `method_args={"teacher": ...}`. Override the default via
-{ref}`method-args` if you want a different teacher.
+Each distillation version ships with a default teacher so you can start training without
+specifying `method_args={"teacher": ...}`. Override the default via {ref}`method-args`
+if you want a different teacher.
 
-| Method                | Default teacher      | License          | Notes                                   |
-| --------------------- | -------------------- | ---------------- | --------------------------------------- |
-| `distillation` / `distillationv3` | `dinov3/vitb16` | DINOv3 (research) | Recommended default since LightlyTrain 0.15.0. |
-| `distillationv1`      | `dinov2/vitb14-noreg` | Apache 2.0       | Global tasks (e.g. classification).     |
-| `distillationv2`      | `dinov2/vitb14-noreg` | Apache 2.0       | Dense tasks; DINOv2 teacher only.       |
+| Method                            | Default teacher       | License           | Notes                                          |
+| --------------------------------- | --------------------- | ----------------- | ---------------------------------------------- |
+| `distillation` / `distillationv3` | `dinov3/vitb16`       | DINOv3 (research) | Recommended default since LightlyTrain 0.15.0. |
+| `distillationv1`                  | `dinov2/vitb14-noreg` | Apache 2.0        | Global tasks (e.g. classification).            |
+| `distillationv2`                  | `dinov2/vitb14-noreg` | Apache 2.0        | Dense tasks; DINOv2 teacher only.              |
 
 ```{tip}
 If you need a permissive Apache 2.0 license, switch the teacher to a DINOv2 model
@@ -47,9 +47,9 @@ list of supported teachers.
 
 [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/distillation.ipynb)
 
-The example below uses LightlyTrain's default teacher (`dinov3/vitb16`, DINOv3
-ViT-B/16 — see {ref}`methods-distillation-default-teacher`) and a
-`torchvision/resnet18` model as the student:
+The example below uses LightlyTrain's default teacher (`dinov3/vitb16`, DINOv3 ViT-B/16
+— see {ref}`methods-distillation-default-teacher`) and a `torchvision/resnet18` model as
+the student:
 
 ```{note}
 DINOv3 models are released under the [DINOv3 license](https://github.com/lightly-ai/lightly-train/blob/main/licences/DINOv3_LICENSE.md). 
@@ -204,9 +204,8 @@ For distillation v1/v2, the following models for `teacher` are supported:
 
 For distillationv3, any model supported by LightlyTrain can be used (including custom
 models). The **default** is `dinov3/vitb16` (DINOv3 ViT-B/16) — see
-{ref}`methods-distillation-default-teacher` for the full per-version default
-table. You can find the full list of supported models on the [Models](#models)
-page.
+{ref}`methods-distillation-default-teacher` for the full per-version default table. You
+can find the full list of supported models on the [Models](#models) page.
 
 ## What's under the Hood
 

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -22,13 +22,34 @@ Three distillation versions are available. Choose based on your downstream task:
     `distillationv3` for DINOv3 teachers instead).
 ```
 
+(methods-distillation-default-teacher)=
+
+### Default Teacher by Version
+
+Each distillation version ships with a default teacher so you can start training
+without specifying `method_args={"teacher": ...}`. Override the default via
+{ref}`method-args` if you want a different teacher.
+
+| Method                | Default teacher      | License          | Notes                                   |
+| --------------------- | -------------------- | ---------------- | --------------------------------------- |
+| `distillation` / `distillationv3` | `dinov3/vitb16` | DINOv3 (research) | Recommended default since LightlyTrain 0.15.0. |
+| `distillationv1`      | `dinov2/vitb14-noreg` | Apache 2.0       | Global tasks (e.g. classification).     |
+| `distillationv2`      | `dinov2/vitb14-noreg` | Apache 2.0       | Dense tasks; DINOv2 teacher only.       |
+
+```{tip}
+If you need a permissive Apache 2.0 license, switch the teacher to a DINOv2 model
+(e.g. `method_args={"teacher": "dinov2/vitl14"}`) or use `distillationv1` /
+`distillationv2`. See {ref}`methods-distillation-supported-models` for the full
+list of supported teachers.
+```
+
 ## Use Distillation in LightlyTrain
 
 [![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/distillation.ipynb)
 
-Follow the code below to distill the knowledge of the default DINOv3 ViT-B/16 teacher
-model into your model architecture. The example uses a `torchvision/resnet18` model as
-the student:
+The example below uses LightlyTrain's default teacher (`dinov3/vitb16`, DINOv3
+ViT-B/16 — see {ref}`methods-distillation-default-teacher`) and a
+`torchvision/resnet18` model as the student:
 
 ```{note}
 DINOv3 models are released under the [DINOv3 license](https://github.com/lightly-ai/lightly-train/blob/main/licences/DINOv3_LICENSE.md). 
@@ -182,7 +203,10 @@ For distillation v1/v2, the following models for `teacher` are supported:
   - `dinov2/vitg14`
 
 For distillationv3, any model supported by LightlyTrain can be used (including custom
-models). You can find the full list of supported models on the [Models](#models) page.
+models). The **default** is `dinov3/vitb16` (DINOv3 ViT-B/16) — see
+{ref}`methods-distillation-default-teacher` for the full per-version default
+table. You can find the full list of supported models on the [Models](#models)
+page.
 
 ## What's under the Hood
 

--- a/docs/source/pretrain_distill/methods/index.md
+++ b/docs/source/pretrain_distill/methods/index.md
@@ -42,6 +42,10 @@ It has the following advantages:
   efficient.
 - **No Hyperparameter Tuning**: It has strong default parameters that require no or
   minimal tuning, simplifying the training process.
+- **Strong Default Teacher**: Out of the box, `distillation` / `distillationv3`
+  uses `dinov3/vitb16` as the teacher, so you don't need to specify one. See
+  {ref}`methods-distillation-default-teacher` for the per-version default
+  table.
 
 #### Cons
 

--- a/docs/source/pretrain_distill/methods/index.md
+++ b/docs/source/pretrain_distill/methods/index.md
@@ -42,10 +42,9 @@ It has the following advantages:
   efficient.
 - **No Hyperparameter Tuning**: It has strong default parameters that require no or
   minimal tuning, simplifying the training process.
-- **Strong Default Teacher**: Out of the box, `distillation` / `distillationv3`
-  uses `dinov3/vitb16` as the teacher, so you don't need to specify one. See
-  {ref}`methods-distillation-default-teacher` for the per-version default
-  table.
+- **Strong Default Teacher**: Out of the box, `distillation` / `distillationv3` uses
+  `dinov3/vitb16` as the teacher, so you don't need to specify one. See
+  {ref}`methods-distillation-default-teacher` for the per-version default table.
 
 #### Cons
 

--- a/docs/source/quick_start_distillation.md
+++ b/docs/source/quick_start_distillation.md
@@ -90,7 +90,8 @@ If you omit `method_args={"teacher": ...}`, LightlyTrain uses its default teache
 the chosen distillation version. For `distillation` / `distillationv3` that default is
 `dinov3/vitb16` (DINOv3 ViT-B/16). See
 {ref}`methods-distillation-default-teacher` for the per-version defaults and how to
-switch to a DINOv2 teacher.
+switch to a DINOv2 teacher. You can also use a custom teacher model — see
+{ref}`methods-distillation-custom-models`.
 ```
 
 ```{note}

--- a/docs/source/quick_start_distillation.md
+++ b/docs/source/quick_start_distillation.md
@@ -86,6 +86,14 @@ lightly_train.pretrain(
 ```
 
 ```{note}
+If you omit `method_args={"teacher": ...}`, LightlyTrain uses its default teacher for
+the chosen distillation version. For `distillation` / `distillationv3` that default is
+`dinov3/vitb16` (DINOv3 ViT-B/16). See
+{ref}`methods-distillation-default-teacher` for the per-version defaults and how to
+switch to a DINOv2 teacher.
+```
+
+```{note}
 This is a minimal example for illustration purposes. In practice you would want to use a
 larger dataset (>=10'000 images), more epochs (>=100, ideally ~1000), and a larger
 batch size (>=128). For pretraining larger models than `dinov3/vitt16` we also recommend

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -652,8 +652,8 @@ fine-tune it on your segmentation dataset. This is especially useful if your dat
 only partially labeled or if you have access to a large amount of unlabeled data.
 
 The following example shows how to pretrain and fine-tune the model. Check out the page
-on [DINOv2](#methods-dinov2) to learn more about pretraining DINOv2 models on unlabeled
-data.
+on the [DINOv2 method](#methods-dinov2) to learn more about pretraining DINOv2 models on
+unlabeled data.
 
 ```python
 import lightly_train


### PR DESCRIPTION
## What has changed and why?

Part of [TRN-2293](https://linear.app/lightly/issue/TRN-2293) (test everything related
to the pretraining pipeline, child of [TRN-2292](https://linear.app/lightly/issue/TRN-2292)
"Documentation Testing Before Maintenance Mode").

The default teacher for `distillation` was previously buried in a single sentence deep
in the intro prose and only hinted at via the hidden JSON dropdown at the bottom of
the page. The `method_args` override example in `pretrain_distill/index.md` also used
`dinov2/vitl14` as the override, which misleadingly suggested DINOv2 was the default.

This PR makes the default explicit and discoverable:

- New `(methods-distillation-default-teacher)` anchor on a "Default Teacher by
  Version" table at the top of `methods/distillation.md` listing `distillation` /
  `distillationv3` → `dinov3/vitb16`, `distillationv1` → `dinov2/vitb14-noreg`,
  `distillationv2` → `dinov2/vitb14-noreg`, with license column.
- Updated the "Supported Teacher Models" section to call out `dinov3/vitb16` as
  the v3 default.
- Fixed the misleading `method_args` override example in `pretrain_distill/index.md`
  to use a within-family DINOv3 override (`dinov3/vitl16`) and added a tip pointing
  to the new default-teacher table.
- Added the default-teacher bullet to the "Why use Distillation?" pros in
  `methods/index.md`.
- Added a note in `quick_start_distillation.md` explaining what happens when
  `method_args={"teacher": ...}` is omitted (default teacher kicks in).

Defaults themselves are unchanged — verified against the auto-generated dropdowns
in `methods/_auto/distillation*_method_args.md`.

## How has it been tested?

- `cd docs && uv run --frozen sphinx-build -b html --fail-on-warning --keep-going source /tmp/docs-build`
  passes with **no warnings**.
- Cross-reference audit: `grep -c 'methods-distillation-default-teacher'` returns
  3 references in `distillation.md`, 1 each in `pretrain_distill/index.md`,
  `methods/index.md`, `quick_start_distillation.md`. All resolve.
- Verified the auto-generated `_auto/distillation_method_args.md`,
  `_auto/distillationv1_method_args.md`, `_auto/distillationv2_method_args.md`
  dropdowns still show the same defaults as the new prose table — no
  inconsistency between docs and code.
- Rendered the page locally and confirmed the table, anchors, and internal links
  look correct.

## Did you update CHANGELOG.md?

- [x] Not needed (internal change without effects for user)

## Did you update the documentation?

- [x] Yes