### PR TITLE
Decouple object detection preprocessing and postprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- ONNX export for LT-DETR object detection now returns raw logits and normalized
+  bounding boxes. Postprocessing is supposed to be applied outside the graph.
+
 ### Deprecated
 
 ### Removed

--- a/docs/source/python_api/lightly_train.md
+++ b/docs/source/python_api/lightly_train.md
@@ -30,7 +30,7 @@ Documentation of the public API of the `lightly_train` package.
     :exclude-members: __init__, __new__
 
 .. autoclass:: lightly_train._task_models.ltdetr_object_detection.task_model.LTDETRObjectDetection
-    :members: export_onnx, export_tensorrt, predict, predict_sahi
+    :members: export_onnx, export_tensorrt, predict, predict_sahi, predict_sahi_batch
     :exclude-members: __init__, __new__
 
 .. autoclass:: lightly_train._task_models.picodet_object_detection.task_model.PicoDetObjectDetection

--- a/docs/source/python_api/lightly_train.md
+++ b/docs/source/python_api/lightly_train.md
@@ -30,7 +30,7 @@ Documentation of the public API of the `lightly_train` package.
     :exclude-members: __init__, __new__
 
 .. autoclass:: lightly_train._task_models.ltdetr_object_detection.task_model.LTDETRObjectDetection
-    :members: export_onnx, export_tensorrt, predict, predict_sahi, predict_sahi_batch
+    :members: export_onnx, export_tensorrt, predict, predict_batch, predict_sahi, predict_sahi_batch
     :exclude-members: __init__, __new__
 
 .. autoclass:: lightly_train._task_models.picodet_object_detection.task_model.PicoDetObjectDetection

--- a/src/lightly_train/_commands/benchmark_backends.py
+++ b/src/lightly_train/_commands/benchmark_backends.py
@@ -142,6 +142,7 @@ class ONNXBackend(ObjectDetectionBackend):
 
         import onnxruntime as ort
 
+        self.model = model
         self.threshold = threshold
 
         self.device = torch.device(device)
@@ -230,6 +231,16 @@ class ONNXBackend(ObjectDetectionBackend):
 
         # postprocess
         outputs = dict(zip(self.output_names, raw_outputs))
+        if "logits" in outputs:
+            results = self.model.postprocess(
+                raw_outputs=(
+                    torch.from_numpy(outputs["logits"]),
+                    torch.from_numpy(outputs["boxes"]),
+                ),
+                metadata=metadata,
+                threshold=self.threshold,
+            )
+            return results, time_predict
         labels = torch.from_numpy(outputs["labels"])
         boxes_unscaled = torch.from_numpy(outputs["boxes"])
         scores = torch.from_numpy(outputs["scores"])
@@ -261,6 +272,7 @@ class TensorRTBackend(ObjectDetectionBackend):
     ) -> None:
         import tensorrt as trt  # type: ignore[import-untyped,import-not-found]
 
+        self.model = model
         self.device = torch.device(device)
         self.precision = backend_args.precision
         self.threshold = threshold
@@ -356,6 +368,13 @@ class TensorRTBackend(ObjectDetectionBackend):
         time_predict = time.perf_counter() - start_predict
 
         # Postprocess.
+        if "logits" in outputs:
+            results = self.model.postprocess(
+                raw_outputs=(outputs["logits"], outputs["boxes"]),
+                metadata=metadata,
+                threshold=self.threshold,
+            )
+            return results, time_predict
         labels_batch = outputs["labels"].cpu()
         boxes_batch = outputs["boxes"].cpu()
         scores_batch = outputs["scores"].cpu()

--- a/src/lightly_train/_pre_post_processing/__init__.py
+++ b/src/lightly_train/_pre_post_processing/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/src/lightly_train/_pre_post_processing/object_detection.py
+++ b/src/lightly_train/_pre_post_processing/object_detection.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TypedDict
+from typing import Tuple, TypedDict
 
 import torch
 from PIL.Image import Image as PILImage
@@ -22,7 +22,7 @@ from lightly_train._data import file_helpers
 from lightly_train._task_models.object_detection_components import tiling_utils
 from lightly_train.types import PathLike
 
-ObjectDetectionOutput: TypeAlias = tuple[Tensor, Tensor]
+ObjectDetectionOutput: TypeAlias = Tuple[Tensor, Tensor]
 """Raw object detection output: ``(logits, normalized cxcywh boxes)``."""
 
 

