### PR TITLE
Rename tutorials

### DIFF
--- a/docs/prebuild.py
+++ b/docs/prebuild.py
@@ -111,6 +111,7 @@ def dump_transform_args_for_tasks(dest_dir: Path) -> None:
         variants = [("", train_model_cls.__name__.lower())]
         if train_model_cls.__name__ == "LTDETRObjectDetectionTrain":
             variants.append(("dinov2/", "dinov2ltdetrobjectdetectiontrain"))
+            variants.append(("dinov3/", "dinov3ltdetrobjectdetectiontrain"))
 
         for model_name, name in variants:
             train_transform_args_cls = train_model_cls.get_train_transform_cls(

--- a/docs/source/instance_segmentation.md
+++ b/docs/source/instance_segmentation.md
@@ -591,7 +591,7 @@ See {py:meth}`~.DINOv3EoMTInstanceSegmentation.export_onnx` for all available op
 when exporting to ONNX.
 
 The following notebook shows how to export a model to ONNX in Colab:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/instance_segmentation_export.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_instance_segmentation_export.ipynb)
 
 (instance-segmentation-tensorrt)=
 
@@ -633,7 +633,7 @@ See {py:meth}`~.DINOv3EoMTInstanceSegmentation.export_tensorrt` for all availabl
 options when exporting to TensorRT.
 
 You can also learn more about exporting EoMT to TensorRT using our Colab notebook:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/instance_segmentation_export.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_instance_segmentation_export.ipynb)
 
 (instance-segmentation-transform-args)=
 

--- a/docs/source/object_detection.md
+++ b/docs/source/object_detection.md
@@ -664,6 +664,17 @@ The following are the default image transform arguments. See
 ````
 `````
 
+`````{dropdown} DINOv3 LTDETR Default Transform Arguments
+````{dropdown} Train
+```{include} _auto/dinov3ltdetrobjectdetectiontrain_train_transform_args.md
+```
+````
+````{dropdown} Val
+```{include} _auto/dinov3ltdetrobjectdetectiontrain_val_transform_args.md
+```
+````
+`````
+
 `````{dropdown} PicoDet Default Transform Arguments
 ````{dropdown} Train
 ```{include} _auto/picodetobjectdetectiontrain_train_transform_args.md

--- a/docs/source/panoptic_segmentation.md
+++ b/docs/source/panoptic_segmentation.md
@@ -373,7 +373,7 @@ See {py:meth}`~.DINOv3EoMTPanopticSegmentation.export_onnx` for all available op
 when exporting to ONNX.
 
 The following notebook shows how to export a model to ONNX in Colab:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/panoptic_segmentation_export.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_panoptic_segmentation_export.ipynb)
 
 (panoptic-segmentation-tensorrt)=
 
@@ -415,4 +415,4 @@ See {py:meth}`~.DINOv3EoMTPanopticSegmentation.export_tensorrt` for all availabl
 options when exporting to TensorRT.
 
 You can also learn more about exporting EoMT to TensorRT using our Colab notebook:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/panoptic_segmentation_export.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_panoptic_segmentation_export.ipynb)

--- a/docs/source/pretrain_distill/index.md
+++ b/docs/source/pretrain_distill/index.md
@@ -464,8 +464,6 @@ hidden:
 maxdepth: 1
 ---
 Overview <self>
-Distillation <methods/distillation>
-Pretrain DINOv2 <methods/dinov2>
 All Methods <methods/index>
 models/index
 export

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -770,7 +770,7 @@ See {py:meth}`~.DINOv3EoMTSemanticSegmentation.export_onnx` for all available op
 when exporting to ONNX.
 
 The following notebook shows how to export a model to ONNX in Colab:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/semantic_segmentation_export.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_semantic_segmentation_export.ipynb)
 
 (semantic-segmentation-tensorrt)=
 
@@ -812,4 +812,4 @@ See {py:meth}`~.DINOv3EoMTSemanticSegmentation.export_tensorrt` for all availabl
 options when exporting to TensorRT.
 
 You can also learn more about exporting EoMT to TensorRT using our Colab notebook:
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/semantic_segmentation_export.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_semantic_segmentation_export.ipynb)

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -38,12 +38,12 @@ eomt_panoptic_segmentation
 ```{toctree}
 ---
 maxdepth: 1
