### PR TITLE
docs: clarify DINOv2 model vs DINOv2 training method

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -97,8 +97,8 @@ LightlyTrain offers several advantages over other self-supervised learning (SSL)
   models in the right format for fine-tuning, reducing risks when moving from pretraining to 
   fine-tuning.
 - **Distillation**: Lightly has developed a unique distillation method that allows
-  you to pretrain smaller models with the knowledge of larger DINOv2 or DINOv3 models
-  without the need for large compute resources.
+  you to pretrain smaller models with the knowledge of larger foundation models,
+  such as DINOv2 or DINOv3, without the need for large compute resources.
 - **DINOv2 method**: LightlyTrain supports the DINOv2 training method out of the box,
   allowing you to train state-of-the-art vision foundation models on your own datasets.
 ```
@@ -387,7 +387,7 @@ model guides the training of your student model.
 
 During distillation, the student model learns to produce similar feature representations as the 
 teacher model for the same input images. This allows smaller models to benefit from the knowledge 
-of larger, more powerful models like vision transformers pretrained with DINOv2, without requiring
+of larger, more powerful foundation models, such as DINOv2 or DINOv3, without requiring
 the same computational resources for training.
 ```
 
@@ -404,7 +404,10 @@ representations exhibit strong semantic understanding and work well for zero-sho
 few-shot learning scenarios.
 
 In LightlyTrain, DINOv2 models serve as teacher models for the distillation method,
-transferring their knowledge to your chosen backbone architecture.
+transferring their knowledge to your chosen backbone architecture. They also serve
+as a starting point for fine-tuning downstream task models, including LT-DETR (object
+detection) and EoMT (semantic segmentation, instance segmentation, panoptic
+segmentation).
 ```
 
 ## Deployment

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -355,7 +355,7 @@ appropriate for your downstream task.
 
 ```{dropdown} <h6>Which pretraining methods are supported?<a class="headerlink" id="which-pretraining-methods-are-supported" href="#which-pretraining-methods-are-supported" title="Link to this heading">¶</a></h6>
 LightlyTrain supports different methods such as:
-- Distillation (with a DINOv2 or DINOv3 teacher)
+- Distillation (with a foundation model teacher, such as DINOv2 or DINOv3)
 - DINOv2 (self-supervised training method)
 - DINO
 - SimCLR

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -96,10 +96,10 @@ LightlyTrain offers several advantages over other self-supervised learning (SSL)
 - **Seamless workflow**: LightlyTrain automatically pretrains the correct layers and exports 
   models in the right format for fine-tuning, reducing risks when moving from pretraining to 
   fine-tuning.
-- **DINOv2 distillation**: Lightly has developed a unique distillation method that allows
-  you to pretrain smaller models with the knowledge of larger DINOv2 models without the need for
-  large compute resources.
-- **DINOv2 pretraining**: LightlyTrain supports DINOv2 pretraining out of the box,
+- **Distillation**: Lightly has developed a unique distillation method that allows
+  you to pretrain smaller models with the knowledge of larger DINOv2 or DINOv3 models
+  without the need for large compute resources.
+- **DINOv2 method**: LightlyTrain supports the DINOv2 training method out of the box,
   allowing you to train state-of-the-art vision foundation models on your own datasets.
 ```
 
@@ -355,8 +355,8 @@ appropriate for your downstream task.
 
 ```{dropdown} <h6>Which pretraining methods are supported?<a class="headerlink" id="which-pretraining-methods-are-supported" href="#which-pretraining-methods-are-supported" title="Link to this heading">¶</a></h6>
 LightlyTrain supports different methods such as:
-- DINOv2 distillation
-- DINOv2
+- Distillation (with a DINOv2 or DINOv3 teacher)
+- DINOv2 (self-supervised training method)
 - DINO
 - SimCLR
 
@@ -392,16 +392,18 @@ the same computational resources for training.
 ```
 
 ```{dropdown} <h6>What is DINOv2?<a class="headerlink" id="what-is-dinov2" href="#what-is-dinov2" title="Link to this heading">¶</a></h6>
-DINOv2 is a self-supervised learning method developed by Facebook AI Research (FAIR) that produces 
-state-of-the-art visual representations. It builds upon the original DINO (Self-Distillation with 
-No Labels) method and uses a Vision Transformer (ViT) architecture.
+DINOv2 is a self-supervised **training method** developed by Facebook AI Research (FAIR)
+that produces state-of-the-art visual representations. It builds upon the original DINO
+(Self-Distillation with No Labels) method and uses a Vision Transformer (ViT)
+architecture.
 
-DINOv2 models are pretrained on a diverse set of image data and have shown remarkable performance 
-across various visual tasks, from classification to dense prediction tasks. The resulting 
-representations exhibit strong semantic understanding and work well for zero-shot and few-shot 
-learning scenarios.
+Models pretrained with the DINOv2 method are called DINOv2 models. They are pretrained
+on a diverse set of image data and have shown remarkable performance across various
+visual tasks, from classification to dense prediction tasks. The resulting
+representations exhibit strong semantic understanding and work well for zero-shot and
+few-shot learning scenarios.
 
-In LightlyTrain, DINOv2-pretrained ViT models serve as teacher models for the distillation method, 
+In LightlyTrain, DINOv2 models serve as teacher models for the distillation method,
 transferring their knowledge to your chosen backbone architecture.
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -218,8 +218,8 @@ LightlyTrain supports the following model and workflow combinations.
 | Custom PyTorch Model                       |           ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html)           | ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html) |
 
 *For DINOv2/DINOv3, the model is paired with the matching training method or serves as
