### PR TITLE
Streamline training and export tutorials

### DIFF
--- a/docs/prebuild.py
+++ b/docs/prebuild.py
@@ -111,7 +111,6 @@ def dump_transform_args_for_tasks(dest_dir: Path) -> None:
         variants = [("", train_model_cls.__name__.lower())]
         if train_model_cls.__name__ == "LTDETRObjectDetectionTrain":
             variants.append(("dinov2/", "dinov2ltdetrobjectdetectiontrain"))
-            variants.append(("dinov3/", "dinov3ltdetrobjectdetectiontrain"))
 
         for model_name, name in variants:
             train_transform_args_cls = train_model_cls.get_train_transform_cls(

--- a/docs/source/object_detection.md
+++ b/docs/source/object_detection.md
@@ -664,17 +664,6 @@ The following are the default image transform arguments. See
 ````
 `````
 
-`````{dropdown} DINOv3 LTDETR Default Transform Arguments
-````{dropdown} Train
-```{include} _auto/dinov3ltdetrobjectdetectiontrain_train_transform_args.md
-```
-````
-````{dropdown} Val
-```{include} _auto/dinov3ltdetrobjectdetectiontrain_val_transform_args.md
-```
-````
-`````
-
 `````{dropdown} PicoDet Default Transform Arguments
 ````{dropdown} Train
 ```{include} _auto/picodetobjectdetectiontrain_train_transform_args.md

--- a/examples/notebooks/depth_estimation_export.ipynb
+++ b/examples/notebooks/depth_estimation_export.ipynb
@@ -263,7 +263,7 @@
     "version, GPU, and NVIDIA driver/CUDA setup.\n",
     "See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for more details.\n",
     "\n",
-    "On CUDA 12.x systems you can often install the Python package via:"
+    "On CUDA 12.x systems, install the TensorRT version tested with this tutorial. Pinning the version prevents pip from installing TensorRT 11, which is not yet supported by LightlyTrain:"
    ]
   },
   {
@@ -273,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorrt-cu12"
+    "!pip install \"tensorrt-cu12==10.13.3.9\""
    ]
   },
   {

--- a/examples/notebooks/depth_estimation_export.ipynb
+++ b/examples/notebooks/depth_estimation_export.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Depth Estimation Model Export - Depth Anything v3\n",
+    "# Depth Estimation Model Export (ONNX and TensorRT)\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/depth_estimation_export.ipynb)\n",
     "\n",

--- a/examples/notebooks/eomt_instance_segmentation.ipynb
+++ b/examples/notebooks/eomt_instance_segmentation.ipynb
@@ -55,113 +55,6 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## Prediction using LightlyTrain's model weights\n",
-    "\n",
-    "### Download an example image\n",
-    "\n",
-    "Download an example image for inference with the following command:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6",
-   "metadata": {},
-   "source": [
-    "### Load the model weights\n",
-    "\n",
-    "Then load the model weights with LightlyTrain's `load_model` function:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lightly_train\n",
-    "\n",
-    "model = lightly_train.load_model(\"dinov3/vits16-eomt-inst-coco\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8",
-   "metadata": {},
-   "source": [
-    "### Predict the instances\n",
-    "\n",
-    "Run `model.predict` on the image. The method accepts file paths, URLs, PIL Images, or tensors as input."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prediction = model.predict(\"image.jpg\", threshold=0.8)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10",
-   "metadata": {},
-   "source": [
-    "### Visualize the results\n",
-    "\n",
-    "Visualize the image and predicted instance masks to inspect the segmentation output."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "from torchvision.io import read_image\n",
-    "from torchvision.utils import draw_segmentation_masks\n",
-    "\n",
-    "image = read_image(\"image.jpg\")\n",
-    "masks = prediction[\"masks\"]\n",
-    "labels = prediction[\"labels\"]\n",
-    "scores = prediction[\"scores\"]\n",
-    "image_with_masks = draw_segmentation_masks(\n",
-    "    image,\n",
-    "    masks=masks,\n",
-    "    alpha=1.0,\n",
-    ")\n",
-    "plt.imshow(image_with_masks.permute(1, 2, 0))\n",
-    "plt.axis(\"off\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12",
-   "metadata": {},
-   "source": [
-    "The predicted masks are returned as tensors with shape `(N, height, width)` and coordinates aligned with the input image."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13",
-   "metadata": {},
-   "source": [
     "## Train an instance segmentation model\n",
     "\n",
     "Training your own instance segmentation model is straightforward with LightlyTrain."
@@ -169,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Download dataset\n",
@@ -180,16 +73,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -O coco128-seg.zip https://github.com/ultralytics/assets/releases/download/v0.0.0/coco128-seg.zip && unzip coco128-seg.zip"
+    "!wget -O coco128-seg.zip https://github.com/ultralytics/assets/releases/download/v0.0.0/coco128-seg.zip && unzip -q coco128-seg.zip"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "The example archive contains a single image directory. Move a small subset into a validation split so that the tutorial demonstrates both training and validation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "dataset_dir = Path(\"coco128-seg\")\n",
+    "val_images_dir = dataset_dir / \"images/val2017\"\n",
+    "val_labels_dir = dataset_dir / \"labels/val2017\"\n",
+    "val_images_dir.mkdir(parents=True, exist_ok=True)\n",
+    "val_labels_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "if not any(val_images_dir.iterdir()):\n",
+    "    train_images_dir = dataset_dir / \"images/train2017\"\n",
+    "    train_labels_dir = dataset_dir / \"labels/train2017\"\n",
+    "    for image_path in sorted(train_images_dir.glob(\"*.jpg\"))[-16:]:\n",
+    "        image_path.rename(val_images_dir / image_path.name)\n",
+    "        label_path = train_labels_dir / image_path.with_suffix(\".txt\").name\n",
+    "        if label_path.exists():\n",
+    "            label_path.rename(val_labels_dir / label_path.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
    "metadata": {},
    "source": [
     "Then start the training with the `train_instance_segmentation` function. You can specify various training parameters such as the model architecture, number of training steps, batch size, learning rate, and more."
@@ -198,10 +124,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import lightly_train\n",
+    "\n",
     "lightly_train.train_instance_segmentation(\n",
     "    out=\"out/my_experiment\",\n",
     "    model=\"dinov3/vits16-eomt-inst-coco\",\n",
@@ -299,29 +227,71 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "11",
    "metadata": {},
    "source": [
-    "Once training completes, the final model checkpoint is saved in `out/my_experiment/exported_models/exported_last.pt`. If you have a validation dataset, the best model according to the validation mask mAP is saved in `out/my_experiment/exported_models/exported_best.pt`."
+    "Once training completes, the final model checkpoint is saved in `out/my_experiment/exported_models/exported_last.pt`. The best model according to the validation mask mAP is saved in `out/my_experiment/exported_models/exported_best.pt`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Predict with your own EoMT weights"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = lightly_train.load_model(\"out/my_experiment/exported_models/exported_last.pt\")"
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Load the model weights\n",
+    "\n",
+    "Load the best model exported during training with LightlyTrain's `load_model` function:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
+    "model = lightly_train.load_model(\"out/my_experiment/exported_models/exported_best.pt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "### Predict and visualize the instances\n",
+    "\n",
+    "Run prediction on the example image again, this time using the weights from your own training run, and visualize the instance masks:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from torchvision.io import read_image\n",
+    "from torchvision.utils import draw_segmentation_masks\n",
+    "\n",
     "prediction = model.predict(\"image.jpg\")\n",
     "\n",
     "image = read_image(\"image.jpg\")\n",

--- a/examples/notebooks/eomt_instance_segmentation_export.ipynb
+++ b/examples/notebooks/eomt_instance_segmentation_export.ipynb
@@ -180,6 +180,7 @@
     "\n",
     "model.export_onnx(\n",
     "    out=\"model.onnx\",\n",
+    "    verify=False,  # The following inference cell verifies the exported model.\n",
     "    # precision=\"fp16\", # Export model with FP16 weights for smaller size and faster inference.\n",
     ")"
    ]
@@ -279,7 +280,7 @@
     "TensorRT is not part of LightlyTrain’s dependencies and must be installed separately. Installation depends on your OS, Python\n",
     "version, GPU, and NVIDIA driver/CUDA setup. See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for more details.\n",
     "\n",
-    "On CUDA 12.x systems you can often install the Python package via:"
+    "On CUDA 12.x systems, install the TensorRT version tested with this tutorial. Pinning the version prevents pip from installing TensorRT 11, which is not yet supported by LightlyTrain:"
    ]
   },
   {
@@ -289,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorrt-cu12"
+    "!pip install \"tensorrt-cu12==10.13.3.9\""
    ]
   },
   {
@@ -302,6 +303,7 @@
     "# Get the TensorRT engine.\n",
     "model.export_tensorrt(\n",
     "    out=\"model.trt\",\n",
+    "    onnx_args={\"verify\": False},  # TensorRT validates and builds the ONNX graph.\n",
     "    # precision=\"fp16\", # Export model with FP16 weights for smaller size and faster inference.\n",
     ")"
    ]

--- a/examples/notebooks/eomt_panoptic_segmentation.ipynb
+++ b/examples/notebooks/eomt_panoptic_segmentation.ipynb
@@ -47,127 +47,14 @@
    "id": "3",
    "metadata": {},
    "source": [
-    "## Prediction using LightlyTrain's model weights\n",
+    "## Train a panoptic segmentation model\n",
     "\n",
-    "### Download an example image\n",
-    "\n",
-    "Download an example image for inference with the following command:"
+    "Training your own panoptic segmentation model is straightforward with LightlyTrain."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000070254.jpg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5",
-   "metadata": {},
-   "source": [
-    "### Load the model weights\n",
-    "\n",
-    "Then load the model weights with LightlyTrain's `load_model` function:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lightly_train\n",
-    "\n",
-    "model = lightly_train.load_model(\"dinov3/vits16-eomt-panoptic-coco\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7",
-   "metadata": {},
-   "source": [
-    "### Predict the panoptic segmentation\n",
-    "\n",
-    "Run `model.predict` on the image. The method accepts file paths, URLs, PIL Images, or tensors as input."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "results = model.predict(\"image.jpg\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9",
-   "metadata": {},
-   "source": [
-    "### Visualize the results\n",
-    "\n",
-    "Visualize the image and predicted panoptic masks."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "10",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import torch\n",
-    "from torchvision.io import read_image\n",
-    "from torchvision.utils import draw_segmentation_masks\n",
-    "\n",
-    "image = read_image(\"image.jpg\")\n",
-    "masks = results[\"masks\"]\n",
-    "segment_ids = results[\"segment_ids\"]\n",
-    "\n",
-    "# Create boolean masks for each segment (including void/background if present).\n",
-    "# masks[..., 1] contains the segment_id for each pixel. Pixels with segment_id -1 are\n",
-    "# void/background.\n",
-    "masks_bool = torch.stack(\n",
-    "    [masks[..., 1] == -1] + [masks[..., 1] == segment_id for segment_id in segment_ids]\n",
-    ")\n",
-    "\n",
-    "# Create colors for each segment.\n",
-    "colors = [(0, 0, 0)] + [\n",
-    "    [int(color * 255) for color in plt.cm.tab20c(i / len(segment_ids))[:3]]\n",
-    "    for i in range(len(segment_ids))\n",
-    "]\n",
-    "\n",
-    "image_with_masks = draw_segmentation_masks(image, masks_bool, colors=colors, alpha=1.0)\n",
-    "plt.imshow(image_with_masks.permute(1, 2, 0))\n",
-    "plt.axis(\"off\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12",
-   "metadata": {},
-   "source": [
-    "The predicted `masks` tensor has shape `(height, width, 2)`, where the last dimension contains `(class_label, segment_id)` for each pixel."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13",
    "metadata": {},
    "source": [
     "### Prepare Data\n",
@@ -208,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "6",
    "metadata": {},
    "source": [
     "The dataset looks like this after the download completes:\n",
@@ -253,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Start Training\n",
@@ -264,10 +151,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import lightly_train\n",
+    "\n",
     "lightly_train.train_panoptic_segmentation(\n",
     "    out=\"out/my_experiment\",\n",
     "    model=\"dinov3/vits16-eomt-panoptic-coco\",\n",
@@ -290,18 +179,46 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "9",
    "metadata": {},
    "source": [
     "Once training completes, the final model checkpoint is saved in `out/my_experiment/exported_models/exported_last.pt`.\n",
-    "If you have a validation dataset, the best model according to the validation mask mAP is\n",
+    "The best model according to the validation panoptic quality is\n",
     "saved in `out/my_experiment/exported_models/exported_best.pt`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Predict with your own EoMT weights"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000070254.jpg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "### Load the model weights\n",
+    "\n",
+    "Load the best model exported during training with LightlyTrain's `load_model` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,23 +226,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Predict and visualize the panoptic segmentation\n",
+    "\n",
+    "Run prediction on the example image again, this time using the weights from your own training run, and visualize the panoptic masks:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "from torchvision.io import read_image\n",
+    "from torchvision.utils import draw_segmentation_masks\n",
+    "\n",
     "image = read_image(\"image.jpg\")\n",
     "results = model.predict(\"image.jpg\")\n",
     "\n",
-    "masks = torch.stack(\n",
+    "masks = results[\"masks\"]\n",
+    "segment_ids = results[\"segment_ids\"]\n",
+    "masks_bool = torch.stack(\n",
     "    [masks[..., 1] == -1] + [masks[..., 1] == segment_id for segment_id in segment_ids]\n",
     ")\n",
     "colors = [(0, 0, 0)] + [\n",
     "    [int(color * 255) for color in plt.cm.tab20c(i / len(segment_ids))[:3]]\n",
     "    for i in range(len(segment_ids))\n",
     "]\n",
-    "image_with_masks = draw_segmentation_masks(image, masks, colors=colors, alpha=1.0)\n",
+    "image_with_masks = draw_segmentation_masks(image, masks_bool, colors=colors, alpha=1.0)\n",
     "plt.imshow(image_with_masks.permute(1, 2, 0))\n",
     "plt.axis(\"off\")\n",
     "plt.show()"

--- a/examples/notebooks/eomt_panoptic_segmentation_export.ipynb
+++ b/examples/notebooks/eomt_panoptic_segmentation_export.ipynb
@@ -284,7 +284,7 @@
     "TensorRT is not part of LightlyTrain’s dependencies and must be installed separately. Installation depends on your OS, Python\n",
     "version, GPU, and NVIDIA driver/CUDA setup. See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for more details.\n",
     "\n",
-    "On CUDA 12.x systems you can often install the Python package via:"
+    "On CUDA 12.x systems, install the TensorRT version tested with this tutorial. Pinning the version prevents pip from installing TensorRT 11, which is not yet supported by LightlyTrain:"
    ]
   },
   {
@@ -294,7 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorrt-cu12"
+    "!pip install \"tensorrt-cu12==10.13.3.9\""
    ]
   },
   {

--- a/examples/notebooks/eomt_semantic_segmentation.ipynb
+++ b/examples/notebooks/eomt_semantic_segmentation.ipynb
@@ -54,31 +54,29 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## Prediction using LightlyTrain's model weights\n",
+    "## Train a semantic segmentation model\n",
     "\n",
-    "### Download an example image\n",
+    "Training your own semantic segmentation model is straightforward with LightlyTrain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "### Download and prepare a dataset\n",
     "\n",
-    "Download an example image for inference with the following command:"
+    "First download a small dataset in YOLO segmentation format. The following cells create a validation split and convert its polygon annotations into semantic masks."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -O cat.jpg https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6",
-   "metadata": {},
-   "source": [
-    "### Load the model weights to LightlyTrain\n",
-    "\n",
-    "Then, we load the model weights with LightlyTrain's `load_model` function and do inference on the example image with the `predict` method:"
+    "!wget -O coco128-seg.zip https://github.com/ultralytics/assets/releases/download/v0.0.0/coco128-seg.zip && unzip -q coco128-seg.zip"
    ]
   },
   {
@@ -88,9 +86,136 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import lightly_train\n",
+    "from pathlib import Path\n",
     "\n",
-    "model = lightly_train.load_model(\"dinov3/vits16-eomt-coco\")"
+    "from PIL import Image, ImageDraw\n",
+    "\n",
+    "dataset_dir = Path(\"coco128-seg\")\n",
+    "val_images_dir = dataset_dir / \"images/val2017\"\n",
+    "val_labels_dir = dataset_dir / \"labels/val2017\"\n",
+    "val_images_dir.mkdir(parents=True, exist_ok=True)\n",
+    "val_labels_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "if not any(val_images_dir.iterdir()):\n",
+    "    train_images_dir = dataset_dir / \"images/train2017\"\n",
+    "    train_labels_dir = dataset_dir / \"labels/train2017\"\n",
+    "    for image_path in sorted(train_images_dir.glob(\"*.jpg\"))[-16:]:\n",
+    "        image_path.rename(val_images_dir / image_path.name)\n",
+    "        label_path = train_labels_dir / image_path.with_suffix(\".txt\").name\n",
+    "        if label_path.exists():\n",
+    "            label_path.rename(val_labels_dir / label_path.name)\n",
+    "\n",
+    "coco_class_names = (\n",
+    "    \"person\",\n",
+    "    \"bicycle\",\n",
+    "    \"car\",\n",
+    "    \"motorcycle\",\n",
+    "    \"airplane\",\n",
+    "    \"bus\",\n",
+    "    \"train\",\n",
+    "    \"truck\",\n",
+    "    \"boat\",\n",
+    "    \"traffic light\",\n",
+    "    \"fire hydrant\",\n",
+    "    \"stop sign\",\n",
+    "    \"parking meter\",\n",
+    "    \"bench\",\n",
+    "    \"bird\",\n",
+    "    \"cat\",\n",
+    "    \"dog\",\n",
+    "    \"horse\",\n",
+    "    \"sheep\",\n",
+    "    \"cow\",\n",
+    "    \"elephant\",\n",
+    "    \"bear\",\n",
+    "    \"zebra\",\n",
+    "    \"giraffe\",\n",
+    "    \"backpack\",\n",
+    "    \"umbrella\",\n",
+    "    \"handbag\",\n",
+    "    \"tie\",\n",
+    "    \"suitcase\",\n",
+    "    \"frisbee\",\n",
+    "    \"skis\",\n",
+    "    \"snowboard\",\n",
+    "    \"sports ball\",\n",
+    "    \"kite\",\n",
+    "    \"baseball bat\",\n",
+    "    \"baseball glove\",\n",
+    "    \"skateboard\",\n",
+    "    \"surfboard\",\n",
+    "    \"tennis racket\",\n",
+    "    \"bottle\",\n",
+    "    \"wine glass\",\n",
+    "    \"cup\",\n",
+    "    \"fork\",\n",
+    "    \"knife\",\n",
+    "    \"spoon\",\n",
+    "    \"bowl\",\n",
+    "    \"banana\",\n",
+    "    \"apple\",\n",
+    "    \"sandwich\",\n",
+    "    \"orange\",\n",
+    "    \"broccoli\",\n",
+    "    \"carrot\",\n",
+    "    \"hot dog\",\n",
+    "    \"pizza\",\n",
+    "    \"donut\",\n",
+    "    \"cake\",\n",
+    "    \"chair\",\n",
+    "    \"couch\",\n",
+    "    \"potted plant\",\n",
+    "    \"bed\",\n",
+    "    \"dining table\",\n",
+    "    \"toilet\",\n",
+    "    \"tv\",\n",
+    "    \"laptop\",\n",
+    "    \"mouse\",\n",
+    "    \"remote\",\n",
+    "    \"keyboard\",\n",
+    "    \"cell phone\",\n",
+    "    \"microwave\",\n",
+    "    \"oven\",\n",
+    "    \"toaster\",\n",
+    "    \"sink\",\n",
+    "    \"refrigerator\",\n",
+    "    \"book\",\n",
+    "    \"clock\",\n",
+    "    \"vase\",\n",
+    "    \"scissors\",\n",
+    "    \"teddy bear\",\n",
+    "    \"hair drier\",\n",
+    "    \"toothbrush\",\n",
+    ")\n",
+    "class_ids = set()\n",
+    "\n",
+    "for split in (\"train2017\", \"val2017\"):\n",
+    "    images_dir = dataset_dir / \"images\" / split\n",
+    "    labels_dir = dataset_dir / \"labels\" / split\n",
+    "    masks_dir = dataset_dir / \"masks\" / split\n",
+    "    masks_dir.mkdir(parents=True, exist_ok=True)\n",
+    "    for image_path in images_dir.glob(\"*.jpg\"):\n",
+    "        with Image.open(image_path) as image:\n",
+    "            width, height = image.size\n",
+    "        mask = Image.new(\"L\", (width, height), 0)\n",
+    "        draw = ImageDraw.Draw(mask)\n",
+    "        label_path = labels_dir / image_path.with_suffix(\".txt\").name\n",
+    "        lines = label_path.read_text().splitlines() if label_path.exists() else ()\n",
+    "        for line in lines:\n",
+    "            values = [float(value) for value in line.split()]\n",
+    "            class_id = int(values[0])\n",
+    "            class_ids.add(class_id)\n",
+    "            polygon = [\n",
+    "                (int(x * width), int(y * height))\n",
+    "                for x, y in zip(values[1::2], values[2::2])\n",
+    "            ]\n",
+    "            draw.polygon(polygon, fill=class_id + 1)\n",
+    "        mask.save(masks_dir / image_path.with_suffix(\".png\").name)\n",
+    "\n",
+    "classes = {0: \"background\"}\n",
+    "classes.update(\n",
+    "    {class_id + 1: coco_class_names[class_id] for class_id in sorted(class_ids)}\n",
+    ")"
    ]
   },
   {
@@ -98,9 +223,9 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "### Predict the mask\n",
+    "### Start training\n",
     "\n",
-    "Simply call the `model`'s `.predict()` method to predict the mask"
+    "Start training with the `train_semantic_segmentation` function. You only have to specify the output directory, model, and input data; LightlyTrain configures the remaining training parameters and augmentations."
    ]
   },
   {
@@ -110,7 +235,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "masks = model.predict(\"cat.jpg\")"
+    "import lightly_train\n",
+    "\n",
+    "lightly_train.train_semantic_segmentation(\n",
+    "    out=\"out/my_experiment\",\n",
+    "    model=\"dinov3/vits16-eomt-coco\",\n",
+    "    steps=100,  # Small number of steps for demonstration, default is 90_000.\n",
+    "    batch_size=4,  # Small batch size for demonstration, default is 16.\n",
+    "    data={\n",
+    "        \"train\": {\n",
+    "            \"images\": \"coco128-seg/images/train2017\",\n",
+    "            \"masks\": \"coco128-seg/masks/train2017\",\n",
+    "        },\n",
+    "        \"val\": {\n",
+    "            \"images\": \"coco128-seg/images/val2017\",\n",
+    "            \"masks\": \"coco128-seg/masks/val2017\",\n",
+    "        },\n",
+    "        \"classes\": classes,\n",
+    "    },\n",
+    ")"
    ]
   },
   {
@@ -118,15 +261,61 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "## Visualize the image and mask\n",
-    "\n",
-    "Finally, we visualize the image and mask to see if it makes sense:"
+    "Once training completes, the final model checkpoint is saved in `out/my_experiment/exported_models/exported_last.pt`. The best model according to the validation mIoU is saved in `out/my_experiment/exported_models/exported_best.pt`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Predict with your own EoMT weights"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -O cat.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "### Load the model weights\n",
+    "\n",
+    "Load the best model exported during training with LightlyTrain's `load_model` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = lightly_train.load_model(\"out/my_experiment/exported_models/exported_best.pt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "### Predict and visualize the semantic mask\n",
+    "\n",
+    "Run prediction on the example image again, this time using the weights from your own training run, and visualize the semantic mask:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,19 +324,14 @@
     "from torchvision.io import read_image\n",
     "from torchvision.utils import draw_segmentation_masks\n",
     "\n",
+    "masks = model.predict(\"cat.jpg\")\n",
+    "\n",
     "image = read_image(\"cat.jpg\")\n",
     "masks = torch.stack([masks == class_id for class_id in masks.unique()])\n",
     "image_with_masks = draw_segmentation_masks(image, masks, alpha=0.6)\n",
     "plt.imshow(image_with_masks.permute(1, 2, 0))\n",
+    "plt.axis(\"off\")\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12",
-   "metadata": {},
-   "source": [
-    "Congrats! Using LightlyTrain's EoMT model weights for inference is as simple as the above example."
    ]
   }
  ],

--- a/examples/notebooks/eomt_semantic_segmentation_export.ipynb
+++ b/examples/notebooks/eomt_semantic_segmentation_export.ipynb
@@ -274,7 +274,7 @@
     "TensorRT is not part of LightlyTrain’s dependencies and must be installed separately. Installation depends on your OS, Python\n",
     "version, GPU, and NVIDIA driver/CUDA setup. See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for more details.\n",
     "\n",
-    "On CUDA 12.x systems you can often install the Python package via:"
+    "On CUDA 12.x systems, install the TensorRT version tested with this tutorial. Pinning the version prevents pip from installing TensorRT 11, which is not yet supported by LightlyTrain:"
    ]
   },
   {
@@ -284,7 +284,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorrt-cu12"
+    "!pip install \"tensorrt-cu12==10.13.3.9\""
    ]
   },
   {

--- a/examples/notebooks/object_detection.ipynb
+++ b/examples/notebooks/object_detection.ipynb
@@ -54,106 +54,6 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## Predict using LightlyTrain's LTDETR weights\n",
-    "\n",
-    "### Download an example image\n",
-    "\n",
-    "Download an example image for inference with the following command:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000577932.jpg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6",
-   "metadata": {},
-   "source": [
-    "### Load the model weights\n",
-    "\n",
-    "Then load the model with LightlyTrain's `load_model` function. This will automatically download the model weights and load the model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lightly_train\n",
-    "\n",
-    "model = lightly_train.load_model(\"ltdetrv2-s-coco\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8",
-   "metadata": {},
-   "source": [
-    "### Predict the objects\n",
-    "\n",
-    "Then run `model.predict` on the image. The method accepts file paths, URLs,\n",
-    "PIL Images, or tensors as input."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "results = model.predict(\"image.jpg\")\n",
-    "results[\"labels\"]  # Class labels, tensor of shape (num_boxes,)\n",
-    "results[\"bboxes\"]  # Bounding boxes in (xmin, ymin, xmax, ymax) absolute pixel\n",
-    "# coordinates of the original image. Tensor of shape (num_boxes, 4).\n",
-    "results[\"scores\"]  # Confidence scores, tensor of shape (num_boxes,)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10",
-   "metadata": {},
-   "source": [
-    "### Visualize the results\n",
-    "\n",
-    "Finally, we visualize the image and results to check what objects were detected."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "from torchvision.io import read_image\n",
-    "from torchvision.utils import draw_bounding_boxes\n",
-    "\n",
-    "image = read_image(\"image.jpg\")\n",
-    "image_with_boxes = draw_bounding_boxes(\n",
-    "    image,\n",
-    "    boxes=results[\"bboxes\"],\n",
-    "    labels=[model.classes[label.item()] for label in results[\"labels\"]],\n",
-    ")\n",
-    "plt.imshow(image_with_boxes.permute(1, 2, 0))\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12",
-   "metadata": {},
-   "source": [
     "## Train an LTDETR model\n",
     "\n",
     "Training your own LTDETR model is straightforward with LightlyTrain.\n",
@@ -166,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "6",
    "metadata": {},
    "source": [
     "The dataset looks like this after the download completes:\n",
@@ -208,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Start training\n",
@@ -219,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "9",
    "metadata": {},
    "source": [
     "Once the training is complete, the output directory looks like this:\n",
@@ -343,10 +243,32 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Predict with your own LTDETR weights\n",
+    "\n",
+    "### Download an example image\n",
+    "\n",
+    "Download an example image for inference with the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000577932.jpg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "Then load the model with LightlyTrain's `load_model` function. This will automatically download the model weights and load the model.\n",
     "\n",
     "### Load the model weights"
    ]
@@ -354,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,16 +285,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "14",
    "metadata": {},
    "source": [
-    "### Predict the objects"
+    "### Predict the objects\n",
+    "\n",
+    "Then run `model.predict` on the image. The method accepts file paths, URLs,\n",
+    "PIL Images, or tensors as input."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,19 +311,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "16",
    "metadata": {},
    "source": [
-    "### Visualize the results"
+    "### Visualize the results\n",
+    "\n",
+    "Finally, we visualize the image and results to check what objects were detected."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from torchvision.io import read_image\n",
+    "from torchvision.utils import draw_bounding_boxes\n",
+    "\n",
     "image = read_image(\"image.jpg\")\n",
     "image_with_boxes = draw_bounding_boxes(\n",
     "    image,\n",
@@ -411,7 +342,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Benchmark your checkpoint\n",
@@ -422,7 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +455,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "20",
    "metadata": {},
    "source": [
     "The command returns a `BenchmarkResult` instance and writes two files to the out directory:\n",
@@ -543,13 +474,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Next Steps\n",
     "\n",
-    "* [Object Detection Documentation](https://docs.lightly.ai/train/stable/object_detection.html): If you want to learn more about object detection with LightlyTrain."
+    "* [Object Detection Documentation](https://docs.lightly.ai/train/stable/object_detection.html): If you want to learn more about object detection with LightlyTrain.\n",
+    "* [Object Detection Model Export](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/object_detection.ipynb): If you want to learn more about export the model to ONNX and TensorRT format."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/notebooks/object_detection_export.ipynb
+++ b/examples/notebooks/object_detection_export.ipynb
@@ -271,7 +271,7 @@
     "version, GPU, and NVIDIA driver/CUDA setup.\n",
     "See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for more details.\n",
     "\n",
-    "On CUDA 12.x systems you can often install the Python package via:"
+    "On CUDA 12.x systems, install the TensorRT version tested with this tutorial. Pinning the version prevents pip from installing TensorRT 11, which is not yet supported by LightlyTrain:"
    ]
   },
   {
@@ -281,7 +281,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install tensorrt-cu12"
+    "!pip install \"tensorrt-cu12==10.13.3.9\""
    ]
   },
   {


### PR DESCRIPTION
## What has changed and why?

- Streamline the LTDETRv2 and EoMT training tutorials around a single train → best-checkpoint → predict workflow.
- Add complete training, validation, checkpoint reload, and prediction sections for EoMT instance, semantic, and panoptic segmentation.
- Add the small dataset preparation steps required for the EoMT notebooks to run end to end in Google Colab.
- Remove the duplicate pretrained-model prediction walkthroughs from the training tutorials.
- Pin the tested TensorRT 10.13.3.9 package in the export tutorials and avoid redundant ONNX verification in the EoMT instance-segmentation export path.

This keeps the tutorials focused on training a model and immediately using the exported checkpoint, while making the Colab workflows reproducible.

## How has it been tested?

- Ran all the notebooks end to end on a Google Colab T4.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