-caption: Export Tutorials
+caption: ONNX & TENSORRT EXPORT TUTORIALS
 ---
 object_detection_export
-instance_segmentation_export
-semantic_segmentation_export
-panoptic_segmentation_export
+eomt_instance_segmentation_export
+eomt_semantic_segmentation_export
+eomt_panoptic_segmentation_export
 depth_estimation_export
 ```
 

--- a/examples/notebooks/depth_estimation.ipynb
+++ b/examples/notebooks/depth_estimation.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Monocular Depth Estimation with Depth Anything V3\n",
+    "# Depth Estimation with Depth Anything V3\n",
     "\n",
     "[Depth Anything V3](https://huggingface.co/depth-anything) is a monocular depth model built on the [DINOv2](https://github.com/facebookresearch/dinov2) foundation backbone. LightlyTrain's version is a faithful implementation of the official code.\n",
     "\n",

--- a/examples/notebooks/depth_estimation_export.ipynb
+++ b/examples/notebooks/depth_estimation_export.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Depth Estimation Model Export (ONNX and TensorRT)\n",
+    "# Depth Estimation Model Export - Depth Anything v3\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/depth_estimation_export.ipynb)\n",
     "\n",

--- a/examples/notebooks/eomt_instance_segmentation_export.ipynb
+++ b/examples/notebooks/eomt_instance_segmentation_export.ipynb
@@ -5,11 +5,11 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Panoptic Segmentation Model Export (ONNX and TensorRT)\n",
+    "# Instance Segmentation Model Export - EoMT\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/panoptic_segmentation_export.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_instance_segmentation_export.ipynb)\n",
     "\n",
-    "This notebook demonstrates how to export a panoptic segmentation model to ONNX and TensorRT.\n",
+    "This notebook demonstrates how to export an instance segmentation model to ONNX and TensorRT.\n",
     "\n",
     "The notebook covers the following steps:\n",
     "1. Install LightlyTrain\n",
@@ -51,7 +51,7 @@
    "source": [
     "import lightly_train\n",
     "\n",
-    "model = lightly_train.load_model(\"dinov3/vits16-eomt-panoptic-coco\")"
+    "model = lightly_train.load_model(\"dinov3/vits16-eomt-inst-coco\")"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000105264.jpg"
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
    ]
   },
   {
@@ -89,7 +89,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch\n",
     "import torchvision.transforms.v2 as T\n",
     "from PIL import Image\n",
     "from torchvision.transforms.functional import pil_to_tensor\n",
@@ -110,7 +109,7 @@
     "    ]\n",
     ")\n",
     "\n",
-    "# Apply transforms for ONNX and TensorRT inference.\n",
+    "# Apply transforms for ONNX inference.\n",
     "image_tensor_transformed = transforms(image_pil)[None]"
    ]
   },
@@ -122,8 +121,7 @@
     "### Get the model predictions for reference\n",
     "\n",
     "We define a helper function to visualize the predictions.\n",
-    "The function will be used to compare the predictions from PyTorch, ONNX and\n",
-    "TensorRT models."
+    "The function will be used to compare the predictions from PyTorch and ONNX models."
    ]
   },
   {
@@ -134,31 +132,13 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
+    "import torch\n",
     "from torchvision.utils import draw_segmentation_masks\n",
     "\n",
     "\n",
-    "def visualize_segmentations(image, masks, segment_ids):\n",
-    "    # masks is (H, W, 2)\n",
-    "    # segment_ids is (num_segments)\n",
-    "\n",
-    "    # Convert masks to boolean masks for each segment\n",
-    "    # masks[..., 1] contains the segment id for each pixel.\n",
-    "    # We add a mask for unassigned pixels (segment id -1).\n",
-    "    masks_bool = torch.stack(\n",
-    "        [masks[..., 1] == -1]\n",
-    "        + [masks[..., 1] == segment_id for segment_id in segment_ids]\n",
-    "    )\n",
-    "\n",
-    "    # Create colors for visualization\n",
-    "    colors = [(0, 0, 0)] + [\n",
-    "        [int(color * 255) for color in plt.cm.tab20c(i / len(segment_ids))[:3]]\n",
-    "        for i in range(len(segment_ids))\n",
-    "    ]\n",
-    "\n",
-    "    image_with_masks = draw_segmentation_masks(\n",
-    "        image, masks_bool, colors=colors, alpha=1.0\n",
-    "    )\n",
-    "\n",
+    "def visualize_segmentations(image, masks):\n",
+    "    # Draw segmentation masks.\n",
+    "    image_with_masks = draw_segmentation_masks(image, masks, alpha=1.0)\n",
     "    fig, axs = plt.subplots(1, 2, figsize=(12, 8))\n",
     "    axs[0].imshow(image.permute(1, 2, 0))\n",
     "    axs[0].axis(\"off\")\n",
@@ -178,9 +158,7 @@
     "results = model.predict(image_tensor)\n",
     "\n",
     "# Visualize predictions from the PyTorch model.\n",
-    "visualize_segmentations(\n",
-    "    image_tensor, masks=results[\"masks\"], segment_ids=results[\"segment_ids\"]\n",
-    ")"
+    "visualize_segmentations(image_tensor, masks=results[\"masks\"])"
    ]
   },
   {
@@ -199,6 +177,7 @@
    "outputs": [],
    "source": [
     "# Export the PyTorch model to ONNX.\n",
+    "\n",
     "model.export_onnx(\n",
     "    out=\"model.onnx\",\n",
     "    # precision=\"fp16\", # Export model with FP16 weights for smaller size and faster inference.\n",
@@ -210,7 +189,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_panoptic_segmentation.task_model.DINOv3EoMTPanopticSegmentation.export_onnx) for all available options when exporting to ONNX.\n"
+    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_instance_segmentation.task_model.DINOv3EoMTInstanceSegmentation.export_onnx) for all available options when exporting to ONNX.\n"
    ]
   },
   {
@@ -242,28 +221,33 @@
     "}[input_dtype]\n",
     "\n",
     "# Run inference.\n",
-    "outputs = sess.run(\n",
+    "labels_onnx, masks_onnx, scores_onnx = sess.run(\n",
     "    output_names=None,\n",
-    "    input_feed={\n",
-    "        \"images\": image_tensor_transformed.numpy().astype(input_dtype_numpy),\n",
-    "    },\n",
+    "    input_feed={\"images\": image_tensor_transformed.numpy().astype(input_dtype_numpy)},\n",
     ")\n",
     "\n",
-    "masks_onnx = outputs[0]\n",
-    "segment_ids_onnx = outputs[1]\n",
-    "scores_onnx = outputs[2]\n",
+    "# Remove batch dimension.\n",
+    "labels_onnx = labels_onnx[0]\n",
+    "masks_onnx = masks_onnx[0]\n",
+    "scores_onnx = scores_onnx[0]\n",
+    "\n",
+    "# Filter by score (ONNX export returns all queries).\n",
+    "keep = scores_onnx >= 0.8\n",
+    "labels_onnx = labels_onnx[keep]\n",
+    "masks_onnx = masks_onnx[keep]\n",
+    "scores_onnx = scores_onnx[keep]\n",
     "\n",
     "# Resize ONNX predictions to original image size if necessary.\n",
+    "# This is only needed if the original image size is different from the model input size.\n",
     "masks_onnx = torch.from_numpy(masks_onnx)\n",
-    "masks_onnx = masks_onnx.permute(0, 3, 1, 2).float()  # (1, 2, H_model, W_model)\n",
-    "# (1, 2, H_orig, W_orig)\n",
-    "masks_onnx = F.interpolate(masks_onnx, size=(h, w), mode=\"nearest\")\n",
-    "masks_onnx = masks_onnx.permute(0, 2, 3, 1).long()  # (1, H_orig, W_orig, 2)\n",
+    "masks_onnx = (\n",
+    "    F.interpolate(masks_onnx.float().unsqueeze(1), size=(h, w), mode=\"nearest\")\n",
+    "    .squeeze(1)\n",
+    "    .bool()\n",
+    ")\n",
     "\n",
     "# Visualize predictions from the ONNX model.\n",
-    "visualize_segmentations(\n",
-    "    image_tensor, masks=masks_onnx[0], segment_ids=segment_ids_onnx[0]\n",
-    ")"
+    "visualize_segmentations(image_tensor, masks=masks_onnx)"
    ]
   },
   {
@@ -271,12 +255,23 @@
    "id": "16",
    "metadata": {},
    "source": [
-    "## Export to TensorRT"
+    "**Note**: There might be small visual differences between the masks predicted by\n",
+    "the PyTorch model with `model.predict` and the ONNX model. This is because the PyTorch\n",
+    "model uses `transforms` that resize the image slightly differently compared to the fixed\n",
+    "size resize used for ONNX."
    ]
   },
   {
    "cell_type": "markdown",
    "id": "17",
+   "metadata": {},
+   "source": [
+    "## Export to TensorRT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Requirements\n",
@@ -290,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,15 +308,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
-    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_panoptic_segmentation.task_model.DINOv3EoMTPanopticSegmentation.export_tensorrt) for all available options when exporting to TensorRT.\n"
+    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_instance_segmentation.task_model.DINOv3EoMTInstanceSegmentation.export_tensorrt) for all available options when exporting to TensorRT.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Run inference with the TensorRT engine"
@@ -330,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,13 +335,7 @@
     "\n",
     "\n",
     "class TRT:\n",
-    "    def __init__(\n",
-    "        self,\n",
-    "        engine_path: str,\n",
-    "        num_queries: int,\n",
-    "        device: str = \"cuda:0\",\n",
-    "        verbose: bool = False,\n",
-    "    ):\n",
+    "    def __init__(self, engine_path: str, device: str = \"cuda:0\", verbose: bool = False):\n",
     "        self.device = torch.device(device)\n",
     "        logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.INFO)\n",
     "        trt.init_libnvinfer_plugins(logger, \"\")\n",
@@ -374,7 +363,6 @@
     "        self.bindings = []\n",
     "        for name in io_names:\n",
     "            shape = tuple(self.context.get_tensor_shape(name))\n",
-    "            shape = [s if s != -1 else num_queries for s in shape]\n",
     "            np_dtype = trt.nptype(self.engine.get_tensor_dtype(name))\n",
     "            torch_dtype = torch.from_numpy(np.empty((), dtype=np_dtype)).dtype\n",
     "            buffer = torch.empty(\n",
@@ -395,36 +383,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate the TensorRT model.\n",
-    "trt_model = TRT(\"model.trt\", num_queries=model.num_queries)\n",
+    "trt_model = TRT(\"model.trt\")\n",
     "\n",
     "# Run inference with the TensorRT model.\n",
+    "# Note: TensorRT inference returns raw outputs (labels, masks, scores).\n",
     "outputs_trt = trt_model({\"images\": image_tensor_transformed})\n",
     "\n",
+    "labels_trt = outputs_trt[\"labels\"][0]\n",
     "masks_trt = outputs_trt[\"masks\"][0]\n",
-    "segment_ids_trt = outputs_trt[\"segment_ids\"][0]\n",
     "scores_trt = outputs_trt[\"scores\"][0]\n",
     "\n",
-    "# Filter out segments with scores below threshold. This is required because TensorRT\n",
-    "# returns scores and segment ids for all possible segments.\n",
-    "keep = scores_trt > 0.8\n",
-    "segment_ids_trt = segment_ids_trt[keep]\n",
+    "# Filter by score (TensorRT export returns all queries).\n",
+    "keep = scores_trt >= 0.8\n",
+    "labels_trt = labels_trt[keep]\n",
+    "masks_trt = masks_trt[keep]\n",
     "scores_trt = scores_trt[keep]\n",
     "\n",
     "# Resize TensorRT predictions to original image size if necessary.\n",
-    "masks_trt = masks_trt.permute(2, 0, 1).float()\n",
-    "masks_trt = masks_trt.unsqueeze(0)\n",
-    "masks_trt = F.interpolate(masks_trt, size=(h, w), mode=\"nearest\")\n",
-    "masks_trt = masks_trt.squeeze(0).permute(1, 2, 0).long()\n",
+    "# This assumes masks_trt is on GPU/device since TRT class keeps them there.\n",
+    "masks_trt = (\n",
+    "    F.interpolate(masks_trt.float().unsqueeze(1), size=(h, w), mode=\"nearest\")\n",
+    "    .squeeze(1)\n",
+    "    .bool()\n",
+    ")\n",
     "\n",
     "# Visualize predictions from the TensorRT model.\n",
-    "visualize_segmentations(\n",
-    "    image_tensor, masks=masks_trt.cpu(), segment_ids=segment_ids_trt.cpu()\n",
-    ")"
+    "visualize_segmentations(image_tensor, masks=masks_trt.cpu())"
    ]
   }
  ],

--- a/examples/notebooks/eomt_panoptic_segmentation_export.ipynb
+++ b/examples/notebooks/eomt_panoptic_segmentation_export.ipynb
@@ -5,11 +5,11 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Instance Segmentation Model Export (ONNX and TensorRT)\n",
+    "# Panoptic Segmentation Model Export - EoMT\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/instance_segmentation_export.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_panoptic_segmentation_export.ipynb)\n",
     "\n",
-    "This notebook demonstrates how to export an instance segmentation model to ONNX and TensorRT.\n",
+    "This notebook demonstrates how to export a panoptic segmentation model to ONNX and TensorRT.\n",
     "\n",
     "The notebook covers the following steps:\n",
     "1. Install LightlyTrain\n",
@@ -51,7 +51,7 @@
    "source": [
     "import lightly_train\n",
     "\n",
-    "model = lightly_train.load_model(\"dinov3/vits16-eomt-inst-coco\")"
+    "model = lightly_train.load_model(\"dinov3/vits16-eomt-panoptic-coco\")"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000105264.jpg"
    ]
   },
   {
@@ -89,6 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import torch\n",
     "import torchvision.transforms.v2 as T\n",
     "from PIL import Image\n",
     "from torchvision.transforms.functional import pil_to_tensor\n",
@@ -109,7 +110,7 @@
     "    ]\n",
     ")\n",
     "\n",
-    "# Apply transforms for ONNX inference.\n",
+    "# Apply transforms for ONNX and TensorRT inference.\n",
     "image_tensor_transformed = transforms(image_pil)[None]"
    ]
   },
@@ -121,7 +122,8 @@
     "### Get the model predictions for reference\n",
     "\n",
     "We define a helper function to visualize the predictions.\n",
-    "The function will be used to compare the predictions from PyTorch and ONNX models."
+    "The function will be used to compare the predictions from PyTorch, ONNX and\n",
+    "TensorRT models."
    ]
   },
   {
@@ -132,13 +134,31 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "import torch\n",
     "from torchvision.utils import draw_segmentation_masks\n",
     "\n",
     "\n",
-    "def visualize_segmentations(image, masks):\n",
-    "    # Draw segmentation masks.\n",
-    "    image_with_masks = draw_segmentation_masks(image, masks, alpha=1.0)\n",
+    "def visualize_segmentations(image, masks, segment_ids):\n",
+    "    # masks is (H, W, 2)\n",
+    "    # segment_ids is (num_segments)\n",
+    "\n",
+    "    # Convert masks to boolean masks for each segment\n",
+    "    # masks[..., 1] contains the segment id for each pixel.\n",
+    "    # We add a mask for unassigned pixels (segment id -1).\n",
+    "    masks_bool = torch.stack(\n",
+    "        [masks[..., 1] == -1]\n",
+    "        + [masks[..., 1] == segment_id for segment_id in segment_ids]\n",
+    "    )\n",
+    "\n",
+    "    # Create colors for visualization\n",
+    "    colors = [(0, 0, 0)] + [\n",
+    "        [int(color * 255) for color in plt.cm.tab20c(i / len(segment_ids))[:3]]\n",
+    "        for i in range(len(segment_ids))\n",
+    "    ]\n",
+    "\n",
+    "    image_with_masks = draw_segmentation_masks(\n",
+    "        image, masks_bool, colors=colors, alpha=1.0\n",
+    "    )\n",
+    "\n",
     "    fig, axs = plt.subplots(1, 2, figsize=(12, 8))\n",
     "    axs[0].imshow(image.permute(1, 2, 0))\n",
     "    axs[0].axis(\"off\")\n",
@@ -158,7 +178,9 @@
     "results = model.predict(image_tensor)\n",
     "\n",
     "# Visualize predictions from the PyTorch model.\n",
-    "visualize_segmentations(image_tensor, masks=results[\"masks\"])"
+    "visualize_segmentations(\n",
+    "    image_tensor, masks=results[\"masks\"], segment_ids=results[\"segment_ids\"]\n",
+    ")"
    ]
   },
   {
@@ -177,7 +199,6 @@
    "outputs": [],
    "source": [
     "# Export the PyTorch model to ONNX.\n",
-    "\n",
     "model.export_onnx(\n",
     "    out=\"model.onnx\",\n",
     "    # precision=\"fp16\", # Export model with FP16 weights for smaller size and faster inference.\n",
@@ -189,7 +210,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_instance_segmentation.task_model.DINOv3EoMTInstanceSegmentation.export_onnx) for all available options when exporting to ONNX.\n"
+    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_panoptic_segmentation.task_model.DINOv3EoMTPanopticSegmentation.export_onnx) for all available options when exporting to ONNX.\n"
    ]
   },
   {
@@ -221,33 +242,28 @@
     "}[input_dtype]\n",
     "\n",
     "# Run inference.\n",
-    "labels_onnx, masks_onnx, scores_onnx = sess.run(\n",
+    "outputs = sess.run(\n",
     "    output_names=None,\n",
-    "    input_feed={\"images\": image_tensor_transformed.numpy().astype(input_dtype_numpy)},\n",
+    "    input_feed={\n",
+    "        \"images\": image_tensor_transformed.numpy().astype(input_dtype_numpy),\n",
+    "    },\n",
     ")\n",
     "\n",
-    "# Remove batch dimension.\n",
-    "labels_onnx = labels_onnx[0]\n",
-    "masks_onnx = masks_onnx[0]\n",
-    "scores_onnx = scores_onnx[0]\n",
-    "\n",
-    "# Filter by score (ONNX export returns all queries).\n",
-    "keep = scores_onnx >= 0.8\n",
-    "labels_onnx = labels_onnx[keep]\n",
-    "masks_onnx = masks_onnx[keep]\n",
-    "scores_onnx = scores_onnx[keep]\n",
+    "masks_onnx = outputs[0]\n",
+    "segment_ids_onnx = outputs[1]\n",
+    "scores_onnx = outputs[2]\n",
     "\n",
     "# Resize ONNX predictions to original image size if necessary.\n",
-    "# This is only needed if the original image size is different from the model input size.\n",
     "masks_onnx = torch.from_numpy(masks_onnx)\n",
-    "masks_onnx = (\n",
-    "    F.interpolate(masks_onnx.float().unsqueeze(1), size=(h, w), mode=\"nearest\")\n",
-    "    .squeeze(1)\n",
-    "    .bool()\n",
-    ")\n",
+    "masks_onnx = masks_onnx.permute(0, 3, 1, 2).float()  # (1, 2, H_model, W_model)\n",
+    "# (1, 2, H_orig, W_orig)\n",
+    "masks_onnx = F.interpolate(masks_onnx, size=(h, w), mode=\"nearest\")\n",
+    "masks_onnx = masks_onnx.permute(0, 2, 3, 1).long()  # (1, H_orig, W_orig, 2)\n",
     "\n",
     "# Visualize predictions from the ONNX model.\n",
-    "visualize_segmentations(image_tensor, masks=masks_onnx)"
+    "visualize_segmentations(\n",
+    "    image_tensor, masks=masks_onnx[0], segment_ids=segment_ids_onnx[0]\n",
+    ")"
    ]
   },
   {
@@ -255,23 +271,12 @@
    "id": "16",
    "metadata": {},
    "source": [
-    "**Note**: There might be small visual differences between the masks predicted by\n",
-    "the PyTorch model with `model.predict` and the ONNX model. This is because the PyTorch\n",
-    "model uses `transforms` that resize the image slightly differently compared to the fixed\n",
-    "size resize used for ONNX."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "17",
-   "metadata": {},
-   "source": [
     "## Export to TensorRT"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Requirements\n",
@@ -285,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,15 +313,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "source": [
-    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_instance_segmentation.task_model.DINOv3EoMTInstanceSegmentation.export_tensorrt) for all available options when exporting to TensorRT.\n"
+    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_eomt_panoptic_segmentation.task_model.DINOv3EoMTPanopticSegmentation.export_tensorrt) for all available options when exporting to TensorRT.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Run inference with the TensorRT engine"
@@ -325,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +340,13 @@
     "\n",
     "\n",
     "class TRT:\n",
-    "    def __init__(self, engine_path: str, device: str = \"cuda:0\", verbose: bool = False):\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        engine_path: str,\n",
+    "        num_queries: int,\n",
+    "        device: str = \"cuda:0\",\n",
+    "        verbose: bool = False,\n",
+    "    ):\n",
     "        self.device = torch.device(device)\n",
     "        logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.INFO)\n",
     "        trt.init_libnvinfer_plugins(logger, \"\")\n",
@@ -363,6 +374,7 @@
     "        self.bindings = []\n",
     "        for name in io_names:\n",
     "            shape = tuple(self.context.get_tensor_shape(name))\n",
+    "            shape = [s if s != -1 else num_queries for s in shape]\n",
     "            np_dtype = trt.nptype(self.engine.get_tensor_dtype(name))\n",
     "            torch_dtype = torch.from_numpy(np.empty((), dtype=np_dtype)).dtype\n",
     "            buffer = torch.empty(\n",
@@ -383,37 +395,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Instantiate the TensorRT model.\n",
-    "trt_model = TRT(\"model.trt\")\n",
+    "trt_model = TRT(\"model.trt\", num_queries=model.num_queries)\n",
     "\n",
     "# Run inference with the TensorRT model.\n",
-    "# Note: TensorRT inference returns raw outputs (labels, masks, scores).\n",
     "outputs_trt = trt_model({\"images\": image_tensor_transformed})\n",
     "\n",
-    "labels_trt = outputs_trt[\"labels\"][0]\n",
     "masks_trt = outputs_trt[\"masks\"][0]\n",
+    "segment_ids_trt = outputs_trt[\"segment_ids\"][0]\n",
     "scores_trt = outputs_trt[\"scores\"][0]\n",
     "\n",
-    "# Filter by score (TensorRT export returns all queries).\n",
-    "keep = scores_trt >= 0.8\n",
-    "labels_trt = labels_trt[keep]\n",
-    "masks_trt = masks_trt[keep]\n",
+    "# Filter out segments with scores below threshold. This is required because TensorRT\n",
+    "# returns scores and segment ids for all possible segments.\n",
+    "keep = scores_trt > 0.8\n",
+    "segment_ids_trt = segment_ids_trt[keep]\n",
     "scores_trt = scores_trt[keep]\n",
     "\n",
     "# Resize TensorRT predictions to original image size if necessary.\n",
-    "# This assumes masks_trt is on GPU/device since TRT class keeps them there.\n",
-    "masks_trt = (\n",
-    "    F.interpolate(masks_trt.float().unsqueeze(1), size=(h, w), mode=\"nearest\")\n",
-    "    .squeeze(1)\n",
-    "    .bool()\n",
-    ")\n",
+    "masks_trt = masks_trt.permute(2, 0, 1).float()\n",
+    "masks_trt = masks_trt.unsqueeze(0)\n",
+    "masks_trt = F.interpolate(masks_trt, size=(h, w), mode=\"nearest\")\n",
+    "masks_trt = masks_trt.squeeze(0).permute(1, 2, 0).long()\n",
     "\n",
     "# Visualize predictions from the TensorRT model.\n",
-    "visualize_segmentations(image_tensor, masks=masks_trt.cpu())"
+    "visualize_segmentations(\n",
+    "    image_tensor, masks=masks_trt.cpu(), segment_ids=segment_ids_trt.cpu()\n",
+    ")"
    ]
   }
  ],

--- a/examples/notebooks/eomt_semantic_segmentation_export.ipynb
+++ b/examples/notebooks/eomt_semantic_segmentation_export.ipynb
@@ -5,9 +5,9 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Semantic Segmentation Model Export (ONNX and TensorRT)\n",
+    "# Semantic Segmentation Model Export - EoMT\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/semantic_segmentation_export.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_semantic_segmentation_export.ipynb)\n",
     "\n",
     "This notebook demonstrates how to export a semantic segmentation model to ONNX and TensorRT.\n",
     "\n",

--- a/examples/notebooks/object_detection_export.ipynb
+++ b/examples/notebooks/object_detection_export.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# LTDETR Model Export (ONNX and TensorRT)\n",
+    "# Object Detection Model Export - LTDETRv2\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/object_detection_export.ipynb)\n",
     "\n",
@@ -51,7 +51,7 @@
    "source": [
     "import lightly_train\n",
     "\n",
-    "model = lightly_train.load_model(\"dinov3/vitt16-ltdetr-coco\")"
+    "model = lightly_train.load_model(\"ltdetrv2-s-coco\")"
    ]
   },
   {
@@ -190,7 +190,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_ltdetr_object_detection.task_model.DINOv3LTDETRObjectDetection.export_onnx) for all available options when exporting to ONNX.\n"
+    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.ltdetr_object_detection.task_model.LTDETRObjectDetection.export_onnx) for all available options when exporting to ONNX.\n"
    ]
   },
   {
@@ -303,7 +303,7 @@
    "id": "20",
    "metadata": {},
    "source": [
-    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.dinov3_ltdetr_object_detection.task_model.DINOv3LTDETRObjectDetection.export_tensorrt) for all available options when exporting to TensorRT.\n"
+    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.ltdetr_object_detection.task_model.LTDETRObjectDetection.export_tensorrt) for all available options when exporting to TensorRT.\n"
    ]
   },
   {


### PR DESCRIPTION
## What has changed and why?

- Rename the object detection export tutorial to use the LTDETRv2 name.
- Use `ltdetrv2-s-coco` as its default model and update the corresponding API links.
- Remove “Monocular” from the Depth Anything V3 tutorial title.
- Add model-family suffixes to the EoMT and Depth Anything V3 export tutorial titles.
- Rename the EoMT segmentation export notebooks with an `eomt_` prefix.
- Update all affected toctree entries, Colab links, and documentation references.
- Rename the export tutorial section to ONNX & TENSORRT EXPORT TUTORIALS.

## How has it been tested?

[Tutorials - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/30130218/Tutorials.-.LightlyTrain.documentation.pdf)

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [X] Yes
- [ ] Not needed (internal change without effects for user)