-distillation teacher (e.g. the DINOv2 model with `method="dinov2"` for pretraining, or as
-teacher for the `distillation` method). For all other models, the listed model is the
+distillation teacher (e.g. the DINOv2 model with `method="dinov2"` for pretraining, or
+as teacher for the `distillation` method). For all other models, the listed model is the
 student: "Pretraining" trains that model directly, and "Distillation" distills a default
 teacher's knowledge into it.*
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -217,9 +217,11 @@ LightlyTrain supports the following model and workflow combinations.
 | YOLOv12                                    |              ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)              |    ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)    |
 | Custom PyTorch Model                       |           ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html)           | ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html) |
 
-*In the "Pretraining" column, the model is paired with the matching training method
-(e.g. the DINOv2 model with the DINOv2 method, `method="dinov2"`). In the "Distillation"
-column, the model instead serves as a teacher for the `distillation` method.*
+*For DINOv2/DINOv3, the model is paired with the matching training method or serves as
+distillation teacher (e.g. the DINOv2 model with `method="dinov2"` for pretraining, or as
+teacher for the `distillation` method). For all other models, the listed model is the
+student: "Pretraining" trains that model directly, and "Distillation" distills a default
+teacher's knowledge into it.*
 
 [Contact us](https://www.lightly.ai/contact) if you need support for additional models.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -217,11 +217,13 @@ LightlyTrain supports the following model and workflow combinations.
 | YOLOv12                                    |              ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)              |    ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)    |
 | Custom PyTorch Model                       |           ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html)           | ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html) |
 
-*For DINOv2/DINOv3, the model is paired with the matching training method or serves as
+```{note}
+For DINOv2/DINOv3, the model is paired with the matching training method or serves as
 distillation teacher (e.g. the DINOv2 model with `method="dinov2"` for pretraining, or
 as teacher for the `distillation` method). For all other models, the listed model is the
 student: "Pretraining" trains that model directly, and "Distillation" distills a default
-teacher's knowledge into it.*
+teacher's knowledge into it.
+```
 
 [Contact us](https://www.lightly.ai/contact) if you need support for additional models.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -217,6 +217,10 @@ LightlyTrain supports the following model and workflow combinations.
 | YOLOv12                                    |              ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)              |    ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/yolov12.html)    |
 | Custom PyTorch Model                       |           ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html)           | ✅ [🔗](https://docs.lightly.ai/train/stable/pretrain_distill/models/custom_models.html) |
 
+*In the "Pretraining" column, the model is paired with the matching training method
+(e.g. the DINOv2 model with the DINOv2 method, `method="dinov2"`). In the "Distillation"
+column, the model instead serves as a teacher for the `distillation` method.*
+
 [Contact us](https://www.lightly.ai/contact) if you need support for additional models.
 
 ## Usage Events

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -11,7 +11,7 @@ data**. LightlyTrain offers three main functionalities for this:
 
    Pretraining lets you train a model on unlabeled data with self-supervised learning
    (SSL) methods. This is ideal if you want to train your own vision foundation models
-   using a method like {ref}`DINOv2 <methods-dinov2>`.
+   using a method like [DINOv2](#methods-dinov2).
 
 1. **[Distillation](#methods-distillation)**
 

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -11,7 +11,7 @@ data**. LightlyTrain offers three main functionalities for this:
 
    Pretraining lets you train a model on unlabeled data with self-supervised learning
    (SSL) methods. This is ideal if you want to train your own vision foundation models
-   like {ref}`DINOv2 <methods-dinov2>`.
+   using a method like {ref}`DINOv2 <methods-dinov2>`.
 
 1. **[Distillation](#methods-distillation)**
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -652,8 +652,8 @@ fine-tune it on your segmentation dataset. This is especially useful if your dat
 only partially labeled or if you have access to a large amount of unlabeled data.
 
 The following example shows how to pretrain and fine-tune the model. Check out the page
-on [DINOv2](#methods-dinov2) to learn more about pretraining DINOv2 models on unlabeled
-data.
+on the [DINOv2 method](#methods-dinov2) to learn more about pretraining DINOv2 models on
+unlabeled data.
 
 ```python
 import lightly_train


### PR DESCRIPTION
## What has changed and why?

"DINOv2" is used in the docs to mean two different things: the ViT model
architecture (`model="dinov2/vit*"`) and the self-supervised training method
(`method="dinov2"`). Several pages used bare "DINOv2" in places where it
wasn't clear which one was meant. This PR tightens the wording in those spots
to consistently say "DINOv2 model(s)" or "DINOv2 method", matching the
convention already used on the dedicated `models/dinov2.md` and
`methods/dinov2.md` pages:

- `semantic_segmentation.md`: link text now reads "DINOv2 method" instead of
  bare "DINOv2" when linking to the method page.
- `faq.md`: renamed ambiguous bullets ("DINOv2 distillation" →
  "Distillation" / "DINOv2 method"), clarified the supported-methods list,
  and reworded the "What is DINOv2?" answer to explicitly separate the
  training method from the models it produces.
- `index.md`: added a short footnote under the Distillation & Pretraining
  table explaining the dual role of the "DINOv2" row (teacher model vs.
  paired training method).
- `pretrain_distill/index.md`: reworded the "Pretraining" intro bullet,
  which framed DINOv2 as an example *model* while linking to the DINOv2
  *method* page.

## How has it been tested?

Ran `mdformat` on the edited files to match existing formatting conventions.
Manually re-read each changed sentence to confirm the model/method referent
is now unambiguous, and verified the `#methods-dinov2` / `#models-dinov2`
anchors still resolve.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)

