### PR TITLE
docs: clarify pretrain docs

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -96,10 +96,10 @@ LightlyTrain offers several advantages over other self-supervised learning (SSL)
 - **Seamless workflow**: LightlyTrain automatically pretrains the correct layers and exports 
   models in the right format for fine-tuning, reducing risks when moving from pretraining to 
   fine-tuning.
-- **DINOv2 distillation**: Lightly has developed a unique distillation method that allows
-  you to pretrain smaller models with the knowledge of larger DINOv2 models without the need for
-  large compute resources.
-- **DINOv2 pretraining**: LightlyTrain supports DINOv2 pretraining out of the box,
+- **Distillation**: Lightly has developed a unique distillation method that allows
+  you to pretrain smaller models with the knowledge of larger foundation models,
+  such as DINOv2 or DINOv3, without the need for large compute resources.
+- **DINOv2 method**: LightlyTrain supports the DINOv2 training method out of the box,
   allowing you to train state-of-the-art vision foundation models on your own datasets.
 ```
 
@@ -355,8 +355,8 @@ appropriate for your downstream task.
 
 ```{dropdown} <h6>Which pretraining methods are supported?<a class="headerlink" id="which-pretraining-methods-are-supported" href="#which-pretraining-methods-are-supported" title="Link to this heading">¶</a></h6>
 LightlyTrain supports different methods such as:
-- DINOv2 distillation
-- DINOv2
+- Distillation (with a foundation model teacher, such as DINOv2 or DINOv3)
+- DINOv2 (self-supervised training method)
 - DINO
 - SimCLR
 
@@ -387,22 +387,27 @@ model guides the training of your student model.
 
 During distillation, the student model learns to produce similar feature representations as the 
 teacher model for the same input images. This allows smaller models to benefit from the knowledge 
-of larger, more powerful models like vision transformers pretrained with DINOv2, without requiring
+of larger, more powerful foundation models, such as DINOv2 or DINOv3, without requiring
 the same computational resources for training.
 ```
 
 ```{dropdown} <h6>What is DINOv2?<a class="headerlink" id="what-is-dinov2" href="#what-is-dinov2" title="Link to this heading">¶</a></h6>
-DINOv2 is a self-supervised learning method developed by Facebook AI Research (FAIR) that produces 
-state-of-the-art visual representations. It builds upon the original DINO (Self-Distillation with 
-No Labels) method and uses a Vision Transformer (ViT) architecture.
+DINOv2 is a self-supervised **training method** developed by Facebook AI Research (FAIR)
+that produces state-of-the-art visual representations. It builds upon the original DINO
+(Self-Distillation with No Labels) method and uses a Vision Transformer (ViT)
+architecture.
 
-DINOv2 models are pretrained on a diverse set of image data and have shown remarkable performance 
-across various visual tasks, from classification to dense prediction tasks. The resulting 
-representations exhibit strong semantic understanding and work well for zero-shot and few-shot 
-learning scenarios.
+Models pretrained with the DINOv2 method are called DINOv2 models. They are pretrained
+on a diverse set of image data and have shown remarkable performance across various
+visual tasks, from classification to dense prediction tasks. The resulting
+representations exhibit strong semantic understanding and work well for zero-shot and
+few-shot learning scenarios.
 