--- a/src/lightly_train/_pre_post_processing/object_detection.py
+++ b/src/lightly_train/_pre_post_processing/object_detection.py
@@ -1,0 +1,211 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypedDict
+
+import torch
+from PIL.Image import Image as PILImage
+from torch import Tensor
+from torch.nn import Module
+from torchvision.ops import box_convert
+from torchvision.transforms.v2 import functional as transforms_functional
+from typing_extensions import NotRequired, TypeAlias
+
+from lightly_train._data import file_helpers
+from lightly_train._task_models.object_detection_components import tiling_utils
+from lightly_train.types import PathLike
+
+ObjectDetectionOutput: TypeAlias = tuple[Tensor, Tensor]
+"""Raw object detection output: ``(logits, normalized cxcywh boxes)``."""
+
+
+class ObjectDetectionMetadata(TypedDict):
+    orig_h: int
+    orig_w: int
+    tiles_coordinates: NotRequired[Tensor]
+
+
+class ObjectDetectionPreprocessor(Module):
+    """Per-image and batch preprocessing for object detection task models."""
+
+    def __init__(
+        self,
+        *,
+        image_size: tuple[int, int],
+        image_normalize: dict[str, tuple[float, ...]] | None,
+        expected_input_channels: int,
+    ) -> None:
+        super().__init__()
+        self.image_size = image_size
+        self.image_normalize = image_normalize
+        self.expected_input_channels = expected_input_channels
+
+    def preprocess_image(
+        self,
+        image: PathLike | PILImage | Tensor,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[Tensor, ObjectDetectionMetadata]:
+        x = file_helpers.as_image_tensor(image).to(device)
+        image_h, image_w = x.shape[-2:]
+        x = self._validate_channels(x)
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        x = transforms_functional.resize(x, self.image_size)
+        return x, {"orig_h": image_h, "orig_w": image_w}
+
+    def preprocess_sahi_image(
+        self,
+        image: PathLike | PILImage | Tensor,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        overlap: float,
+    ) -> tuple[Tensor, ObjectDetectionMetadata]:
+        x = file_helpers.as_image_tensor(image).to(device)
+        orig_h, orig_w = x.shape[-2:]
+        x = self._validate_channels(x)
+        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
+        tiles, tiles_coordinates = tiling_utils.tile_image(
+            x, overlap=overlap, tile_size=self.image_size
+        )
+        x_global = transforms_functional.resize(x, self.image_size).unsqueeze(0)
+        return torch.cat([x_global, tiles], dim=0), {
+            "orig_h": orig_h,
+            "orig_w": orig_w,
+            "tiles_coordinates": tiles_coordinates,
+        }
+
+    def preprocess_sahi_batch(self, batch: Tensor) -> Tensor:
+        return self.preprocess_batch(batch)
+
+    def _validate_channels(self, x: Tensor) -> Tensor:
+        expected_c = self.expected_input_channels
+        if x.shape[-3] == 1 and expected_c > 1:
+            x = x.expand(expected_c, -1, -1)
+        elif x.shape[-3] != expected_c:
+            raise ValueError(
+                f"Image has {x.shape[-3]} channels but model expects {expected_c}."
+            )
+        return x
+
+    def preprocess_batch(self, batch: Tensor) -> Tensor:
+        if self.image_normalize is not None:
+            batch = transforms_functional.normalize(
+                batch,
+                mean=list(self.image_normalize["mean"]),
+                std=list(self.image_normalize["std"]),
+            )
+        return batch
+
+
+class ObjectDetectionPostprocessor(Module):
+    """Decode raw object detection outputs into per-image predictions."""
+
+    internal_class_to_class: Tensor
+
+    def __init__(
+        self,
+        *,
+        num_classes: int,
+        num_top_queries: int,
+        internal_class_to_class: Tensor,
+    ) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.num_top_queries = num_top_queries
+        self.register_buffer(
+            "internal_class_to_class", internal_class_to_class, persistent=False
+        )
+
+    def decode(
+        self, raw: ObjectDetectionOutput, orig_target_sizes: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        logits, raw_boxes = raw
+        scores = logits.sigmoid()
+        num_classes = scores.shape[-1]
+        scores, index = scores.flatten(1).topk(self.num_top_queries, dim=-1)
+        labels = index % num_classes
+        query_index = index // num_classes
+        boxes = box_convert(raw_boxes, in_fmt="cxcywh", out_fmt="xyxy")
+        boxes = boxes.gather(1, query_index.unsqueeze(-1).expand(-1, -1, 4))
+        boxes = boxes * orig_target_sizes.repeat(1, 2).unsqueeze(1)
+        return self.internal_class_to_class[labels], boxes, scores
+
+    def postprocess(
+        self,
+        raw: ObjectDetectionOutput,
+        metadata: Sequence[ObjectDetectionMetadata],
+        threshold: float,
+    ) -> list[dict[str, Tensor]]:
+        device = self.internal_class_to_class.device
+        orig_target_size = torch.tensor(
+            [[m["orig_w"], m["orig_h"]] for m in metadata],
+            dtype=torch.int64,
+            device=device,
+        )
+        labels_batch, boxes_batch, scores_batch = self.decode(raw, orig_target_size)
+        out: list[dict[str, Tensor]] = []
+        for i in range(len(metadata)):
+            keep = scores_batch[i] > threshold
+            out.append(
+                {
+                    "labels": labels_batch[i][keep],
+                    "bboxes": boxes_batch[i][keep],
+                    "scores": scores_batch[i][keep],
+                }
+            )
+        return out
+
+    def postprocess_sahi(
+        self,
+        raw: ObjectDetectionOutput,
+        metadata: ObjectDetectionMetadata,
+        *,
+        threshold: float,
+        nms_iou_threshold: float,
+        global_local_iou_threshold: float,
+        tile_size: tuple[int, int],
+    ) -> dict[str, Tensor]:
+        device = self.internal_class_to_class.device
+        tile_h, tile_w = tile_size
+        tiles_coordinates = metadata["tiles_coordinates"].to(device)
+        orig_target_sizes = torch.tensor(
+            [
+                [int(metadata["orig_w"]), int(metadata["orig_h"])],
+                *[[tile_w, tile_h] for _ in tiles_coordinates],
+            ],
+            dtype=torch.int64,
+            device=device,
+        )
+        labels, boxes, scores = self.decode(raw, orig_target_sizes)
+        offsets = tiles_coordinates.repeat(1, 2).unsqueeze(1)
+        boxes[1:] += offsets.expand(-1, boxes.shape[1], -1)
+
+        boxes_global, boxes_tiles = boxes[0].view(-1, 4), boxes[1:].view(-1, 4)
+        labels_global, labels_tiles = labels[0].flatten(), labels[1:].flatten()
+        scores_global, scores_tiles = scores[0].flatten(), scores[1:].flatten()
+        keep_global = scores_global > threshold
+        keep_tiles = scores_tiles > threshold
+        labels, boxes, scores = tiling_utils.combine_object_detection_tiles(
+            pred_global={
+                "labels": labels_global[keep_global],
+                "bboxes": boxes_global[keep_global],
+                "scores": scores_global[keep_global],
+            },
+            pred_tiles={
+                "labels": labels_tiles[keep_tiles],
+                "bboxes": boxes_tiles[keep_tiles],
+                "scores": scores_tiles[keep_tiles],
+            },
+            nms_iou_threshold=nms_iou_threshold,
+            global_local_iou_threshold=global_local_iou_threshold,
+        )
+        return {"labels": labels, "bboxes": boxes, "scores": scores}

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -16,12 +16,10 @@ from typing import Any, Callable, Literal, Union, cast
 import torch
 from PIL.Image import Image as PILImage
 from torch import Tensor
-from torchvision.transforms.v2 import functional as transforms_functional
 from typing_extensions import Self, override
 
 from lightly_train import _logging, _torch_testing
 from lightly_train._commands import _warnings
-from lightly_train._data import file_helpers
 from lightly_train._export import tensorrt_helpers
 from lightly_train._export.onnx_helpers import (
     fix_topological_order,
@@ -42,6 +40,12 @@ from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
 from lightly_train._models.dinov3.dinov3_vit import DINOv3ViTModelWrapper
 from lightly_train._models.ecvit.ecvit import ECViTModelWrapper
 from lightly_train._models.ecvit.ecvit_package import EDGE_CRAFTER_PACKAGE
+from lightly_train._pre_post_processing.object_detection import (
+    ObjectDetectionMetadata,
+    ObjectDetectionOutput,
+    ObjectDetectionPostprocessor,
+    ObjectDetectionPreprocessor,
+)
 from lightly_train._task_models.ltdetr_object_detection.config import (
     LTDETR_MODEL_REGISTRY,
     DetectorConfig,
@@ -59,15 +63,11 @@ from lightly_train._task_models.ltdetr_object_detection.dinov3_convnext_wrapper 
 from lightly_train._task_models.ltdetr_object_detection.ecvit_vit_wrapper import (
     ECViTBackboneWrapper,
 )
-from lightly_train._task_models.object_detection_components import tiling_utils
 from lightly_train._task_models.object_detection_components.dfine_decoder import (
     DFINETransformer,
 )
 from lightly_train._task_models.object_detection_components.hybrid_encoder import (
     HybridEncoder,
-)
-from lightly_train._task_models.object_detection_components.rtdetr_postprocessor import (
-    RTDETRPostProcessor,
 )
 from lightly_train._task_models.object_detection_components.rtdetrv2_decoder import (
     RTDETRTransformerv2,
@@ -188,16 +188,9 @@ class LTDETRObjectDetection(TaskModel):
         config.resolve_auto(patch_size=patch_size)
 
         # Internally, the model processes classes as contiguous integers starting at 0.
-        # This list maps the internal class id to the class id in `classes`.
-        internal_class_to_class = list(self.classes.keys())
-
-        # Efficient lookup for converting internal class IDs to class IDs.
-        # Registered as buffer to be automatically moved to the correct device.
-        self.internal_class_to_class: Tensor
-        self.register_buffer(
-            "internal_class_to_class",
-            torch.tensor(internal_class_to_class, dtype=torch.long),
-            persistent=False,  # No need to save it in the state dict.
+        # The postprocessor owns the mapping back to user-facing class ids.
+        internal_class_to_class = torch.tensor(
+            list(self.classes.keys()), dtype=torch.long
         )
         self.included_classes: dict[int, str] = {
             internal_class_id: class_name
@@ -292,11 +285,17 @@ class LTDETRObjectDetection(TaskModel):
                 **transformer_cfg, eval_spatial_size=self.image_size
             )
 
-        postprocessor_cfg = config.rtdetr_postprocessor.model_dump()
-        postprocessor_cfg["num_classes"] = len(self.classes)
-        self.postprocessor: RTDETRPostProcessor = RTDETRPostProcessor(
-            **postprocessor_cfg
+        self.preprocessor = ObjectDetectionPreprocessor(
+            image_size=self.image_size,
+            image_normalize=self.image_normalize,
+            expected_input_channels=self._expected_input_channels,
         )
+        self.postprocessor = ObjectDetectionPostprocessor(
+            num_classes=len(self.classes),
+            num_top_queries=config.rtdetr_postprocessor.num_top_queries,
+            internal_class_to_class=internal_class_to_class,
+        )
+        self._deployed = False
 
         if self.backbone_freeze:
             self.freeze_backbone()
@@ -330,39 +329,16 @@ class LTDETRObjectDetection(TaskModel):
         }
 
     def get_export_output_names(self) -> list[str]:
-        return ["labels", "boxes", "scores"]
+        return ["logits", "boxes"]
 
     def forward_backend(self, x: Tensor) -> Any:
         x = self.backbone(x)
         x = self.encoder(x)
         return self.decoder(x)
 
-    def forward(
-        self, x: Tensor, orig_target_size: Tensor | None = None
-    ) -> tuple[Tensor, Tensor, Tensor]:
-        # Function used for ONNX export
-        if orig_target_size is None:
-            h, w = x.shape[-2:]
-            orig_target_size_ = torch.tensor([[w, h]]).to(x.device)
-        else:
-            # Flip from (H, W) to (W, H).
-            orig_target_size = orig_target_size[:, [1, 0]]
-
-            # Move to device.
-            orig_target_size_ = orig_target_size.to(device=x.device, dtype=torch.int64)
-
-        # Forward the image through the model.
-        x = self.forward_backend(x)
-
-        result: list[dict[str, Tensor]] | tuple[Tensor, Tensor, Tensor] = (
-            self.postprocessor(x, orig_target_size_)
-        )
-        # Postprocessor must be in deploy mode at this point. It returns only tuples
-        # during deploy mode.
-        assert isinstance(result, tuple)
-        labels, boxes, scores = result
-        labels = self.internal_class_to_class[labels]
-        return (labels, boxes, scores)
+    def forward(self, x: Tensor) -> ObjectDetectionOutput:
+        raw = self.forward_backend(x)
+        return raw["pred_logits"], raw["pred_boxes"]
 
     def _forward_train(self, x: Tensor, targets):  # type: ignore[no-untyped-def]
         x = self.backbone(x)
@@ -376,34 +352,12 @@ class LTDETRObjectDetection(TaskModel):
         metadata: Sequence[dict[str, Any]],
         threshold: float,
     ) -> list[dict[str, Tensor]]:
-        if not isinstance(raw_outputs, dict):
-            raise ValueError(
-                f"Expected raw_outputs to be a dict, got {type(raw_outputs).__name__}."
-            )
-        device = next(self.parameters()).device
-        # Postprocessor expects (W, H) per image.
-        orig_target_size = torch.tensor(
-            [[m["orig_w"], m["orig_h"]] for m in metadata],
-            dtype=torch.int64,
-            device=device,
-        )
-        postprocessor_out: tuple[Tensor, Tensor, Tensor] = self.postprocessor(
-            raw_outputs, orig_target_size
-        )
-        out: list[dict[str, Tensor]] = []
-        labels_batch, boxes_batch, scores_batch = postprocessor_out
-
-        labels_batch = self.internal_class_to_class[labels_batch]
-        for i in range(len(metadata)):
-            keep = scores_batch[i] > threshold
-            out.append(
-                {
-                    "labels": labels_batch[i][keep],
-                    "bboxes": boxes_batch[i][keep],
-                    "scores": scores_batch[i][keep],
-                }
-            )
-        return out
+        if isinstance(raw_outputs, dict):
+            raw = raw_outputs["pred_logits"], raw_outputs["pred_boxes"]
+        else:
+            raw = cast(ObjectDetectionOutput, raw_outputs)
+        typed_metadata = cast(Sequence[ObjectDetectionMetadata], metadata)
+        return self.postprocessor.postprocess(raw, typed_metadata, threshold)
 
     def freeze_backbone(self) -> None:
         self.backbone.eval()
@@ -411,10 +365,12 @@ class LTDETRObjectDetection(TaskModel):
 
     def deploy(self) -> Self:
         self.eval()
-        self.postprocessor.deploy()  # type: ignore[no-untyped-call]
+        if self._deployed:
+            return self
         for m in self.modules():
             if hasattr(m, "convert_to_deploy"):
                 m.convert_to_deploy()  # type: ignore[operator]
+        self._deployed = True
         return self
 
     def load_train_state_dict(
@@ -454,39 +410,6 @@ class LTDETRObjectDetection(TaskModel):
         if not missing and not unexpected:
             logger.info(f"Backbone weights loaded from '{path}'")
 
-    def preprocess_image(
-        self, image: PathLike | PILImage | Tensor
-    ) -> tuple[Tensor, dict[str, Any]]:
-        first_param = next(self.parameters())
-        device, dtype = first_param.device, first_param.dtype
-
-        x = file_helpers.as_image_tensor(image).to(device)
-        image_h, image_w = x.shape[-2:]
-
-        # Expand grayscale to the expected channel count so images can be stacked.
-        # TODO(Nauryzbay, 05/26): Revisit grayscale handling — the implicit
-        # 1-channel expansion is a convenience inherited from RGB-only models.
-        expected_c = self._expected_input_channels
-        if x.shape[-3] == 1 and expected_c > 1:
-            x = x.expand(expected_c, -1, -1)
-        elif x.shape[-3] != expected_c:
-            raise ValueError(
-                f"Image has {x.shape[-3]} channels but model expects {expected_c}."
-            )
-
-        x = transforms_functional.to_dtype(x, dtype=dtype, scale=True)
-        x = transforms_functional.resize(x, self.image_size)
-        return x, {"orig_h": image_h, "orig_w": image_w}
-
-    def preprocess_batch(self, batch: Tensor) -> Tensor:
-        if self.image_normalize is not None:
-            batch = transforms_functional.normalize(
-                batch,
-                mean=list(self.image_normalize["mean"]),
-                std=list(self.image_normalize["std"]),
-            )
-        return batch
-
     @torch.no_grad()
     def predict_batch(
         self,
@@ -507,18 +430,19 @@ class LTDETRObjectDetection(TaskModel):
             A list with one prediction dict per input image.
         """
         self._track_inference()
-        if self.training or not self.postprocessor.deploy_mode:
+        if self.training or not self._deployed:
             self.deploy()
+        first_param = next(self.parameters())
         tensors: list[Tensor] = []
-        metadata: list[dict[str, Any]] = []
+        metadata: list[ObjectDetectionMetadata] = []
         for image in images:
-            x, meta = self.preprocess_image(image)
+            x, meta = self.preprocessor.preprocess_image(
+                image, device=first_param.device, dtype=first_param.dtype
+            )
             tensors.append(x)
             metadata.append(meta)
-        batch = torch.stack(tensors, dim=0)
-        batch = self.preprocess_batch(batch)
-        raw = self.forward_backend(batch)
-        return self.postprocess(raw, metadata, threshold=threshold)
+        batch = self.preprocessor.preprocess_batch(torch.stack(tensors, dim=0))
+        return self.postprocessor.postprocess(self(batch), metadata, threshold)
 
     @torch.no_grad()
     def predict(
@@ -537,12 +461,14 @@ class LTDETRObjectDetection(TaskModel):
             A task-specific prediction dictionary.
         """
         self._track_inference()
-        if self.training or not self.postprocessor.deploy_mode:
+        if self.training or not self._deployed:
             self.deploy()
-        x, metadata = self.preprocess_image(image)
-        batch = self.preprocess_batch(x.unsqueeze(0))
-        raw = self.forward_backend(batch)
-        return self.postprocess(raw, [metadata], threshold=threshold)[0]
+        first_param = next(self.parameters())
+        x, metadata = self.preprocessor.preprocess_image(
+            image, device=first_param.device, dtype=first_param.dtype
+        )
+        batch = self.preprocessor.preprocess_batch(x.unsqueeze(0))
+        return self.postprocessor.postprocess(self(batch), [metadata], threshold)[0]
 
     @torch.no_grad()
     def predict_sahi(
@@ -589,81 +515,73 @@ class LTDETRObjectDetection(TaskModel):
                 - "scores": Tensor of shape (N,) with confidence scores for each prediction.
         """
 
-        if self.training or not self.postprocessor.deploy_mode:
+        if self.training or not self._deployed:
             self.deploy()
-
-        device = next(self.parameters()).device
-        x = file_helpers.as_image_tensor(image).to(device)
-
-        # Tile the image.
-        tiles, tiles_coordinates = tiling_utils.tile_image(x, overlap, self.image_size)
-
-        # Prepare the full image tile
-        h, w = x.shape[-2:]
-        x = transforms_functional.resize(x, self.image_size)
-        x = x.unsqueeze(0)
-        tiles = torch.cat([x, tiles], dim=0)
-
-        # Normalize the tiles and the image together.
-        tiles = transforms_functional.to_dtype(tiles, dtype=torch.float32, scale=True)
-
-        # Normalize the tiles.
-        if self.image_normalize is not None:
-            tiles = transforms_functional.normalize(
-                tiles,
-                mean=self.image_normalize["mean"],
-                std=self.image_normalize["std"],
-            )
-
-        # Prepare the image/tiles sizes.
-        orig_target_sizes = torch.tensor([self.image_size], device=device).repeat(
-            len(tiles), 1
+        first_param = next(self.parameters())
+        batch, metadata = self.preprocessor.preprocess_sahi_image(
+            image,
+            device=first_param.device,
+            dtype=first_param.dtype,
+            overlap=overlap,
         )
-        orig_target_sizes[0, 0] = h
-        orig_target_sizes[0, 1] = w
-
-        # Feed the tiles in parallel to the model.
-        labels, boxes, scores = self(tiles, orig_target_size=orig_target_sizes)
-
-        # Add coordinates of the tiles to the boxes.
-        tiles_coordinates = (
-            tiles_coordinates.repeat(1, 2).unsqueeze(1).expand(-1, boxes.shape[1], -1)
-        )
-        boxes[1:] += tiles_coordinates
-
-        # Reorganize the predictions.
-        boxes_global = boxes[0].view(-1, 4)
-        boxes_tiles = boxes[1:].view(-1, 4)
-        labels_global = labels[0].flatten()
-        labels_tiles = labels[1:].flatten()
-        scores_global = scores[0].flatten()
-        scores_tiles = scores[1:].flatten()
-
-        # Discard low-confidence predictions.
-        keep_global = scores_global > threshold
-        keep_tiles = scores_tiles > threshold
-
-        # Combine global and tiles predictions.
-        labels, boxes, scores = tiling_utils.combine_object_detection_tiles(
-            pred_global={
-                "labels": labels_global[keep_global],
-                "bboxes": boxes_global[keep_global],
-                "scores": scores_global[keep_global],
-            },
-            pred_tiles={
-                "labels": labels_tiles[keep_tiles],
-                "bboxes": boxes_tiles[keep_tiles],
-                "scores": scores_tiles[keep_tiles],
-            },
+        raw = self(self.preprocessor.preprocess_sahi_batch(batch))
+        return self.postprocessor.postprocess_sahi(
+            raw,
+            metadata,
+            threshold=threshold,
             nms_iou_threshold=nms_iou_threshold,
             global_local_iou_threshold=global_local_iou_threshold,
+            tile_size=self.image_size,
         )
 
-        return {
-            "labels": labels,
-            "bboxes": boxes,
-            "scores": scores,
-        }
+    @torch.no_grad()
+    def predict_sahi_batch(
+        self,
+        images: Sequence[PathLike | PILImage | Tensor],
+        threshold: float = 0.6,
+        overlap: float = 0.2,
+        nms_iou_threshold: float = 0.3,
+        global_local_iou_threshold: float = 0.1,
+    ) -> list[dict[str, Tensor]]:
+        """Run Slicing Aided Hyper Inference on a batch of images."""
+        self._track_inference()
+        if not images:
+            raise ValueError("images must contain at least one image.")
+        if self.training or not self._deployed:
+            self.deploy()
+        first_param = next(self.parameters())
+        batches: list[Tensor] = []
+        metadata: list[ObjectDetectionMetadata] = []
+        batch_sizes: list[int] = []
+        for image in images:
+            image_batch, image_metadata = self.preprocessor.preprocess_sahi_image(
+                image,
+                device=first_param.device,
+                dtype=first_param.dtype,
+                overlap=overlap,
+            )
+            batches.append(image_batch)
+            metadata.append(image_metadata)
+            batch_sizes.append(len(image_batch))
+        raw_logits, raw_boxes = self(
+            self.preprocessor.preprocess_sahi_batch(torch.cat(batches, dim=0))
+        )
+        out: list[dict[str, Tensor]] = []
+        start = 0
+        for image_metadata, batch_size in zip(metadata, batch_sizes):
+            end = start + batch_size
+            out.append(
+                self.postprocessor.postprocess_sahi(
+                    (raw_logits[start:end], raw_boxes[start:end]),
+                    image_metadata,
+                    threshold=threshold,
+                    nms_iou_threshold=nms_iou_threshold,
+                    global_local_iou_threshold=global_local_iou_threshold,
+                    tile_size=self.image_size,
+                )
+            )
+            start = end
+        return out
 
     @torch.no_grad()
     def export_onnx(
@@ -685,6 +603,10 @@ class LTDETRObjectDetection(TaskModel):
         inferred from the first model parameter and (H, W) come from
         `self.image_size`. If `dynamic_batch_size` is True, the ONNX graph will
         have a dynamic batch dimension for the input. The graph output names are provided by the concrete task model.
+
+        The exported graph returns raw class logits and normalized ``cxcywh`` boxes.
+        Image preprocessing, top-k selection, thresholding, box rescaling, and SAHI
+        merging are intentionally kept outside the graph.
 
         Optionally simplifies the exported model in-place using onnxslim and
         verifies numerical closeness against a float32 CPU reference via
@@ -884,15 +806,8 @@ class LTDETRObjectDetection(TaskModel):
                     def msg(s: str) -> str:
                         return f'ONNX validation failed for output "{output_name}": {s}'
 
-                    # Due to the presence of top-k operations in the model, the outputs may be
-                    # in different order but still valid. To account for this, we sum
-                    # over the query dimension before comparing.
-                    # TODO(yutong, 07/2026): Summing each output over the query
-                    # dimension only checks per-field marginals: it cannot detect
-                    # an export that swaps labels between boxes, and summing the
-                    # integer labels is weaker still (e.g. [0, 2] matches [1, 1]).
-                    # Match detections per image by box location and compare the
-                    # full (label, box, score) tuples together instead.
+                    # Decoder query order can differ between backends while the raw
+                    # predictions remain equivalent, so compare query-reduced tensors.
                     output_model = output_model.sum(dim=1)
                     if output_onnx.is_floating_point():
                         # Convert to fp32 to avoid overflow issues when summing in fp16.

--- a/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
@@ -103,6 +103,20 @@ logger = logging.getLogger(__name__)
 _DINOV2_PREFIX = "dinov2/"
 
 
+def _decode_predictions_for_metrics(
+    model: LTDETRObjectDetection,
+    outputs: dict[str, Tensor],
+    orig_target_sizes: Tensor,
+) -> list[dict[str, Tensor]]:
+    labels, boxes, scores = model.postprocessor.decode(
+        (outputs["pred_logits"], outputs["pred_boxes"]), orig_target_sizes
+    )
+    return [
+        {"labels": labels_i, "boxes": boxes_i, "scores": scores_i}
+        for labels_i, boxes_i, scores_i in zip(labels, boxes, scores)
+    ]
+
+
 class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
     """Shared defaults for LTDETRObjectDetectionTrainArgs and
     DINOv2LTDETRObjectDetectionTrainArgsV2.
@@ -598,8 +612,10 @@ class LTDETRObjectDetectionTrain(TrainModel):
             orig_target_sizes_tensor = torch.tensor(
                 orig_target_sizes, device=samples.device
             )
-            results = self.model.postprocessor(
-                outputs, orig_target_sizes=orig_target_sizes_tensor
+            results = _decode_predictions_for_metrics(
+                model=self.model,
+                outputs=outputs,
+                orig_target_sizes=orig_target_sizes_tensor,
             )
             self.train_metrics.update_with_predictions(results, targets)
 
@@ -669,8 +685,10 @@ class LTDETRObjectDetectionTrain(TrainModel):
         orig_target_sizes_tensor = torch.tensor(
             orig_target_sizes, device=samples.device
         )
-        results: list[dict[str, Tensor]] = self.model.postprocessor(
-            outputs, orig_target_sizes=orig_target_sizes_tensor
+        results = _decode_predictions_for_metrics(
+            model=self.model,
+            outputs=outputs,
+            orig_target_sizes=orig_target_sizes_tensor,
         )
 
         # Metrics

--- a/tests/_pre_post_processing/__init__.py
+++ b/tests/_pre_post_processing/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_pre_post_processing/test_object_detection.py
+++ b/tests/_pre_post_processing/test_object_detection.py
@@ -1,0 +1,140 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import pytest
+import torch
+
+from lightly_train._pre_post_processing.object_detection import (
+    ObjectDetectionPostprocessor,
+    ObjectDetectionPreprocessor,
+)
+
+
+class TestObjectDetectionPreprocessor:
+    def test_preprocess_image__resizes_scales_and_returns_metadata(self) -> None:
+        preprocessor = ObjectDetectionPreprocessor(
+            image_size=(32, 48), image_normalize=None, expected_input_channels=3
+        )
+        image = torch.randint(0, 256, (3, 60, 80), dtype=torch.uint8)
+
+        output, metadata = preprocessor.preprocess_image(
+            image, device=torch.device("cpu"), dtype=torch.float32
+        )
+
+        assert output.shape == (3, 32, 48)
+        assert output.dtype == torch.float32
+        assert output.min() >= 0 and output.max() <= 1
+        assert metadata == {"orig_h": 60, "orig_w": 80}
+
+    def test_preprocess_image__validates_channels(self) -> None:
+        preprocessor = ObjectDetectionPreprocessor(
+            image_size=(16, 16), image_normalize=None, expected_input_channels=3
+        )
+        grayscale, _ = preprocessor.preprocess_image(
+            torch.rand(1, 8, 8),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+        assert grayscale.shape == (3, 16, 16)
+        with pytest.raises(ValueError, match="channels"):
+            preprocessor.preprocess_image(
+                torch.rand(2, 8, 8),
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            )
+
+    def test_preprocess_batch__normalizes(self) -> None:
+        preprocessor = ObjectDetectionPreprocessor(
+            image_size=(4, 4),
+            image_normalize={"mean": (0.5, 0.5, 0.5), "std": (0.5, 0.5, 0.5)},
+            expected_input_channels=3,
+        )
+        output = preprocessor.preprocess_batch(torch.zeros(2, 3, 4, 4))
+        torch.testing.assert_close(output, torch.full_like(output, -1))
+
+    def test_preprocess_sahi_image__returns_global_and_tiles(self) -> None:
+        preprocessor = ObjectDetectionPreprocessor(
+            image_size=(4, 6), image_normalize=None, expected_input_channels=3
+        )
+        batch, metadata = preprocessor.preprocess_sahi_image(
+            torch.zeros(3, 8, 10, dtype=torch.uint8),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            overlap=0.5,
+        )
+        assert batch.shape == (10, 3, 4, 6)
+        assert metadata["orig_h"] == 8
+        assert metadata["orig_w"] == 10
+        assert metadata["tiles_coordinates"].shape == (9, 2)
+
+
+def _postprocessor() -> ObjectDetectionPostprocessor:
+    return ObjectDetectionPostprocessor(
+        num_classes=2,
+        num_top_queries=3,
+        internal_class_to_class=torch.tensor([10, 20]),
+    )
+
+
+class TestObjectDetectionPostprocessor:
+    def test_decode__selects_rescales_and_remaps(self) -> None:
+        logits = torch.tensor([[[8.0, -8.0], [1.0, 7.0], [6.0, 0.0]]])
+        boxes = torch.tensor(
+            [[[0.5, 0.5, 0.2, 0.4], [0.25, 0.25, 0.2, 0.2], [0.8, 0.5, 0.1, 0.2]]]
+        )
+        labels, decoded_boxes, scores = _postprocessor().decode(
+            (logits, boxes), torch.tensor([[100, 200]])
+        )
+        torch.testing.assert_close(labels, torch.tensor([[10, 20, 10]]))
+        torch.testing.assert_close(
+            decoded_boxes[0, 0], torch.tensor([40.0, 60.0, 60.0, 140.0])
+        )
+        assert scores.shape == (1, 3)
+
+    def test_postprocess__filters_by_threshold(self) -> None:
+        logits = torch.full((1, 3, 2), -10.0)
+        boxes = torch.rand(1, 3, 4)
+        output = _postprocessor().postprocess(
+            (logits, boxes), [{"orig_h": 20, "orig_w": 30}], threshold=0.5
+        )
+        assert output[0]["labels"].shape == (0,)
+        assert output[0]["bboxes"].shape == (0, 4)
+
+    def test_postprocess_sahi__offsets_tiles(self) -> None:
+        postprocessor = ObjectDetectionPostprocessor(
+            num_classes=1,
+            num_top_queries=1,
+            internal_class_to_class=torch.tensor([7]),
+        )
+        output = postprocessor.postprocess_sahi(
+            (
+                torch.tensor([[[10.0]], [[9.0]], [[-10.0]]]),
+                torch.tensor(
+                    [
+                        [[0.5, 0.5, 0.2, 0.2]],
+                        [[0.5, 0.5, 0.2, 0.2]],
+                        [[0.5, 0.5, 0.2, 0.2]],
+                    ]
+                ),
+            ),
+            {
+                "orig_h": 50,
+                "orig_w": 100,
+                "tiles_coordinates": torch.tensor([[5, 7], [30, 20]]),
+            },
+            threshold=0.5,
+            nms_iou_threshold=0.3,
+            global_local_iou_threshold=0.1,
+            tile_size=(10, 20),
+        )
+        torch.testing.assert_close(output["labels"], torch.tensor([7, 7]))
+        torch.testing.assert_close(
+            output["bboxes"],
+            torch.tensor([[40.0, 20.0, 60.0, 30.0], [13.0, 11.0, 17.0, 13.0]]),
+        )

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -450,10 +450,9 @@ def test_dinov2_vits14_ltdetr__constructs_and_runs_forward() -> None:
     model.eval()
     model.deploy()
     with torch.no_grad():
-        labels, boxes, scores = model(torch.randn(1, 3, 224, 224))
-    assert labels.shape == (1, 300)
+        logits, boxes = model(torch.randn(1, 3, 224, 224))
+    assert logits.shape == (1, 300, 2)
     assert boxes.shape == (1, 300, 4)
-    assert scores.shape == (1, 300)
 
 
 @pytest.mark.parametrize(
@@ -639,10 +638,10 @@ def test_predict_batch__composes_stages_in_order(mocker: MockerFixture) -> None:
         load_weights=False,
     )
 
-    preprocess_image_spy = mocker.spy(model, "preprocess_image")
-    preprocess_batch_spy = mocker.spy(model, "preprocess_batch")
+    preprocess_image_spy = mocker.spy(model.preprocessor, "preprocess_image")
+    preprocess_batch_spy = mocker.spy(model.preprocessor, "preprocess_batch")
     forward_backend_spy = mocker.spy(model, "forward_backend")
-    postprocess_spy = mocker.spy(model, "postprocess")
+    postprocess_spy = mocker.spy(model.postprocessor, "postprocess")
 
     images = [torch.rand(3, 480, 640), torch.rand(3, 720, 1280)]
     result = model.predict_batch(images=images)
@@ -662,12 +661,86 @@ def test_predict_batch__composes_stages_in_order(mocker: MockerFixture) -> None:
 
     # postprocess receives forward_backend's output and per-image metadata.
     assert postprocess_spy.call_count == 1
-    raw_in, metadata = postprocess_spy.call_args.args
-    assert raw_in is forward_backend_spy.spy_return
+    raw_in, metadata, _ = postprocess_spy.call_args.args
+    assert raw_in[0] is forward_backend_spy.spy_return["pred_logits"]
+    assert raw_in[1] is forward_backend_spy.spy_return["pred_boxes"]
     assert len(metadata) == 2
 
-    # predict_batch returns whatever postprocess produced.
+    # predict_batch returns whatever the standalone postprocessor produced.
     assert result is postprocess_spy.spy_return
+
+
+def test_predict_sahi_batch__splits_raw_outputs_per_image(
+    mocker: MockerFixture,
+) -> None:
+    model = LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(16, 16),
+        load_weights=False,
+    )
+    model._deployed = True
+    metadata = [
+        {
+            "orig_h": 20,
+            "orig_w": 20,
+            "tiles_coordinates": torch.zeros(1, 2, dtype=torch.int64),
+        },
+        {
+            "orig_h": 40,
+            "orig_w": 40,
+            "tiles_coordinates": torch.zeros(2, 2, dtype=torch.int64),
+        },
+    ]
+    mocker.patch.object(
+        model.preprocessor,
+        "preprocess_sahi_image",
+        side_effect=[
+            (torch.zeros(2, 3, 16, 16), metadata[0]),
+            (torch.zeros(3, 3, 16, 16), metadata[1]),
+        ],
+    )
+    mocker.patch.object(
+        model.preprocessor, "preprocess_sahi_batch", side_effect=lambda batch: batch
+    )
+    mocker.patch.object(
+        model,
+        "forward",
+        return_value=(torch.zeros(5, 4, 2), torch.zeros(5, 4, 4)),
+    )
+    postprocess_sahi = mocker.patch.object(
+        model.postprocessor,
+        "postprocess_sahi",
+        side_effect=[
+            {
+                "labels": torch.tensor([1]),
+                "bboxes": torch.zeros(1, 4),
+                "scores": torch.ones(1),
+            },
+            {
+                "labels": torch.tensor([2]),
+                "bboxes": torch.zeros(1, 4),
+                "scores": torch.ones(1),
+            },
+        ],
+    )
+
+    output = model.predict_sahi_batch([torch.zeros(3, 20, 20), torch.zeros(3, 40, 40)])
+
+    assert [int(item["labels"].item()) for item in output] == [1, 2]
+    assert postprocess_sahi.call_args_list[0].args[0][0].shape[0] == 2
+    assert postprocess_sahi.call_args_list[1].args[0][0].shape[0] == 3
+
+
+def test_predict_sahi_batch__rejects_empty_input() -> None:
+    model = LTDETRObjectDetection(
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(16, 16),
+        load_weights=False,
+    )
+    with pytest.raises(ValueError, match="at least one image"):
+        model.predict_sahi_batch([])
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
@@ -703,9 +776,7 @@ def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
     with torch.no_grad():
         torch_outputs = model(torch.from_numpy(inputs))
 
-    # Compare via the shared helper: it sums over the query dim before comparing
-    # floats (order-invariant, since the postprocessor's top-k can reorder
-    # queries across backends) and treats labels as sorted multisets.
+    # Compare via the shared helper, which accounts for query ordering differences.
     assert_onnx_outputs_close(onnx_outputs, torch_outputs)
 
 

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -676,7 +676,7 @@ def test_predict_sahi_batch__splits_raw_outputs_per_image(
     model = LTDETRObjectDetection(
         model_name="dinov3/vitt16-notpretrained-ltdetr",
         classes={0: "class_0", 1: "class_1"},
-        image_size=(16, 16),
+        image_size=(64, 64),
         load_weights=False,
     )
     model._deployed = True
@@ -736,7 +736,7 @@ def test_predict_sahi_batch__rejects_empty_input() -> None:
     model = LTDETRObjectDetection(
         model_name="dinov3/vitt16-notpretrained-ltdetr",
         classes={0: "class_0", 1: "class_1"},
-        image_size=(16, 16),
+        image_size=(64, 64),
         load_weights=False,
     )
     with pytest.raises(ValueError, match="at least one image"):


### PR DESCRIPTION
## What has changed and why?
- decouple pre-/postprocessing
- exclude postprocessing from onnx
- add `predict_sahi_batch` since it was convenient

## How has it been tested?
- unit tests
- ran benchmark command locally
## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
