### PR TITLE
Update Readme with Depth Estimation Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,12 +396,12 @@ Depth accuracy is evaluated zero-shot on the NYUv2 test split (654 images) with 
 eigen crop and a depth range of 0.1 m to 10 m. NYUv2 was not used during training.
 **Metric** models are scored directly against the ground-truth depth:
 
-| Model                          | Params (M) |  δ1   | AbsRel | RMSE  |
-| ------------------------------ | :--------: | :---: | :----: | :---: |
-| `dinov2/dav3-metric-large`     |   334.2M   | 0.950 | 0.078  | 0.339 |
-| `dinov2/dav3-metric-small`     |   24.7M    | 0.912 | 0.099  | 0.377 |
-| `dinov3/dav3-metric-tiny-plus` |    7.9M    | 0.846 | 0.123  | 0.457 |
-| `dinov3/dav3-metric-tiny`      |    6.2M    | 0.818 | 0.131  | 0.506 |
+| Model                                                   | Params (M) |  δ1   | AbsRel | RMSE  |
+| ------------------------------------------------------- | :--------: | :---: | :----: | :---: |
+| `dinov3/dav3-metric-tiny` (LightlyTrain-distilled)      |    6.2M    | 0.818 | 0.131  | 0.506 |
+| `dinov3/dav3-metric-tiny-plus` (LightlyTrain-distilled) |    7.9M    | 0.846 | 0.123  | 0.457 |
+| `dinov2/dav3-metric-small` (LightlyTrain-distilled)     |   24.7M    | 0.912 | 0.099  | 0.377 |
+| `dinov2/dav3-metric-large`                              |   334.2M   | 0.950 | 0.078  | 0.339 |
 
 #### Inference Speed
 

--- a/README.md
+++ b/README.md
@@ -385,8 +385,34 @@ if __name__ == "__main__":
 <details>
 <summary><strong>Depth Estimation</strong></summary>
 
-Run monocular depth inference with Depth Anything V2 and V3 models. Training support
-will be released soon!
+Run monocular depth inference with Depth Anything V2 and V3 models.
+
+The ViT-S, ViT-TinyPlus, and ViT-Tiny models were distilled from the ViT-L model by the
+LightlyTrain team.
+
+#### Metric Depth Results
+
+Depth accuracy is evaluated zero-shot on the NYUv2 test split (654 images) with the
+eigen crop and a depth range of 0.1 m to 10 m. NYUv2 was not used during training.
+**Metric** models are scored directly against the ground-truth depth:
+
+| Model                          | Params (M) |  δ1   | AbsRel | RMSE  |
+| ------------------------------ | :--------: | :---: | :----: | :---: |
+| `dinov2/dav3-metric-large`     |   334.2M   | 0.950 | 0.078  | 0.339 |
+| `dinov2/dav3-metric-small`     |   24.7M    | 0.912 | 0.099  | 0.377 |
+| `dinov3/dav3-metric-tiny-plus` |    7.9M    | 0.846 | 0.123  | 0.457 |
+| `dinov3/dav3-metric-tiny`      |    6.2M    | 0.818 | 0.131  | 0.506 |
+
+#### Inference Speed
+
+Inference time of the distilled relative models, measured with FP16 TensorRT engines on
+an NVIDIA T4 GPU:
+
+| Model                            | Input Size | Params (M) | Avg inference time |
+| -------------------------------- | :--------: | :--------: | :----------------: |
+| `dinov3/dav3-relative-tiny`      |  576×576   |    6.2M    |      5.27 ms       |
+| `dinov3/dav3-relative-tiny-plus` |  576×576   |    7.9M    |      5.49 ms       |
+| `dinov2/dav3-relative-small`     |  504×504   |   24.7M    |      9.17 ms       |
 
 #### Usage
 

--- a/docs/source/depth_estimation.md
+++ b/docs/source/depth_estimation.md
@@ -1,6 +1,6 @@
 (depth-estimation-doc)=
 
-# Depth Estimation (NEW)
+# Depth Estimation
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/depth_estimation.ipynb)
 
@@ -8,7 +8,6 @@
 LightlyTrain supports depth estimation inference with
 [Depth Anything V2](https://github.com/DepthAnything/Depth-Anything-V2) and
 [Depth Anything V3](https://github.com/ByteDance-Seed/Depth-Anything-3) models.
-Training support will be released soon!
 ```
 
 LightlyTrain ports the Depth Anything V2 (DAv2) and V3 (DAv3) monocular depth estimation

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -113,7 +113,7 @@ Train EoMT segmentation models with DINOv2 or DINOv3 backbones.<br>
 Train image classification models with any backbone.<br>
 ```
 
-```{grid-item-card} Depth Estimation (NEW)
+```{grid-item-card} Depth Estimation
 :link: depth_estimation.html
 <img src="_static/images/tasks/depth_estimation.png" height="64"><br>
 Run Depth Anything V2 and V3 monocular depth inference.<br>


### PR DESCRIPTION
## What has changed and why?

Documentation-only updates to the Depth Estimation content:

- **Removed the "(NEW)" tag** from the Depth Estimation page heading and the docs landing-page grid card, since the feature is no longer new.
- **Added benchmark tables to the README** Depth Estimation section, matching the layout used by the Semantic Segmentation section:
    - **Metric Depth Results** — zero-shot NYUv2 accuracy (δ1 / AbsRel / RMSE).
    - **Inference Speed** — FP16 TensorRT timings on an NVIDIA T4 GPU.
- Added a note clarifying that the ViT-S, ViT-TinyPlus, and ViT-Tiny models were distilled from the ViT-L model by the LightlyTrain team.

## How has it been tested?

No code changes, documentation only.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