-In LightlyTrain, DINOv2-pretrained ViT models serve as teacher models for the distillation method, 
-transferring their knowledge to your chosen backbone architecture.
+In LightlyTrain, DINOv2 models serve as teacher models for the distillation method,
+transferring their knowledge to your chosen backbone architecture. They also serve
+as a starting point for fine-tuning downstream task models, including LT-DETR (object
+detection) and EoMT (semantic segmentation, instance segmentation, panoptic
+segmentation).
 ```
 
 ## Deployment

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -217,6 +217,14 @@ LightlyTrain supports the following model and workflow combinations.
 | YOLOv12                                    |              ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)              |    ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)    |
 | Custom PyTorch Model                       |           ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html)           | ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html) |
 
+```{note}
+For DINOv2/DINOv3, the model is paired with the matching training method or serves as
+distillation teacher (e.g. the DINOv2 model with `method="dinov2"` for pretraining, or
+as teacher for the `distillation` method). For all other models, the listed model is the
+student: "Pretraining" trains that model directly, and "Distillation" distills a default
+teacher's knowledge into it.
+```
+
 [Contact us](https://www.lightly.ai/contact) if you need support for additional models.
 
 ## Usage Events

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -16,10 +16,10 @@ data**. LightlyTrain offers three main functionalities for this:
 1. **[Distillation](#methods-distillation)**
 
    Distillation is a special form of pretraining where a large, pretrained teacher
-   model, like {ref}`DINOv2 <models-dinov2>` or {ref}`DINOv3 <models-dinov3>`, is used
-   to guide the training of a smaller student model. This is the ideal starting point if
-   you want to improve performance of any model that is not already a large vision
-   foundation model, like YOLO, ConvNet, or special transformer architectures.
+   model, like [DINOv2](#models-dinov2) or [DINOv3](#models-dinov3), is used to guide
+   the training of a smaller student model. This is the ideal starting point if you want
+   to improve performance of any model that is not already a large vision foundation
+   model, like YOLO, ConvNet, or special transformer architectures.
 
 1. **[Autolabeling](#predict-autolabel)**
 
@@ -69,18 +69,18 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 ````
 
 ```{important}
-The default pretraining method {ref}`distillation <methods-distillation>` is
+The default pretraining method [distillation](#methods-distillation) is
 recommended, as it consistently outperforms others in extensive experiments. Batch
 sizes between `128` and `1536` strike
 a good balance between speed and performance. Moreover, long training runs, such as
 2,000 epochs on COCO, significantly improve results. Check the [Methods](#methods-comparison)
-page for more details why {ref}`distillation <methods-distillation>` is the best
+page for more details why [distillation](#methods-distillation) is the best
 choice.
 ```
 
 This will distill a TorchVision ResNet-50 student model using images from `my_data_dir`
-and the default {ref}`distillation <methods-distillation>` setup, which uses a
-{ref}`DINOv3 <models-dinov3>` teacher by default. All training logs, model exports, and
+and the default [distillation](#methods-distillation) setup, which uses a
+[DINOv3](#models-dinov3) teacher by default. All training logs, model exports, and
 checkpoints are saved to the output directory at `out/my_experiment`.
 
 ```{tip}
@@ -207,12 +207,12 @@ models. You can also pass a pre-instantiated wrapper for a
 ## Method
 
 The `method` argument selects the self-supervised learning recipe, not the model
-library. For example, `method="dinov2"` trains supported {ref}`DINOv2 <methods-dinov2>`
-ViTs with the DINOv2 recipe, while `method="distillation"` trains a student model from a
-teacher and is the recommended default. {ref}`DINOv3 <models-dinov3>` models are
-currently used through {ref}`distillation <methods-distillation>` or as fine-tuning
-backbones, not through a standalone `method="dinov3"` recipe. See [Methods](#methods)
-for a list of all supported methods.
+library. For example, `method="dinov2"` trains supported [DINOv2](#methods-dinov2) ViTs
+with the DINOv2 recipe, while `method="distillation"` trains a student model from a
+teacher and is the recommended default. [DINOv3](#models-dinov3) models are currently
+used through [distillation](#methods-distillation) or as fine-tuning backbones, not
+through a standalone `method="dinov3"` recipe. See [Methods](#methods) for a list of all
+supported methods.
 
 (logging)=
 
@@ -260,16 +260,11 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 Disable the JSONL logger with:
 
 ````{tab} Python
-```python
-import lightly_train
-
-if __name__ == "__main__":
-    lightly_train.pretrain(
-        out="out/my_experiment",
-        data="my_data_dir",
-        model="torchvision/resnet50",
-        loggers={"jsonl": None},
-    )
+```python skip_ruff
+lightly_train.pretrain(
+    ...,
+    loggers={"jsonl": None},
+)
 ````
 
 ````{tab} Command Line
@@ -317,8 +312,8 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 
 ### TensorBoard
 
-TensorBoard logs are automatically saved to the output directory. Configure TensorBoard
-under the `tensorboard` logger key:
+TensorBoard is enabled by default and its logs are automatically saved to the output
+directory. Configure TensorBoard under the `tensorboard` logger key:
 
 ````{tab} Python
 ```python
@@ -347,16 +342,11 @@ tensorboard --logdir out/my_experiment
 Disable the TensorBoard logger with:
 
 ````{tab} Python
-```python
-import lightly_train
-
-if __name__ == "__main__":
-    lightly_train.pretrain(
-        out="out/my_experiment",
-        data="my_data_dir",
-        model="torchvision/resnet50",
-        loggers={"tensorboard": None},
-    )
+```python skip_ruff
+lightly_train.pretrain(
+    ...,
+    loggers={"tensorboard": None},
+)
 ````
 
 ````{tab} Command Line
@@ -406,16 +396,11 @@ for more information.
 Disable the Weights & Biases logger with:
 
 ````{tab} Python
-```python
-import lightly_train
-
-if __name__ == "__main__":
-    lightly_train.pretrain(
-        out="out/my_experiment",
-        data="my_data_dir",
-        model="torchvision/resnet50",
-        loggers={"wandb": None},
-    )
+```python skip_ruff
+lightly_train.pretrain(
+    ...,
+    loggers={"wandb": None},
+)
 ````
 
 ````{tab} Command Line
@@ -530,7 +515,7 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 ```{tip}
 The default teacher for `distillation` / `distillationv3` is `dinov3/vitb16`. See
 {ref}`methods-distillation-default-teacher` for the per-version default table
-and the full list of supported teachers. Use a {ref}`DINOv2 <models-dinov2>` teacher
+and the full list of supported teachers. Use a [DINOv2](#models-dinov2) teacher
 (e.g. `dinov2/vitl14`) for a permissive Apache 2.0 license.
 ```
 

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -372,7 +372,7 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 Weights & Biases must be installed with `pip install "lightly-train[wandb]"`.
 ```
 
-The Weights & Biases logger can be configured with the following arguments:
+Configure Weights & Biases under the `wandb` logger key:
 
 ````{tab} Python
 ```python
@@ -407,12 +407,20 @@ Disable the Weights & Biases logger with:
 
 ````{tab} Python
 ```python
-loggers={"wandb": None}
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"wandb": None},
+    )
 ````
 
 ````{tab} Command Line
 ```bash
-loggers.wandb=null
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.wandb=null
 ````
 
 ## Resume Training

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -11,7 +11,7 @@ data**. LightlyTrain offers three main functionalities for this:
 
    Pretraining lets you train a model on unlabeled data with self-supervised learning
    (SSL) methods. This is ideal if you want to train your own vision foundation models
-   like {ref}`DINOv2 <methods-dinov2>`.
+   using a method like [DINOv2](#methods-dinov2).
 
 1. **[Distillation](#methods-distillation)**
 

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -11,15 +11,15 @@ data**. LightlyTrain offers three main functionalities for this:
 
    Pretraining lets you train a model on unlabeled data with self-supervised learning
    (SSL) methods. This is ideal if you want to train your own vision foundation models
-   like DINOv2.
+   like {ref}`DINOv2 <methods-dinov2>`.
 
 1. **[Distillation](#methods-distillation)**
 
    Distillation is a special form of pretraining where a large, pretrained teacher
-   model, like DINOv2 or DINOv3, is used to guide the training of a smaller student
-   model. This is the ideal starting point if you want to improve performance of any
-   model that is not already a large vision foundation model, like YOLO, ConvNet, or
-   special transformer architectures.
+   model, like {ref}`DINOv2 <models-dinov2>` or {ref}`DINOv3 <models-dinov3>`, is used
+   to guide the training of a smaller student model. This is the ideal starting point if
+   you want to improve performance of any model that is not already a large vision
+   foundation model, like YOLO, ConvNet, or special transformer architectures.
 
 1. **[Autolabeling](#predict-autolabel)**
 
@@ -54,7 +54,9 @@ if __name__ == "__main__":
     lightly_train.pretrain(
         out="out/my_experiment",
         data="my_data_dir",
+        # Examples: "edgecrafter/ecvitt", "timm/vits14", CustomModel(), ...
         model="torchvision/resnet50",
+        # Examples: "dinov2", "simclr", "dino", ...
         method="distillation",
         epochs=100,
         batch_size=128,
@@ -67,19 +69,23 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 ````
 
 ```{important}
-The default pretraining method `distillation` is recommended, as it consistently
-outperforms others in extensive experiments. Batch sizes between `128` and `1536` strike
+The default pretraining method {ref}`distillation <methods-distillation>` is
+recommended, as it consistently outperforms others in extensive experiments. Batch
+sizes between `128` and `1536` strike
 a good balance between speed and performance. Moreover, long training runs, such as
 2,000 epochs on COCO, significantly improve results. Check the [Methods](#methods-comparison)
-page for more details why `distillation` is the best choice.
+page for more details why {ref}`distillation <methods-distillation>` is the best
+choice.
 ```
 
-This will pretrain a ResNet-50 model from TorchVision using images from `my_data_dir`
-and the DINOv2 distillation pretraining method. All training logs, model exports, and
+This will distill a TorchVision ResNet-50 student model using images from `my_data_dir`
+and the default {ref}`distillation <methods-distillation>` setup, which uses a
+{ref}`DINOv3 <models-dinov3>` teacher by default. All training logs, model exports, and
 checkpoints are saved to the output directory at `out/my_experiment`.
 
 ```{tip}
-See {meth}`lightly_train.train` for a complete list of available arguments.
+See {meth}`lightly_train.pretrain` for the complete Python API and run
+`lightly-train pretrain --help` for all command line arguments.
 ```
 
 (train-output)=
@@ -195,17 +201,28 @@ lightly-train pretrain out="out/my_experiment" data='["image2.jpg", "image3.jpg"
 
 See [supported libraries](#models-supported-libraries) in the Models page for a detailed
 list of all supported libraries and their respective docs pages for all supported
-models.
+models. You can also pass a pre-instantiated wrapper for a
+[custom model](#custom-models) when using Python.
 
 ## Method
 
-See [](#methods) for a list of all supported methods.
+The `method` argument selects the self-supervised learning recipe, not the model
+library. For example, `method="dinov2"` trains supported {ref}`DINOv2 <methods-dinov2>`
+ViTs with the DINOv2 recipe, while `method="distillation"` trains a student model from a
+teacher and is the recommended default. {ref}`DINOv3 <models-dinov3>` models are
+currently used through {ref}`distillation <methods-distillation>` or as fine-tuning
+backbones, not through a standalone `method="dinov3"` recipe. See [Methods](#methods)
+for a list of all supported methods.
 
 (logging)=
 
 ## Loggers
 
-Logging is configured with the `loggers` argument. The following loggers are supported:
+Logging is configured with the `loggers` argument passed to `lightly_train.pretrain()`
+or the `lightly-train pretrain` command. In Python, pass a nested dictionary such as
+`loggers={"jsonl": {"flush_logs_every_n_steps": 10}}`. On the command line, use dot
+notation such as `loggers.jsonl.flush_logs_every_n_steps=10`. The following loggers are
+supported:
 
 - [`jsonl`](#jsonl): Logs training metrics to a .jsonl file (enabled by default)
 - [`mlflow`](#mlflow): Logs training metrics to MLflow (disabled by default, requires
@@ -220,18 +237,44 @@ Logging is configured with the `loggers` argument. The following loggers are sup
 ### JSONL
 
 The JSONL logger is enabled by default and logs training metrics to a .jsonl file at
-`out/my_experiment/metrics.jsonl`.
+`out/my_experiment/metrics.jsonl`. Configure its arguments under the `jsonl` logger key:
+
+````{tab} Python
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"jsonl": {"flush_logs_every_n_steps": 10}},
+    )
+````
+
+````{tab} Command Line
+```bash
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.jsonl.flush_logs_every_n_steps=10
+````
 
 Disable the JSONL logger with:
 
 ````{tab} Python
 ```python
-loggers={"jsonl": None}
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"jsonl": None},
+    )
 ````
 
 ````{tab} Command Line
 ```bash
-loggers.jsonl=null
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.jsonl=null
 ````
 
 (mlflow)=
@@ -242,7 +285,7 @@ loggers.jsonl=null
 MLflow must be installed with `pip install "lightly-train[mlflow]"`.
 ```
 
-The mlflow logger can be configured with the following arguments:
+Configure MLflow under the `mlflow` logger key:
 
 ````{tab} Python
 ```python
@@ -274,8 +317,28 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 
 ### TensorBoard
 
-TensorBoard logs are automatically saved to the output directory. Run TensorBoard in a
-new terminal to visualize the training progress:
+TensorBoard logs are automatically saved to the output directory. Configure TensorBoard
+under the `tensorboard` logger key:
+
+````{tab} Python
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"tensorboard": {"name": "my_experiment"}},
+    )
+````
+
+````{tab} Command Line
+```bash
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.tensorboard.name="my_experiment"
+````
+
+Run TensorBoard in a new terminal to visualize the training progress:
 
 ```bash
 tensorboard --logdir out/my_experiment
@@ -285,12 +348,20 @@ Disable the TensorBoard logger with:
 
 ````{tab} Python
 ```python
-loggers={"tensorboard": None}
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="torchvision/resnet50",
+        loggers={"tensorboard": None},
+    )
 ````
 
 ````{tab} Command Line
 ```bash
-loggers.tensorboard=null
+lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvision/resnet50" loggers.tensorboard=null
 ````
 
 (wandb)=
@@ -451,8 +522,8 @@ lightly-train pretrain out="out/my_experiment" data="my_data_dir" model="torchvi
 ```{tip}
 The default teacher for `distillation` / `distillationv3` is `dinov3/vitb16`. See
 {ref}`methods-distillation-default-teacher` for the per-version default table
-and the full list of supported teachers. Use a DINOv2 teacher (e.g.
-`dinov2/vitl14`) for a permissive Apache 2.0 license.
+and the full list of supported teachers. Use a {ref}`DINOv2 <models-dinov2>` teacher
+(e.g. `dinov2/vitl14`) for a permissive Apache 2.0 license.
 ```
 
 Each pretraining method has its own set of arguments that can be configured.

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -652,8 +652,8 @@ fine-tune it on your segmentation dataset. This is especially useful if your dat
 only partially labeled or if you have access to a large amount of unlabeled data.
 
 The following example shows how to pretrain and fine-tune the model. Check out the page
-on [DINOv2](#methods-dinov2) to learn more about pretraining DINOv2 models on unlabeled
-data.
+on the [DINOv2 method](#methods-dinov2) to learn more about pretraining DINOv2 models on
+unlabeled data.
 
 ```python
 import lightly_train


### PR DESCRIPTION
## What has changed and why?

Clarifies the Pretrain & Distill overview docs based on follow-up notes:

- links DINOv2, DINOv3, and distillation references where applicable
- updates the starter example comments with model/method alternatives and custom model mention
- clarifies that the default `distillation` setup uses a DINOv3 teacher
- points users to `lightly_train.pretrain` and `lightly-train pretrain --help`
- adds clearer logger configuration examples for JSONL, MLflow, and TensorBoard
- clarifies how `method` differs from model families such as DINOv2/DINOv3

This is stacked on #872.

## How has it been tested?

- `make format`
- `make -C docs docs`
- `make static-checks` (format, pre-commit, and docs code checks passed; mypy failed on unrelated existing/missing dependency issues around `onnx` stubs and ultralytics typing)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
