### PR TITLE
Training Script for ViT-S/Tiny/TinyPlus Depth Estimation Distillation from ViT-L

### DIFF
--- a/src/lightly_train/__init__.py
+++ b/src/lightly_train/__init__.py
@@ -41,6 +41,7 @@ from lightly_train._commands.export_task import export_onnx
 from lightly_train._commands.predict_task import predict_semantic_segmentation
 from lightly_train._commands.train import pretrain, train
 from lightly_train._commands.train_task import (
+    train_depth_estimation,
     train_image_classification,
     train_image_classification_multihead,
     train_instance_segmentation,
@@ -74,6 +75,7 @@ __all__ = [
     "ModelPart",
     "predict_semantic_segmentation",
     "pretrain",
+    "train_depth_estimation",
     "train_image_classification",
     "train_image_classification_multihead",
     "train_instance_segmentation",

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -37,6 +37,9 @@ from lightly_train._data import data_helpers as data_arg_helpers
 from lightly_train._data.coco_object_detection_dataset import (
     COCOObjectDetectionDataArgs,
 )
+from lightly_train._data.depth_estimation_dataset import (
+    DepthEstimationDataArgs,
+)
 from lightly_train._data.image_classification_dataset import (
     ImageClassificationMulticlassDataArgs,
     ImageClassificationMultilabelDataArgs,
@@ -74,6 +77,183 @@ from lightly_train._training_step_timer import CUDAUtilization, TrainingStepTime
 from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
+
+
+def train_depth_estimation(
+    *,
+    out: PathLike,
+    data: dict[str, Any] | str,
+    model: str,
+    steps: int | Literal["auto"] = "auto",
+    batch_size: int | Literal["auto"] = "auto",
+    num_workers: int | Literal["auto"] = "auto",
+    devices: int | str | list[int] = "auto",
+    num_nodes: int = 1,
+    resume_interrupted: bool = False,
+    checkpoint: PathLike | None = None,
+    overwrite: bool = False,
+    accelerator: str = "auto",
+    strategy: str = "auto",
+    precision: _PRECISION_INPUT = "bf16-mixed",
+    float32_matmul_precision: Literal["auto", "highest", "high", "medium"] = "auto",
+    seed: int = 0,
+    logger_args: dict[str, Any] | None = None,
+    model_args: dict[str, Any] | None = None,
+    transform_args: dict[str, Any] | None = None,
+    metric_args: dict[str, Any] | None = None,
+    loader_args: dict[str, Any] | None = None,
+    save_checkpoint_args: dict[str, Any] | None = None,
+    torch_compile_args: dict[str, Any] | None = None,
+    gradient_accumulation_steps: int | Literal["auto"] = "auto",
+) -> None:
+    """Train a depth estimation model.
+
+    Fine-tunes a Depth Anything V3 model by distilling depth and sky pseudo-labels
+    (e.g. generated with the V3 ViT-L teacher) into a smaller backbone. Both
+    relative-depth models (e.g. "dinov2/dav3-relative-small") and metric-depth models
+    (e.g. "dinov2/dav3-metric-small") are supported; a metric model is typically
+    fine-tuned from a trained relative checkpoint by passing it as ``model`` or
+    ``checkpoint`` (the architectures match, so the weights transfer cleanly).
+
+    The training process can be monitored with TensorBoard:
+
+    .. code-block:: bash
+
+        tensorboard --logdir out
+
+    After training, the last model checkpoint is saved in the out directory to:
+    ``out/checkpoints/last.ckpt`` and also exported to
+    ``out/exported_models/exported_last.pt``.
+
+    Args:
+        out:
+            The output directory where the model checkpoints and logs are saved.
+        data:
+            The dataset configuration or path to a YAML file with the configuration.
+            Each split points to a directory of RGB images and directories of depth and
+            sky pseudo-labels (``.npy`` files matched to each image by filename stem)::
+
+                data={
+                    "train": {"images": ".../train/images",
+                              "depth": ".../train/depth",
+                              "sky": ".../train/sky"},
+                    "val": {"images": ".../val/images",
+                            "depth": ".../val/depth",
+                            "sky": ".../val/sky"},
+                }
+
+            Depth pixels with value ``<= 0`` are treated as invalid and ignored by the
+            loss and metrics.
+
+            For metric-depth models the depth labels must be in the model's prediction
+            space, i.e. the Depth Anything V3 *canonical-camera* depth (the teacher's
+            output before the ``focal / 300`` conversion to meters). The conversion to
+            metric meters uses the camera intrinsics and is applied only at inference, so
+            no intrinsics are needed here. Storing metric meters instead of canonical
+            depth would be double-scaled at inference.
+        model:
+            The model to train. For example, "dinov2/dav3-relative-small",
+            "dinov3/dav3-relative-tiny", "dinov3/dav3-relative-tiny-plus",
+            "dinov2/dav3-metric-small" (metric depth), or a path to a local model
+            checkpoint.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter.
+        steps:
+            The number of training steps.
+        batch_size:
+            Global batch size. The batch size per device/GPU is inferred from this value
+            and the number of devices and nodes.
+        num_workers:
+            Number of workers for the dataloader per device/GPU. 'auto' automatically
+            sets the number of workers based on the available CPU cores.
+        devices:
+            Number of devices/GPUs for training. 'auto' automatically selects all
+            available devices. The device type is determined by the ``accelerator``
+            parameter.
+        num_nodes:
+            Number of nodes for distributed training.
+        checkpoint:
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint. The checkpoint must be a path to a checkpoint file, for example
+            "checkpoints/model.ckpt". This will only load the model weights from the
+            previous run. All other training state (e.g. optimizer state, epochs) from
+            the previous run are not loaded.
+
+            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter instead.
+        resume_interrupted:
+            Set this to True if you want to resume training from an **interrupted or
+            crashed** training run. This will pick up exactly where the training left
+            off, including the optimizer state and the current step.
+
+            - You must use the same ``out`` directory as the interrupted run.
+            - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
+            - This is intended for continuing the same run without modification.
+        overwrite:
+            Overwrite the output directory if it already exists. Warning, this might
+            overwrite existing files in the directory!
+        accelerator:
+            Hardware accelerator. Can be one of ['cpu', 'gpu', 'mps', 'auto'].
+            'auto' will automatically select the best accelerator available.
+        strategy:
+            Training strategy. For example 'ddp' or 'auto'. 'auto' automatically
+            selects the best strategy available.
+        precision:
+            Training precision. Select '16-mixed' for mixed 16-bit precision, '32-true'
+            for full 32-bit precision, or 'bf16-mixed' for mixed bfloat16 precision.
+        float32_matmul_precision:
+            Precision for float32 matrix multiplication. Can be one of ['auto',
+            'highest', 'high', 'medium']. See https://docs.pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision
+            for more information.
+        seed:
+            Random seed for reproducibility.
+        logger_args:
+            Logger arguments. Either None or a dictionary of logger names to either
+            None or a dictionary of logger arguments. None uses the default loggers.
+            To disable a logger, set it to None: ``logger_args={"tensorboard": None}``.
+        model_args:
+            Model training arguments. Either None or a dictionary of model arguments.
+        transform_args:
+            Transform arguments. Either None or a dictionary of transform arguments.
+            The image size and normalization parameters can be set with
+            ``transform_args={"image_size": (height, width), "normalize": {"mean": (r, g, b), "std": (r, g, b)}}``
+        metric_args:
+            Metric arguments. Either None or a dictionary of metric arguments.
+            Set ``metric_args={"train": True}`` to also compute depth metrics on the
+            training data. Set ``metric_args={"watch_metric": "val_metric/rmse"}`` to
+            configure the metric used to select the best checkpoint.
+        loader_args:
+            Arguments for the PyTorch DataLoader. Should only be used in special cases
+            as default values are automatically set. Prefer to use the `batch_size` and
+            `num_workers` arguments instead. For details, see:
+            https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader
+        save_checkpoint_args:
+            Arguments to configure the saving of checkpoints. The checkpoint frequency
+            can be set with ``save_checkpoint_args={"save_every_num_steps": 100}``.
+        torch_compile_args:
+            Arguments to configure model compilation with torch.compile. The arguments
+            are directly passed to torch.compile. Set
+            ``torch_compile_args={"disable": True}`` to disable it if you encounter any
+            issues.
+        gradient_accumulation_steps:
+            Number of gradient accumulation steps. 'auto' automatically enables
+            gradient accumulation when batch_size is smaller than the model's default
+            batch size, using ``max(1, default_batch_size // batch_size)`` steps to
+            keep the effective batch size and learning rate close to the model defaults.
+            Set to 1 to explicitly disable gradient accumulation.
+    """
+    tracker.track_training_started(
+        task_type="depth_estimation",
+        model=model,
+        method="depth_anything",
+        batch_size=batch_size,
+        devices=devices,
+        steps=steps,
+    )
+    return _train_task(config_cls=DepthEstimationTrainTaskConfig, **locals())
 
 
 def train_image_classification(
@@ -2016,6 +2196,7 @@ class TrainTaskConfig(PydanticConfig):
     data: TaskDataArgs
     model: str
     task: Literal[
+        "depth_estimation",
         "image_classification",
         "image_classification_multihead",
         "instance_segmentation",
@@ -2057,6 +2238,11 @@ class TrainTaskConfig(PydanticConfig):
         return data_helpers.load_data_yaml_if_path(
             v, cls.model_fields["data"].annotation
         )
+
+
+class DepthEstimationTrainTaskConfig(TrainTaskConfig):
+    data: DepthEstimationDataArgs
+    task: Literal["depth_estimation"] = "depth_estimation"
 
 
 class ImageClassificationMulticlassTrainTaskConfig(TrainTaskConfig):

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -49,6 +49,9 @@ from lightly_train._metrics.task_metric import (
 )
 from lightly_train._task_checkpoint import TaskSaveCheckpointArgs
 from lightly_train._task_models import task_model_helpers
+from lightly_train._task_models.depth_estimation.train_model import (
+    DepthEstimationTrain,
+)
 from lightly_train._task_models.dinov2_eomt_instance_segmentation.train_model import (
     DINOv2EoMTInstanceSegmentationTrain,
 )
@@ -119,6 +122,7 @@ logger = logging.getLogger(__name__)
 
 
 TASK_TRAIN_MODEL_CLASSES: list[type[TrainModel]] = [
+    DepthEstimationTrain,
     ImageClassificationTrain,
     ImageClassificationMultiheadTrain,
     DINOv2EoMTInstanceSegmentationTrain,
@@ -137,6 +141,11 @@ TASK_TRAIN_MODEL_CLASSES: list[type[TrainModel]] = [
 
 # TODO(Thomas, 10/25): Create a type for the metrics.
 TASK_TO_METRICS: dict[str, dict[str, str]] = {
+    "depth_estimation": {
+        "val_metric/rmse": "Val RMSE",
+        "val_metric/abs_rel": "Val AbsRel",
+        "val_metric/delta1": "Val delta<1.25",
+    },
     "instance_segmentation": {
         "val_metric/map": "Val mAP@0.5:0.95",
         "val_metric/map_50": "Val mAP@0.5",

--- a/src/lightly_train/_data/depth_estimation_dataset.py
+++ b/src/lightly_train/_data/depth_estimation_dataset.py
@@ -1,0 +1,191 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import ClassVar
+
+import numpy as np
+
+from lightly_train._configs.config import PydanticConfig
+from lightly_train._data import data_helpers, file_helpers
+from lightly_train._data.file_helpers import ImageMode
+from lightly_train._data.task_data_args import TaskDataArgs
+from lightly_train._data.task_dataset import TaskDataset, TaskDatasetArgs
+from lightly_train._transforms.depth_estimation_transform import (
+    DepthEstimationCollateFunction,
+    DepthEstimationTransform,
+)
+from lightly_train._transforms.task_transform import TaskCollateFunction
+from lightly_train.types import (
+    DepthEstimationDatasetItem,
+    NDArrayDepth,
+    PathLike,
+)
+
+
+class DepthEstimationDataset(TaskDataset):
+    # Narrow the type of dataset_args.
+    dataset_args: DepthEstimationDatasetArgs
+
+    batch_collate_fn_cls: ClassVar[type[TaskCollateFunction]] = (
+        DepthEstimationCollateFunction
+    )
+
+    def __init__(
+        self,
+        dataset_args: DepthEstimationDatasetArgs,
+        image_info: Sequence[dict[str, str]],
+        transform: DepthEstimationTransform | None = None,
+    ) -> None:
+        super().__init__(
+            transform=transform, dataset_args=dataset_args, image_info=image_info
+        )
+
+    def __getitem__(self, index: int) -> DepthEstimationDatasetItem:
+        row = self.image_info[index]
+        image_path = row["image_filepaths"]
+        depth_path = row["depth_filepaths"]
+        sky_path = row["sky_filepaths"]
+
+        image = file_helpers.open_image_numpy(
+            image_path=Path(image_path), mode=ImageMode.RGB
+        )
+        depth = _load_npy(Path(depth_path))
+        sky = _load_sky_png(Path(sky_path))
+
+        if image.shape[:2] != depth.shape[:2] or image.shape[:2] != sky.shape[:2]:
+            raise ValueError(
+                f"Shape mismatch for '{image_path}': image (height, width) is "
+                f"{image.shape[:2]}, depth is {depth.shape[:2]}, sky is "
+                f"{sky.shape[:2]}."
+            )
+
+        transformed = self.transform({"image": image, "depth": depth, "sky": sky})
+        return DepthEstimationDatasetItem(
+            image_path=str(image_path),  # Str for torch dataloader compatibility.
+            image=transformed["image"],
+            depth=transformed["depth"],
+            sky=transformed["sky"],
+        )
+
+
+class DepthEstimationDatasetArgs(TaskDatasetArgs):
+    image_dir: Path
+    depth_dir: Path
+    sky_dir: Path
+
+    def list_image_info(self) -> Iterable[dict[str, str]]:
+        for image_filename in file_helpers.list_image_filenames_from_dir(
+            image_dir=self.image_dir
+        ):
+            image_filepath = self.image_dir / image_filename
+            stem = Path(image_filename).stem
+            depth_filepath = (self.depth_dir / stem).with_suffix(".npy")
+            sky_filepath = (self.sky_dir / stem).with_suffix(".png")
+            if depth_filepath.exists() and sky_filepath.exists():
+                yield {
+                    "image_filepaths": str(image_filepath),
+                    "depth_filepaths": str(depth_filepath),
+                    "sky_filepaths": str(sky_filepath),
+                }
+
+    @staticmethod
+    def get_dataset_cls() -> type[DepthEstimationDataset]:
+        return DepthEstimationDataset
+
+
+class SplitArgs(PydanticConfig):
+    images: PathLike
+    depth: PathLike
+    sky: PathLike
+
+
+class DepthEstimationDataArgs(TaskDataArgs):
+    train: SplitArgs
+    val: SplitArgs
+
+    def resolve_data_paths(self, base_dir: Path) -> None:
+        self.train.images = data_helpers.resolve_path(
+            self.train.images, base_dir=base_dir
+        )
+        self.train.depth = data_helpers.resolve_path(
+            self.train.depth, base_dir=base_dir
+        )
+        self.train.sky = data_helpers.resolve_path(self.train.sky, base_dir=base_dir)
+        self.val.images = data_helpers.resolve_path(self.val.images, base_dir=base_dir)
+        self.val.depth = data_helpers.resolve_path(self.val.depth, base_dir=base_dir)
+        self.val.sky = data_helpers.resolve_path(self.val.sky, base_dir=base_dir)
+
+    @property
+    def included_classes(self) -> dict[int, str]:
+        # Depth estimation is a dense regression task and has no classes.
+        return {}
+
+    def train_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.train.images).resolve(),
+                Path(self.train.depth).resolve(),
+                Path(self.train.sky).resolve(),
+            )
+        )
+
+    def val_data_mmap_hash(self) -> str:
+        return str(
+            (
+                Path(self.val.images).resolve(),
+                Path(self.val.depth).resolve(),
+                Path(self.val.sky).resolve(),
+            )
+        )
+
+    def get_train_args(self) -> DepthEstimationDatasetArgs:
+        return DepthEstimationDatasetArgs(
+            image_dir=Path(self.train.images),
+            depth_dir=Path(self.train.depth),
+            sky_dir=Path(self.train.sky),
+        )
+
+    def get_val_args(self) -> DepthEstimationDatasetArgs:
+        return DepthEstimationDatasetArgs(
+            image_dir=Path(self.val.images),
+            depth_dir=Path(self.val.depth),
+            sky_dir=Path(self.val.sky),
+        )
+
+
+def _load_npy(path: Path) -> NDArrayDepth:
+    """Loads a (H, W) float depth pseudo-label from a ``.npy`` file."""
+    array = np.load(path)
+    if array.ndim != 2:
+        raise ValueError(
+            f"Expected a 2D (height, width) array in '{path}', got shape {array.shape}."
+        )
+    result: NDArrayDepth = array.astype(np.float32)
+    return result
+
+
+def _load_sky_png(path: Path) -> NDArrayDepth:
+    """Loads a (H, W) sky pseudo-label from an 8-bit grayscale ``.png`` mask.
+
+    The mask is stored as a single-channel ``{0, 255}`` image (white = sky) and is
+    scaled to a ``{0.0, 1.0}`` float probability map for the BCE sky-distillation loss.
+    """
+    array = file_helpers.open_image_numpy(image_path=path, mode=ImageMode.UNCHANGED)
+    # An 8-bit grayscale PNG decodes to (H, W) or (H, W, 1); drop a singleton channel.
+    if array.ndim == 3 and array.shape[-1] == 1:
+        array = array[..., 0]
+    if array.ndim != 2:
+        raise ValueError(
+            f"Expected a 2D (height, width) sky mask in '{path}', got shape "
+            f"{array.shape}."
+        )
+    result: NDArrayDepth = array.astype(np.float32) / 255.0
+    return result

--- a/src/lightly_train/_data/file_helpers.py
+++ b/src/lightly_train/_data/file_helpers.py
@@ -131,6 +131,7 @@ def _get_image_filenames(
         _supported_image_extensions() if image_extensions is None else image_extensions
     )
     for dirpath, _, filenames in os.walk(image_dir, followlinks=True):
+        filenames.sort()
         # Make paths relative to image_dir. `dirpath` is absolute.
         parent = os.path.relpath(dirpath, start=image_dir)
         parent = "" if parent == "." else parent

--- a/src/lightly_train/_metrics/depth_estimation/__init__.py
+++ b/src/lightly_train/_metrics/depth_estimation/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/src/lightly_train/_metrics/depth_estimation/task_metric.py
+++ b/src/lightly_train/_metrics/depth_estimation/task_metric.py
@@ -1,0 +1,314 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal
+
+import torch
+from torch import Tensor
+from torchmetrics import Metric as TorchmetricsMetric
+
+from lightly_train._metrics.loss_metric_collection import LossMetricCollection
+from lightly_train._metrics.task_metric import (
+    AggregatedMetricValues,
+    TaskMetric,
+    TaskMetricArgs,
+)
+
+# Small constant guarding divisions and the degenerate (near-constant prediction)
+# case of the scale-and-shift fit.
+_EPS = 1e-8
+
+# Standard relative-error depth metrics and whether they should be minimised or
+# maximised for best-model selection.
+_METRIC_MODES: dict[str, Literal["min", "max"]] = {
+    "abs_rel": "min",
+    "rmse": "min",
+    "delta1": "max",
+}
+
+
+class DepthEstimationTaskMetricArgs(TaskMetricArgs):
+    """Metrics configuration for depth estimation."""
+
+    watch_metric: str = "val_metric/abs_rel"
+    # Whether to also compute quality metrics (not just losses) on the train split.
+    train: bool = False
+
+
+class DepthEstimationTaskMetric(TaskMetric):
+    """Stores depth metrics and losses for one split.
+
+    Quality metrics are AbsRel, RMSE and ``delta1`` (the fraction of pixels with
+    ``max(pred/target, target/pred) < 1.25``), all computed over valid pixels
+    (``target > 0``) after a per-image least-squares scale-and-shift alignment of the
+    prediction to the target. The student predicts relative depth with an unconstrained
+    global scale and shift (the scale-invariant training loss deliberately does not pin
+    them down), so raw metrics would be dominated by that arbitrary scale rather than by
+    depth quality; aligning first is the standard MiDaS/DepthAnything relative-depth
+    evaluation protocol.
+    """
+
+    def __init__(
+        self,
+        *,
+        task_metric_args: DepthEstimationTaskMetricArgs,
+        split: str,
+        loss_names: Sequence[str],
+        train_loss_running_mean_window: int | None = None,
+        init_metrics: bool | None = None,
+        align: bool = True,
+    ) -> None:
+        """
+        Args:
+            task_metric_args: Metrics configuration.
+            split: Split name (e.g. "train", "val").
+            loss_names: Names of losses to track.
+            train_loss_running_mean_window:
+                Window size for the running mean of training losses. Required when
+                ``split == "train"``, ignored otherwise.
+            init_metrics:
+                Whether to initialize quality metrics. If None, uses
+                ``task_metric_args.train`` for the train split and True otherwise.
+            align:
+                Whether to align each prediction to its target by a least-squares
+                scale-and-shift fit before computing the quality metrics. True for
+                relative-depth models, whose global scale and shift are unconstrained;
+                False for metric-depth models, where the absolute scale is the quantity
+                being learned and aligning it away would hide metric accuracy.
+        """
+        super().__init__(task_metric_args=task_metric_args)
+        self.split = split
+        self.watch_metric = task_metric_args.watch_metric
+        self.watch_metric_mode = _get_watch_metric_mode(
+            watch_metric_name=task_metric_args.watch_metric,
+            loss_names=list(loss_names),
+        )
+
+        if init_metrics is None:
+            init_metrics = task_metric_args.train if split == "train" else True
+        self._init_metrics = init_metrics
+        # For metric-depth models the primary metrics are unaligned (align=False), but we
+        # also emit the scale-and-shift-aligned variants (``*_aligned``) as a diagnostic:
+        # the aligned metrics measure relative-depth structure independent of the global
+        # scale, so the gap between the two shows how much of the error is pure scale.
+        self.metrics = _DepthMetrics(
+            prefix=f"{split}_metric/", align=align, also_aligned=not align
+        )
+
+        self.loss_metrics = LossMetricCollection(
+            split=split,
+            loss_names=loss_names,
+            train_loss_running_mean_window=train_loss_running_mean_window,
+        )
+
+    def update_with_predictions(self, preds: Tensor, target: Tensor) -> None:
+        """Update quality metrics with a batch of predictions and targets.
+
+        Args:
+            preds: Predicted depth of shape ``(B, 1, H, W)``.
+            target: Target depth of shape ``(B, 1, H, W)``; pixels with ``target <= 0``
+                are treated as invalid and ignored.
+        """
+        if self._init_metrics:
+            self.metrics.update(preds, target)
+
+    def update_with_losses(self, loss_dict: Mapping[str, Tensor], weight: int) -> None:
+        """Accumulate loss values (see ``LossMetricCollection``)."""
+        self.loss_metrics.update(loss_dict, weight=weight)
+
+    def compute_aggregated_values(self) -> AggregatedMetricValues:
+        result = self.loss_metrics.compute()
+        if self._init_metrics:
+            result.update(
+                {name: float(value) for name, value in self.metrics.compute().items()}
+            )
+        best_val = result.get(self.watch_metric)
+        return AggregatedMetricValues(
+            metric_values=result,
+            watch_metric=self.watch_metric if best_val is not None else None,
+            watch_metric_value=float(best_val) if best_val is not None else None,
+            watch_metric_mode=self.watch_metric_mode if best_val is not None else None,
+            best_head_name=None,
+            best_head_metric_values=None,
+        )
+
+
+class _DepthMetrics(TorchmetricsMetric):
+    """Accumulates AbsRel, RMSE and ``delta1`` over valid pixels across batches.
+
+    For relative-depth models (``align=True``) each prediction is aligned to its target
+    by a per-image least-squares scale-and-shift fit before the metrics are computed
+    (see ``align_scale_shift``), so the metrics measure relative-depth quality
+    independent of the arbitrary global scale/shift the scale-invariant training loss
+    leaves free. For metric-depth models (``align=False``) the raw prediction is compared
+    to the target, so the metrics reflect true metric accuracy.
+
+    When ``also_aligned`` is set the aligned variants are accumulated in the same pass and
+    emitted under ``*_aligned`` keys alongside the primary metrics. This is used by
+    metric-depth models to expose the scale-invariant structure quality as a diagnostic
+    next to the primary (unaligned) metrics: the gap between the two is the residual
+    global-scale error.
+    """
+
+    abs_rel_sum: Tensor
+    se_sum: Tensor
+    delta1_sum: Tensor
+    count: Tensor
+    abs_rel_aligned_sum: Tensor
+    se_aligned_sum: Tensor
+    delta1_aligned_sum: Tensor
+
+    def __init__(
+        self, prefix: str, align: bool = True, also_aligned: bool = False
+    ) -> None:
+        super().__init__()
+        self.prefix = prefix
+        self.align = align
+        self.also_aligned = also_aligned
+        self.add_state("abs_rel_sum", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("se_sum", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("delta1_sum", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("count", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        # Separate accumulators for the aligned diagnostic variant. Only updated (and only
+        # emitted) when ``also_aligned`` is set; they share the same ``count``.
+        self.add_state(
+            "abs_rel_aligned_sum", default=torch.tensor(0.0), dist_reduce_fx="sum"
+        )
+        self.add_state(
+            "se_aligned_sum", default=torch.tensor(0.0), dist_reduce_fx="sum"
+        )
+        self.add_state(
+            "delta1_aligned_sum", default=torch.tensor(0.0), dist_reduce_fx="sum"
+        )
+
+    def update(self, preds: Tensor, target: Tensor) -> None:
+        # Align each image independently: a batch-wide fit would let one image's scale
+        # contaminate another. Errors are summed and divided by the pixel count at
+        # ``compute`` time so the epoch aggregate is a proper pixel-weighted mean.
+        for pred_img, target_img in zip(preds.float(), target.float()):
+            valid = (
+                (target_img > 0) & torch.isfinite(pred_img) & torch.isfinite(target_img)
+            )
+            if not bool(valid.any()):
+                continue
+            pred_raw = pred_img[valid]
+            gt = target_img[valid]
+            pred = (
+                align_scale_shift(pred=pred_raw, target=gt) if self.align else pred_raw
+            )
+            # The ratio-based metrics need positive predictions: the aligned prediction
+            # can be non-positive where the fit extrapolates below zero, so clamp. This
+            # is a no-op for the (already positive) unaligned metric-depth prediction.
+            pred = pred.clamp_min(_EPS)
+
+            self.abs_rel_sum += torch.sum(torch.abs(pred - gt) / gt)
+            self.se_sum += torch.sum((pred - gt) ** 2)
+            ratio = torch.maximum(pred / gt, gt / pred)
+            self.delta1_sum += torch.sum((ratio < 1.25).float())
+            self.count += gt.numel()
+
+            if self.also_aligned:
+                # Primary is unaligned here (``also_aligned`` is only set when
+                # ``align=False``), so compute the aligned fit for the diagnostic.
+                pred_al = align_scale_shift(pred=pred_raw, target=gt).clamp_min(_EPS)
+                self.abs_rel_aligned_sum += torch.sum(torch.abs(pred_al - gt) / gt)
+                self.se_aligned_sum += torch.sum((pred_al - gt) ** 2)
+                ratio_al = torch.maximum(pred_al / gt, gt / pred_al)
+                self.delta1_aligned_sum += torch.sum((ratio_al < 1.25).float())
+
+    def compute(self) -> dict[str, Tensor]:
+        if bool(self.count == 0):
+            zero = torch.tensor(0.0)
+            result = {
+                f"{self.prefix}abs_rel": zero,
+                f"{self.prefix}rmse": zero,
+                f"{self.prefix}delta1": zero,
+            }
+            if self.also_aligned:
+                result.update(
+                    {
+                        f"{self.prefix}abs_rel_aligned": zero,
+                        f"{self.prefix}rmse_aligned": zero,
+                        f"{self.prefix}delta1_aligned": zero,
+                    }
+                )
+            return result
+        result = {
+            f"{self.prefix}abs_rel": self.abs_rel_sum / self.count,
+            f"{self.prefix}rmse": torch.sqrt(self.se_sum / self.count),
+            f"{self.prefix}delta1": self.delta1_sum / self.count,
+        }
+        if self.also_aligned:
+            result.update(
+                {
+                    f"{self.prefix}abs_rel_aligned": self.abs_rel_aligned_sum
+                    / self.count,
+                    f"{self.prefix}rmse_aligned": torch.sqrt(
+                        self.se_aligned_sum / self.count
+                    ),
+                    f"{self.prefix}delta1_aligned": self.delta1_aligned_sum
+                    / self.count,
+                }
+            )
+        return result
+
+
+def align_scale_shift(*, pred: Tensor, target: Tensor) -> Tensor:
+    """Returns ``pred`` aligned to ``target`` by a least-squares scale and shift.
+
+    Solves ``min_{s, t} sum_i (s * pred_i + t - target_i)^2`` in closed form and returns
+    ``s * pred + t``. This is the standard MiDaS/DepthAnything relative-depth evaluation
+    alignment: the student's depth has an arbitrary global scale and shift (the
+    scale-invariant loss does not constrain them), so the prediction must be aligned to
+    the target before an error metric is meaningful.
+
+    Args:
+        pred: Predicted depth over valid pixels, shape ``(N,)``.
+        target: Target depth over the same valid pixels, shape ``(N,)``.
+
+    Returns:
+        The aligned prediction, shape ``(N,)``. If the prediction is (near-)constant the
+        fit is degenerate; the prediction is then shifted to match the target mean.
+    """
+    n = pred.numel()
+    mean_pred = pred.mean()
+    mean_target = target.mean()
+    pred_centered = pred - mean_pred
+    var_pred = torch.sum(pred_centered * pred_centered) / n
+    if bool(var_pred < _EPS):
+        return pred - mean_pred + mean_target
+    cov = torch.sum(pred_centered * (target - mean_target)) / n
+    scale = cov / var_pred
+    shift = mean_target - scale * mean_pred
+    return scale * pred + shift
+
+
+def _get_watch_metric_mode(
+    watch_metric_name: str, loss_names: Sequence[str]
+) -> Literal["min", "max"]:
+    """Returns whether ``watch_metric_name`` should be minimised or maximised.
+
+    Matches the metric suffix (after ``/``) against the known depth metric names, then
+    falls back to loss names (always minimised).
+    """
+    parts = watch_metric_name.split("/")
+    if len(parts) > 1:
+        suffix = parts[1]
+        for metric_name, mode in _METRIC_MODES.items():
+            if suffix.startswith(metric_name):
+                return mode
+    for loss_name in loss_names:
+        if loss_name in watch_metric_name:
+            return "min"
+    raise ValueError(
+        f"watch_metric_name {watch_metric_name!r} not found in metric names "
+        f"{sorted(_METRIC_MODES)} or loss names {list(loss_names)}."
+    )

--- a/src/lightly_train/_task_models/depth_estimation/criterion.py
+++ b/src/lightly_train/_task_models/depth_estimation/criterion.py
@@ -1,0 +1,297 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+"""Distillation losses for the DepthAnything V3 student.
+
+This module implements an intentional *subset* of the DepthAnything V3 training
+objective (arXiv:2511.10647, Eq. 7: ``L_T = α·L_grad + L_gl + L_N + L_sky + L_obj``)
+tailored to distilling a ViT-L teacher into a ViT-S student. The mapping is:
+
+- ``SILogLoss`` is the depth term. The paper uses the MoGe global–local loss ``L_gl``
+  here; for distilling a single clean teacher a scale-invariant log loss is the standard
+  and well-behaved choice, so we substitute it.
+- ``GradientMatchingLoss`` is the paper's ``L_grad`` (combined with weight ``α = 0.5``).
+- ``SkyDistillLoss`` is the paper's ``L_sky``. The paper supervises the sky mask with
+  MSE; we use BCE on the sigmoid sky head because the target is a probability map.
+
+The paper's ``L_N`` (distance-weighted surface-normal loss) and ``L_obj`` (object-mask
+loss) are intentionally omitted: ``L_N`` requires camera intrinsics and ``L_obj``
+requires object-mask labels, neither of which is available in the distillation
+pseudo-labels (only depth and sky maps are stored on disk).
+
+In addition to these output-space terms, ``FeatureAlignmentLoss`` distills the teacher's
+intermediate backbone features (the four patch-token tensors fed to the DPT head) into
+the student. This is a feature-space term that requires an online teacher and is
+therefore not derivable from the on-disk pseudo-labels.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Linear, Module, ModuleList
+
+
+class SILogLoss(Module):
+    """Scale-invariant log loss (Eigen et al., as used by MiDaS/DepthAnything).
+
+    Operates on valid pixels only and is invariant to a global scale of the prediction,
+    which makes it well suited for relative-depth distillation where the teacher and
+    student may differ by a global factor.
+    """
+
+    def __init__(self, lambd: float = 0.5, eps: float = 1e-6) -> None:
+        """
+        Args:
+            lambd: Weight of the (squared) mean term that removes the global scale.
+                ``lambd=0`` reduces to the log-space MSE; ``lambd=1`` is fully
+                scale-invariant.
+            eps: Small constant added before the logarithm for numerical stability.
+        """
+        super().__init__()
+        self.lambd = lambd
+        self.eps = eps
+
+    def forward(self, pred: Tensor, target: Tensor, mask: Tensor) -> Tensor:
+        """
+        Args:
+            pred: Predicted depth of shape ``(B, 1, H, W)``, strictly positive.
+            target: Target depth of shape ``(B, 1, H, W)``.
+            mask: Boolean validity mask of shape ``(B, 1, H, W)``; loss is computed over
+                ``True`` pixels only.
+
+        Returns:
+            Scalar loss. If no pixel is valid, returns a graph-connected zero so the
+            backward pass stays well-defined.
+        """
+        valid = mask & torch.isfinite(target) & torch.isfinite(pred)
+        if not bool(valid.any()):
+            return pred.sum() * 0.0
+
+        diff = torch.log(pred[valid] + self.eps) - torch.log(target[valid] + self.eps)
+        loss = torch.mean(diff**2) - self.lambd * (torch.mean(diff) ** 2)
+        # The scale-invariant term can produce a tiny negative value from floating point
+        # error when the prediction matches the target exactly; clamp before the sqrt.
+        return torch.sqrt(loss.clamp_min(0.0) + self.eps)
+
+
+class GradientMatchingLoss(Module):
+    """Multi-scale gradient-matching loss (MiDaS/DepthAnything).
+
+    For each scale, the absolute spatial gradients of the log-depth difference are
+    averaged over pixels where both neighbours are valid, then the difference and mask
+    are downsampled and the process repeats. This sharpens depth discontinuities and
+    discourages over-smooth predictions when distilling a higher-capacity teacher.
+    """
+
+    def __init__(self, scales: int = 4, eps: float = 1e-6) -> None:
+        """
+        Args:
+            scales: Number of (halving) scales over which the gradients are matched.
+            eps: Small constant added before the logarithm for numerical stability.
+        """
+        super().__init__()
+        self.scales = scales
+        self.eps = eps
+
+    def forward(self, pred: Tensor, target: Tensor, mask: Tensor) -> Tensor:
+        """
+        Args:
+            pred: Predicted depth of shape ``(B, 1, H, W)``, strictly positive.
+            target: Target depth of shape ``(B, 1, H, W)``.
+            mask: Boolean validity mask of shape ``(B, 1, H, W)``.
+
+        Returns:
+            Scalar loss summed over all scales. Returns a graph-connected zero if no
+            scale contributes any valid gradient.
+        """
+        valid = mask & torch.isfinite(target) & torch.isfinite(pred)
+        diff = torch.log(pred + self.eps) - torch.log(target + self.eps)
+        # Zero out invalid pixels so they do not leak into the finite differences; the
+        # per-edge validity mask below ensures they are not counted either.
+        diff = torch.where(valid, diff, torch.zeros_like(diff))
+        mask_f = valid.to(diff.dtype)
+
+        total = pred.sum() * 0.0
+        for _ in range(self.scales):
+            if diff.shape[-1] < 2 or diff.shape[-2] < 2:
+                break
+            total = total + _gradient_term(diff=diff, mask=mask_f)
+            # Average-pool to the next coarser scale.
+            diff = F.avg_pool2d(diff, kernel_size=2)
+            mask_f = F.avg_pool2d(mask_f, kernel_size=2)
+        return total
+
+
+class SkyDistillLoss(Module):
+    """Binary cross-entropy between the student and teacher sky confidence maps.
+
+    Both inputs are expected to be probabilities in ``[0, 1]`` (the trainable depth
+    configs use a sigmoid sky head); the teacher map is used as a soft BCE target.
+    """
+
+    def __init__(self, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, pred_sky: Tensor, target_sky: Tensor) -> Tensor:
+        """
+        Args:
+            pred_sky: Student sky confidence of shape ``(B, 1, H, W)`` in ``[0, 1]``.
+            target_sky: Teacher sky confidence of shape ``(B, 1, H, W)`` in ``[0, 1]``.
+
+        Returns:
+            Scalar BCE loss.
+        """
+        with torch.autocast(device_type=pred_sky.device.type, enabled=False):
+            pred = pred_sky.float().clamp(self.eps, 1.0 - self.eps)
+            target = target_sky.float().clamp(0.0, 1.0)
+            return F.binary_cross_entropy(pred, target)
+
+
+class RelativeL1Loss(Module):
+    """Scale-aware relative-L1 (AbsRel) loss on valid pixels.
+
+    Computes the mean of ``|pred - target| / target`` over valid pixels. Unlike the
+    scale-invariant ``SILogLoss`` (``lambd > 0``) and the neighbour-difference-only
+    ``GradientMatchingLoss``, this term's gradient with respect to a global scale error
+    does not vanish, so it directly pins the absolute scale of a metric-depth student to
+    the teacher. It is the training-time counterpart of the unaligned AbsRel validation
+    metric. Intended only for metric-depth distillation, where the student's output and
+    the teacher target live in the same (canonical-camera) depth space.
+    """
+
+    def __init__(self, eps: float = 1e-6) -> None:
+        """
+        Args:
+            eps: Small constant added to the target denominator for numerical stability.
+        """
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, pred: Tensor, target: Tensor, mask: Tensor) -> Tensor:
+        """
+        Args:
+            pred: Predicted depth of shape ``(B, 1, H, W)``, strictly positive.
+            target: Target depth of shape ``(B, 1, H, W)``.
+            mask: Boolean validity mask of shape ``(B, 1, H, W)``; loss is computed over
+                ``True`` pixels only.
+
+        Returns:
+            Scalar loss. If no pixel is valid, returns a graph-connected zero so the
+            backward pass stays well-defined.
+        """
+        valid = mask & torch.isfinite(target) & torch.isfinite(pred)
+        if not bool(valid.any()):
+            return pred.sum() * 0.0
+
+        return torch.mean(
+            torch.abs(pred[valid] - target[valid]) / (target[valid] + self.eps)
+        )
+
+
+class FeatureAlignmentLoss(Module):
+    """Feature-space distillation of the teacher's DPT-input patch tokens.
+
+    The student and teacher backbones expose the same number of intermediate patch-token
+    tensors that are fed to their DPT heads. They share the patch size and processing
+    resolution (e.g. a ViT-L teacher and a ViT-S student both at 14px/504px), so the
+    token grids match and features align token-for-token. Only the backbone widths differ
+    (e.g. a ``teacher_dim``-wide ViT-L teacher and a ``student_dim``-wide ViT-S student),
+    so each student tensor is projected to the teacher width by a learnable per-stage
+    ``Linear`` before matching.
+
+    The loss is the mean cosine distance ``1 - cos(student, teacher)`` per token, so the
+    student is pulled towards the *direction* of the teacher features and is not required
+    to reproduce their absolute magnitude. Cosine distance is width-independent and lies
+    in ``[0, 2]`` (``~1.0`` for uncorrelated features), so it stays on the same scale as
+    the other depth losses regardless of the teacher width, keeping
+    ``feature_align_weight`` interpretable. The projections are training-only and are
+    discarded when the student is exported for inference.
+    """
+
+    def __init__(
+        self,
+        *,
+        student_dim: int,
+        teacher_dim: int,
+        num_stages: int = 4,
+        eps: float = 1e-6,
+    ) -> None:
+        """
+        Args:
+            student_dim: Channel dimension of the student patch tokens.
+            teacher_dim: Channel dimension of the teacher patch tokens.
+            num_stages: Number of intermediate feature tensors to align (one projection
+                per stage).
+            eps: Small constant added to the norm for numerical stability.
+        """
+        super().__init__()
+        self.eps = eps
+        self.projections = ModuleList(
+            [Linear(student_dim, teacher_dim) for _ in range(num_stages)]
+        )
+
+    def forward(
+        self,
+        student_feats: Sequence[Tensor],
+        teacher_feats: Sequence[Tensor],
+    ) -> Tensor:
+        """
+        Args:
+            student_feats: The student's intermediate patch-token tensors, each of shape
+                ``(B, N, student_dim)``.
+            teacher_feats: The teacher's intermediate patch-token tensors, each of shape
+                ``(B, N, teacher_dim)``, detached from the graph by the caller. The token
+                count ``N`` matches the student's (shared patch size and resolution).
+
+        Returns:
+            Scalar loss averaged over the aligned stages.
+        """
+        if len(student_feats) != len(self.projections):
+            raise ValueError(
+                f"Expected {len(self.projections)} student feature tensors, got "
+                f"{len(student_feats)}."
+            )
+        if len(teacher_feats) != len(self.projections):
+            raise ValueError(
+                f"Expected {len(self.projections)} teacher feature tensors, got "
+                f"{len(teacher_feats)}."
+            )
+
+        total = student_feats[0].sum() * 0.0
+        for projection, student, teacher in zip(
+            self.projections, student_feats, teacher_feats
+        ):
+            # Project the student tokens to the teacher width; the token grids already
+            # match, so the features align token-for-token. Mean cosine distance per
+            # token keeps the loss in [0, 2] and independent of the teacher width.
+            projected = projection(student)
+            cos = F.cosine_similarity(projected, teacher, dim=-1, eps=self.eps)
+            total = total + (1.0 - cos).mean()
+        return total / len(self.projections)
+
+
+def _gradient_term(diff: Tensor, mask: Tensor) -> Tensor:
+    """Returns the mean absolute horizontal and vertical gradient of ``diff``.
+
+    Gradients are only counted across edges where both neighbouring pixels are fully
+    valid (``mask == 1`` on both sides).
+    """
+    grad_x = torch.abs(diff[..., :, 1:] - diff[..., :, :-1])
+    mask_x = mask[..., :, 1:] * mask[..., :, :-1]
+    grad_y = torch.abs(diff[..., 1:, :] - diff[..., :-1, :])
+    mask_y = mask[..., 1:, :] * mask[..., :-1, :]
+
+    num = (grad_x * mask_x).sum() + (grad_y * mask_y).sum()
+    den = mask_x.sum() + mask_y.sum()
+    if bool(den == 0):
+        return diff.sum() * 0.0
+    return num / den

--- a/src/lightly_train/_task_models/depth_estimation/task_model.py
+++ b/src/lightly_train/_task_models/depth_estimation/task_model.py
@@ -368,6 +368,55 @@ _MODEL_CONFIGS: dict[str, dict[str, Any]] = {
             "use_sky_head": True,
         },
     },
+    # Test-only V3 config: the real ViT-S backbone with a tiny DPT head and a small
+    # processing resolution to keep depth fine-tuning tests fast on CPU. (The 2-block
+    # `_vittest14` backbone cannot feed the DPT, which needs four distinct intermediate
+    # layers.)
+    "dinov2/_vittest14-dav3": {
+        "canonical_name": "dinov2/_vittest14-dav3",
+        "backbone_package": "dinov2",
+        "backbone_name": "vits14-noreg",
+        "image_size": 70,
+        "activation": "exp",
+        "use_sky_head": True,
+        "sky_activation": "sigmoid",
+        "align_corners": False,
+        "scale_mode": "none",
+        "model_args": {
+            "out_layers": (2, 5, 8, 11),
+            # Backbone img_size matches the DINOv2 checkpoint (pos_embed is interpolated
+            # to the actual processing resolution at forward time).
+            "image_size": 518,
+            "patch_size": 14,
+            "features": 16,
+            "out_channels": (8, 16, 32, 32),
+            "output_dim": 1,
+            "use_sky_head": True,
+        },
+    },
+    # Test-only metric counterpart of `_vittest14-dav3`: identical tiny DPT head and
+    # small processing resolution, but `scale_mode="focal"` so metric fine-tuning (the
+    # scale-aware loss and unaligned metrics) can be exercised fast on CPU.
+    "dinov2/_vittest14-dav3-metric": {
+        "canonical_name": "dinov2/_vittest14-dav3-metric",
+        "backbone_package": "dinov2",
+        "backbone_name": "vits14-noreg",
+        "image_size": 70,
+        "activation": "exp",
+        "use_sky_head": True,
+        "sky_activation": "sigmoid",
+        "align_corners": False,
+        "scale_mode": "focal",
+        "model_args": {
+            "out_layers": (2, 5, 8, 11),
+            "image_size": 518,
+            "patch_size": 14,
+            "features": 16,
+            "out_channels": (8, 16, 32, 32),
+            "output_dim": 1,
+            "use_sky_head": True,
+        },
+    },
 }
 
 
@@ -484,11 +533,26 @@ class DepthAnythingDepthEstimation(TaskModel):
             raise ValueError(f"Unknown backbone package '{backbone_package}'.")
         if backbone_args is not None:
             backbone_model_args.update(backbone_args)
-        self.backbone = backbone_package_obj.get_model(
+        # Stored so fine-tuning can re-fetch the same backbone (with the same
+        # construction args) and load pretrained weights into it separately (see
+        # `_load_pretrained_backbone` in `train_model.py`).
+        self.backbone_package = backbone_package_obj
+        self.backbone_name: str = config["backbone_name"]
+        self.backbone_model_args: dict[str, Any] = backbone_model_args
+        self.backbone = self.backbone_package.get_model(
             model_name=config["backbone_name"],
             model_args=backbone_model_args,
             load_weights=False,
         )
+        try:
+            mask_token = self.backbone.mask_token  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+        else:
+            # Depth estimation does not use the mask token. We disable grads for it to
+            # avoid DDP errors from unused parameters during fine-tuning (see
+            # image_classification's task_model.py for the same pattern).
+            mask_token.requires_grad = False
         self.decoder = DPT(
             dim_in=int(self.backbone.embed_dim),
             patch_size=patch_size,
@@ -723,6 +787,20 @@ class DepthAnythingDepthEstimation(TaskModel):
         return out
 
     def load_train_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Loads weights from a training-export or converted checkpoint.
+
+        Training exports the full ``DepthEstimationTrain`` module, so the task-model
+        weights are nested under a ``model.`` prefix alongside criterion and metric
+        buffers; converted checkpoints store the bare task-model keys. When any
+        ``model.``-prefixed key is present, the prefix is stripped and all other keys
+        (criterion, metrics) are dropped; otherwise the state dict is loaded as-is.
+        """
+        if any(name.startswith("model.") for name in state_dict):
+            state_dict = {
+                name[len("model.") :]: param
+                for name, param in state_dict.items()
+                if name.startswith("model.")
+            }
         self.load_state_dict(state_dict, strict=True)
 
     @torch.no_grad()
@@ -1003,6 +1081,32 @@ class DepthAnythingDepthEstimation(TaskModel):
                 )
         elif intrinsics is not None:
             raise ValueError("This model does not accept intrinsics.")
+
+
+def get_model_image_size(model_name: str) -> int:
+    """Returns the fixed processing image size for a depth model.
+
+    Used to resolve the training transform image size from the model name without
+    instantiating the model.
+    """
+    key = model_name.lower()
+    if key not in _MODEL_CONFIGS:
+        raise ValueError(
+            f"Model name '{model_name}' is not supported. Available models are: "
+            f"{DepthAnythingDepthEstimation.list_model_names()}."
+        )
+    return int(_MODEL_CONFIGS[key]["image_size"])
+
+
+def get_model_patch_size(model_name: str) -> int:
+    """Returns the ViT patch size for a depth model."""
+    key = model_name.lower()
+    if key not in _MODEL_CONFIGS:
+        raise ValueError(
+            f"Model name '{model_name}' is not supported. Available models are: "
+            f"{DepthAnythingDepthEstimation.list_model_names()}."
+        )
+    return int(_MODEL_CONFIGS[key]["model_args"]["patch_size"])
 
 
 def _processed_focal_length(

--- a/src/lightly_train/_task_models/depth_estimation/train_model.py
+++ b/src/lightly_train/_task_models/depth_estimation/train_model.py
@@ -1,0 +1,579 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import math
+from typing import Any, ClassVar, Literal, cast
+
+import torch
+from lightly.utils.scheduler import CosineWarmupScheduler
+from lightning_fabric import Fabric
+from torch import Tensor
+from torch.optim.adamw import AdamW
+from torch.optim.lr_scheduler import LRScheduler
+from torch.optim.optimizer import Optimizer
+
+from lightly_train._configs.validate import no_auto
+from lightly_train._data.depth_estimation_dataset import DepthEstimationDataArgs
+from lightly_train._data.task_data_args import TaskDataArgs
+from lightly_train._metrics.depth_estimation.task_metric import (
+    DepthEstimationTaskMetric,
+    DepthEstimationTaskMetricArgs,
+)
+from lightly_train._optim import optimizer_helpers
+from lightly_train._task_models.depth_estimation.criterion import (
+    FeatureAlignmentLoss,
+    GradientMatchingLoss,
+    RelativeL1Loss,
+    SILogLoss,
+    SkyDistillLoss,
+)
+from lightly_train._task_models.depth_estimation.task_model import (
+    DepthAnythingDepthEstimation,
+)
+from lightly_train._task_models.depth_estimation.transforms import (
+    DepthEstimationTrainTransform,
+    DepthEstimationTrainTransformArgs,
+    DepthEstimationValTransform,
+    DepthEstimationValTransformArgs,
+)
+from lightly_train._task_models.object_detection_components.ema import ModelEMA
+from lightly_train._task_models.train_model import (
+    TaskStepResult,
+    TrainModel,
+    TrainModelArgs,
+)
+from lightly_train._torch_compile import TorchCompileArgs
+from lightly_train._visualize.depth_estimation import (
+    DepthEstimationTaskStepVisualization,
+)
+from lightly_train.types import DepthEstimationBatch, PathLike
+
+_LOSS_NAMES = ["loss", "silog_loss", "grad_loss", "sky_loss", "abs_l1_loss"]
+# Extra loss logged only when feature-space distillation is enabled.
+_FEATURE_LOSS_NAME = "feat_loss"
+
+
+class DepthEstimationTrainArgs(TrainModelArgs):
+    # Training uses a single fixed resolution (the DepthAnything V3 base 504x504,
+    # resolved from the model config) with a fixed batch size. The paper's
+    # multi-resolution-per-step sampling and its constant-token-count dynamic batch
+    # sizing are intentionally not implemented.
+    default_batch_size: ClassVar[int] = 8
+    default_steps: ClassVar[int] = 40_000
+
+    # Backbone args.
+    backbone_freeze: bool = False
+    backbone_weights: PathLike | None = None
+    # Multiplier on the backbone learning rate relative to the decoder. The backbone is
+    # pretrained while the DPT/sky heads are random, so the backbone is fine-tuned at a
+    # lower rate by default. Ignored when ``backbone_freeze`` is set.
+    backbone_lr_factor: float = 0.1
+
+    gradient_clip_val: float | Literal["auto"] = "auto"
+
+    # Optim.
+    lr: float = 5e-5
+    weight_decay: float | Literal["auto"] = "auto"
+    lr_warmup_steps: int | Literal["auto"] = "auto"
+
+    # Loss.
+    silog_lambda: float = 0.5
+    grad_loss_weight: float = 0.5
+    grad_loss_scales: int = 4
+    sky_loss_weight: float = 1.0
+    # Weight of the relative-L1 (AbsRel) depth term (raw scale-aware RelativeL1Loss). Off by
+    # default and metric-depth only: its gradient does not vanish with a global scale error
+    # and so pins the student's absolute scale to the teacher (the scale-invariant SILog and
+    # gradient terms give no such signal). It has no effect on relative-depth models, whose
+    # global scale is intentionally left free.
+    abs_l1_loss_weight: float = 0.0
+
+    # Feature-space distillation of the teacher's DPT-input patch tokens. Disabled by
+    # default (``feature_align_weight == 0``): when enabled the frozen ``feature_align_teacher``
+    # model is loaded online and its intermediate features are aligned with the student's
+    # via a learnable per-stage projection (see ``FeatureAlignmentLoss``). The teacher must
+    # share the student's patch size and processing resolution and expose the same number
+    # of intermediate layers (e.g. the default ViT-L teacher for a ViT-S student, both at
+    # 14px/504px); only the backbone widths may differ, which the loss handles.
+    feature_align_weight: float = 0.0
+    feature_align_teacher: str = "dinov2/dav3-metric-large"
+    feature_align_teacher_weights: PathLike | None = None
+
+    # Exponential moving average of the weights, used for validation and export. Off by
+    # default; when enabled, validation and the exported checkpoint use the EMA weights
+    # (see the object-detection tasks for the same `ModelEMA` pattern). EMA smooths the
+    # noisy tail of a not-yet-converged run and is a cheap variance reduction.
+    use_ema: bool = False
+    ema_decay: float = 0.9998
+    ema_warmup_steps: int = 2000
+
+    def resolve_auto(
+        self,
+        total_steps: int,
+        gradient_accumulation_steps: int,
+        train_num_batches: int,
+        model_name: str,
+        model_init_args: dict[str, Any],
+        data_args: TaskDataArgs,
+    ) -> None:
+        if self.weight_decay == "auto":
+            self.weight_decay = 0.0 if self.backbone_freeze else 0.01
+        if self.lr_warmup_steps == "auto":
+            self.lr_warmup_steps = 0 if self.backbone_freeze else min(500, total_steps)
+        if self.gradient_clip_val == "auto":
+            self.gradient_clip_val = 0.0 if self.backbone_freeze else 3.0
+
+
+class DepthEstimationTrain(TrainModel):
+    task = "depth_estimation"
+    train_model_args_cls = DepthEstimationTrainArgs
+    task_metric_args_cls = DepthEstimationTaskMetricArgs
+    task_model_cls = DepthAnythingDepthEstimation
+    train_transform_cls = DepthEstimationTrainTransform
+    val_transform_cls = DepthEstimationValTransform
+    torch_compile_args_cls = TorchCompileArgs
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        model_args: DepthEstimationTrainArgs,
+        data_args: DepthEstimationDataArgs,
+        train_transform_args: DepthEstimationTrainTransformArgs,
+        val_transform_args: DepthEstimationValTransformArgs,
+        load_weights: bool,
+        metric_args: DepthEstimationTaskMetricArgs,
+        gradient_accumulation_steps: int,
+    ) -> None:
+        super().__init__()
+        self.model_args = model_args
+        self.metric_args = metric_args
+
+        # Build the student without hosted depth weights; trainable V3 students load the
+        # pretrained backbone separately and keep the DPT and sky heads randomly
+        # initialized.
+        self.model = DepthAnythingDepthEstimation(
+            model_name=model_name,
+            load_weights=False,
+        )
+        if load_weights:
+            _load_pretrained_backbone(
+                model=self.model, backbone_weights=model_args.backbone_weights
+            )
+
+        # Optional EMA of the task-model weights (backbone + DPT/sky heads), used for
+        # validation and export. Built after the (optional) pretrained backbone load so
+        # the shadow starts from the same weights as the live model. Reuses the shared
+        # `ModelEMA` from the object-detection tasks. `None` when disabled so all
+        # export/load paths behave exactly as before. EMA is an internal training trick
+        # and is never surfaced to users: the exported checkpoint stores the EMA weights
+        # under the normal task-model keys (see `get_export_state_dict`), so it is
+        # indistinguishable from a non-EMA checkpoint.
+        self.ema_model: ModelEMA | None = None
+        if model_args.use_ema:
+            self.ema_model = ModelEMA(
+                model=self.model,
+                decay=model_args.ema_decay,
+                warmups=model_args.ema_warmup_steps,
+            )
+
+        # Metric-depth models predict depth with an absolute scale (`scale_mode != "none"`,
+        # e.g. the DA3 canonical-camera output that inference scales by `focal / 300`).
+        # Relative-depth models leave the global scale unconstrained. This flag switches
+        # the depth loss from scale-invariant to scale-aware and disables the
+        # scale-and-shift alignment in the validation metrics.
+        self._is_metric = self.model._scale_mode != "none"
+
+        # For metric models the depth term must be scale-aware, so the scale-invariant
+        # mean-subtraction is turned off (`lambd=0` reduces SILog to a log-space L2, see
+        # SILogLoss). Relative models keep the configured `silog_lambda`.
+        silog_lambda = 0.0 if self._is_metric else model_args.silog_lambda
+        self.silog_criterion = SILogLoss(lambd=silog_lambda)
+        self.grad_criterion = GradientMatchingLoss(scales=model_args.grad_loss_scales)
+        self.sky_criterion = SkyDistillLoss()
+        # Relative-L1 (AbsRel) term (see abs_l1_loss_weight). Metric-depth only: it pins the
+        # student's absolute scale to the teacher. Relative-depth models do not use it (their
+        # global scale is intentionally free).
+        self.abs_l1_criterion = RelativeL1Loss()
+
+        # Feature-space distillation is opt-in: only when its weight is positive do we
+        # load the (expensive) frozen teacher and add the alignment loss and its metric.
+        self.feature_align_weight = model_args.feature_align_weight
+        self.teacher: DepthAnythingDepthEstimation | None = None
+        self.feature_align_criterion: FeatureAlignmentLoss | None = None
+        loss_names = list(_LOSS_NAMES)
+        if self.feature_align_weight > 0:
+            teacher = _build_teacher(
+                model_name=model_args.feature_align_teacher,
+                weights=model_args.feature_align_teacher_weights,
+            )
+            if len(teacher.out_layers) != len(self.model.out_layers):
+                raise ValueError(
+                    "The teacher and student must expose the same number of "
+                    f"intermediate layers for feature alignment, got "
+                    f"{len(teacher.out_layers)} (teacher) and "
+                    f"{len(self.model.out_layers)} (student)."
+                )
+            if teacher.patch_size != self.model.patch_size:
+                raise ValueError(
+                    "The teacher and student must share the patch size for feature "
+                    f"alignment (the token grids must match), got "
+                    f"{teacher.patch_size} (teacher) and "
+                    f"{self.model.patch_size} (student)."
+                )
+            self.teacher = teacher
+            self.feature_align_criterion = FeatureAlignmentLoss(
+                student_dim=int(self.model.backbone.embed_dim),
+                teacher_dim=int(teacher.backbone.embed_dim),
+                num_stages=len(self.model.out_layers),
+            )
+            loss_names.append(_FEATURE_LOSS_NAME)
+
+        self.val_metrics = DepthEstimationTaskMetric(
+            task_metric_args=metric_args,
+            split="val",
+            loss_names=loss_names,
+            align=not self._is_metric,
+        )
+        self.train_metrics = DepthEstimationTaskMetric(
+            task_metric_args=metric_args,
+            split="train",
+            loss_names=loss_names,
+            train_loss_running_mean_window=gradient_accumulation_steps,
+            align=not self._is_metric,
+        )
+
+        # Visualization: denormalize the logged images with the same mean/std as the
+        # transform so the RGB tiles look natural next to the colorized depth maps.
+        normalize = no_auto(train_transform_args.normalize)
+        self.image_normalize = {"mean": normalize.mean, "std": normalize.std}
+        # TODO(Nauryz, 06/2026): This visualization limit is hardcoded, matching the
+        # other tasks; it may become configurable via logger_args in the future.
+        self.viz_max_images = 4
+
+    def get_task_model(self) -> DepthAnythingDepthEstimation:
+        # Inference and export use the EMA weights when EMA is enabled (the smoothed
+        # weights validate better), otherwise the live model.
+        if self.ema_model is not None:
+            return cast(DepthAnythingDepthEstimation, self.ema_model.model)
+        return self.model
+
+    def forward(self, images: Tensor) -> dict[str, Tensor]:
+        return self._forward(model=self.model, images=images)
+
+    def training_step(
+        self, fabric: Fabric, batch: DepthEstimationBatch, step: int
+    ) -> TaskStepResult:
+        return self._step(
+            model=self.model,
+            batch=batch,
+            metrics=self.train_metrics,
+            compute_metrics=True,
+        )
+
+    def validation_step(
+        self, fabric: Fabric, batch: DepthEstimationBatch, step: int
+    ) -> TaskStepResult:
+        # Validate with the EMA weights when enabled, otherwise the live model.
+        model = (
+            self.model
+            if self.ema_model is None
+            else cast(DepthAnythingDepthEstimation, self.ema_model.model)
+        )
+        return self._step(
+            model=model,
+            batch=batch,
+            metrics=self.val_metrics,
+            compute_metrics=True,
+        )
+
+    def on_train_batch_end(self) -> None:
+        # Update the EMA shadow after each optimizer step (framework hook, called from
+        # the training loop). No-op when EMA is disabled.
+        if self.ema_model is not None:
+            self.ema_model.update(self.model)
+
+    def get_export_state_dict(self) -> dict[str, Any]:
+        """Returns the state dict for exporting.
+
+        EMA is an internal training trick and is not surfaced to users: when it is
+        enabled the exported checkpoint stores the *EMA* weights (which validate better)
+        but under the normal live-model (``model.``) keys, and the ``ema_model.`` keys
+        are dropped. The result is byte-for-byte structurally identical to a non-EMA
+        export, so downstream loading (into the task model or a fresh train model) is
+        unchanged and callers cannot tell EMA was used.
+        """
+        state_dict = super().get_export_state_dict()
+        if self.ema_model is None:
+            return state_dict
+
+        prefix = "ema_model.model."
+        # Overwrite each live-model weight with its EMA counterpart, then drop all
+        # `ema_model.` entries so only the standard train-model keys remain.
+        ema_weights = {
+            f"model.{name[len(prefix) :]}": value
+            for name, value in state_dict.items()
+            if name.startswith(prefix)
+        }
+        result = {
+            name: value
+            for name, value in state_dict.items()
+            if not name.startswith("ema_model.")
+        }
+        result.update(ema_weights)
+        return result
+
+    def load_train_state_dict(
+        self, state_dict: dict[str, Any], strict: bool = True, assign: bool = False
+    ) -> Any:
+        """Loads a training/export state dict, initializing the EMA shadow if enabled.
+
+        Exported and converted checkpoints never contain ``ema_model.`` keys (EMA is not
+        surfaced; see ``get_export_state_dict``), so when EMA is enabled the shadow is
+        seeded from the loaded live-model weights rather than from the state dict. This
+        is the metric-fine-tune-from-a-relative-checkpoint path: the relative checkpoint
+        has no EMA keys, so the metric run's EMA starts from the loaded relative weights.
+        Loading is delegated to the base method with the ``ema_model`` submodule
+        temporarily detached so its (absent) keys are not reported as missing.
+        """
+        if self.ema_model is None:
+            return super().load_train_state_dict(
+                state_dict, strict=strict, assign=assign
+            )
+
+        # Detach the EMA submodule so its parameters are not expected in `state_dict`.
+        ema_model = self.ema_model
+        self.ema_model = None
+        try:
+            incompatible = super().load_train_state_dict(
+                state_dict, strict=strict, assign=assign
+            )
+        finally:
+            self.ema_model = ema_model
+        # Re-seed the EMA shadow from the freshly loaded live weights.
+        self.ema_model.model.load_state_dict(self.model.state_dict())
+        return incompatible
+
+    def get_optimizer(
+        self,
+        total_steps: int,
+        global_batch_size: int,
+    ) -> tuple[Optimizer, LRScheduler]:
+        _, params_no_wd_list = optimizer_helpers.get_weight_decay_parameters([self])
+        params_no_wd = set(params_no_wd_list)
+
+        lr = self.model_args.lr * math.sqrt(
+            global_batch_size / self.model_args.default_batch_size
+        )
+        backbone_lr = lr * self.model_args.backbone_lr_factor
+
+        # The backbone is pretrained and fine-tuned at the reduced backbone_lr; the DPT
+        # decoder (depth + sky heads) is randomly initialized and trains at the full lr.
+        # The feature-alignment projections (when enabled) are also randomly initialized,
+        # so they join the decoder group at the full lr; the frozen teacher has no
+        # trainable parameters and is not part of any group.
+        backbone_params = set(self.model.backbone.parameters())
+        decoder_params = set(self.model.decoder.parameters())
+        if self.feature_align_criterion is not None:
+            decoder_params |= set(self.feature_align_criterion.parameters())
+        param_groups: list[dict[str, Any]] = []
+        for name, module_params, group_lr in (
+            ("backbone", backbone_params, backbone_lr),
+            ("decoder", decoder_params, lr),
+        ):
+            params_wd = [
+                p for p in module_params if p.requires_grad and p not in params_no_wd
+            ]
+            params_no_wd_group = [
+                p for p in module_params if p.requires_grad and p in params_no_wd
+            ]
+            if params_wd:
+                param_groups.append({"name": name, "params": params_wd, "lr": group_lr})
+            if params_no_wd_group:
+                param_groups.append(
+                    {
+                        "name": f"{name}_no_weight_decay",
+                        "params": params_no_wd_group,
+                        "lr": group_lr,
+                        "weight_decay": 0.0,
+                    }
+                )
+
+        optimizer = AdamW(
+            params=param_groups,
+            lr=lr,
+            weight_decay=no_auto(self.model_args.weight_decay),
+        )
+        scheduler = CosineWarmupScheduler(
+            optimizer=optimizer,
+            warmup_epochs=no_auto(self.model_args.lr_warmup_steps),
+            max_epochs=total_steps,
+        )
+        return optimizer, scheduler
+
+    def set_train_mode(self) -> None:
+        self.train()
+        if self.model_args.backbone_freeze:
+            self.model.backbone.eval()
+            for param in self.model.backbone.parameters():
+                param.requires_grad_(False)
+        # The teacher is frozen for feature distillation; ``self.train()`` above flips it
+        # back to train mode, so restore eval to keep its features deterministic.
+        if self.teacher is not None:
+            self.teacher.eval()
+
+    def clip_gradients(self, fabric: Fabric, optimizer: Optimizer) -> None:
+        if no_auto(self.model_args.gradient_clip_val) > 0:
+            fabric.clip_gradients(
+                module=self,
+                optimizer=optimizer,
+                max_norm=no_auto(self.model_args.gradient_clip_val),
+                error_if_nonfinite=False,
+            )
+
+    def _forward(
+        self, model: DepthAnythingDepthEstimation, images: Tensor
+    ) -> dict[str, Tensor]:
+        feats = model._extract_features(images)
+        out: dict[str, Tensor] = model.decoder(
+            feats=feats, H=images.shape[-2], W=images.shape[-1]
+        )
+        return out
+
+    def _step(
+        self,
+        model: DepthAnythingDepthEstimation,
+        batch: DepthEstimationBatch,
+        metrics: DepthEstimationTaskMetric,
+        compute_metrics: bool,
+    ) -> TaskStepResult:
+        images = batch["image"]
+        depth = batch["depth"]
+        sky = batch["sky"]
+        assert isinstance(images, Tensor)
+        assert isinstance(depth, Tensor)
+        assert isinstance(sky, Tensor)
+
+        # Extract the student's DPT-input features once and reuse them for the decoder
+        # output and (when enabled) the feature-alignment loss, avoiding a second
+        # backbone forward pass.
+        student_feats = model._extract_features(images)
+        out: dict[str, Tensor] = model.decoder(
+            feats=student_feats, H=images.shape[-2], W=images.shape[-1]
+        )
+        # Sky has no valid depth: the teacher's depth in sky regions is garbage, so
+        # exclude it from the depth losses. The sky head still trains on the full sky
+        # map below.
+        depth_mask = (depth > 0) & (sky < 0.5)
+        silog_loss = self.silog_criterion(out["depth"], depth, depth_mask)
+        grad_loss = self.grad_criterion(out["depth"], depth, depth_mask)
+        sky_loss = self.sky_criterion(out["sky"], sky)
+        loss = (
+            silog_loss
+            + self.model_args.grad_loss_weight * grad_loss
+            + self.model_args.sky_loss_weight * sky_loss
+        )
+        # Relative-L1 (AbsRel) term. Metric-depth only: the raw scale-aware AbsRel pins the
+        # student's absolute scale to the teacher (the scale-invariant SILog and gradient
+        # terms give no such signal). It is not applied to relative-depth models, whose
+        # global scale is intentionally free; there it stays a logged constant 0 so the loss
+        # dict shape matches the metric collection.
+        if self._is_metric:
+            abs_l1_loss = self.abs_l1_criterion(out["depth"], depth, depth_mask)
+            loss = loss + self.model_args.abs_l1_loss_weight * abs_l1_loss
+        else:
+            abs_l1_loss = loss.new_zeros(())
+
+        loss_log = {
+            "silog_loss": silog_loss.detach(),
+            "grad_loss": grad_loss.detach(),
+            "sky_loss": sky_loss.detach(),
+            "abs_l1_loss": abs_l1_loss.detach(),
+        }
+        # Feature-space distillation of the teacher's DPT-input patch tokens. The teacher
+        # shares the student's patch size and input resolution, so both backbones produce
+        # the same token grid and the features align token-for-token (only the widths
+        # differ, which the loss projects away). Enabled only when a positive weight has
+        # loaded the teacher.
+        if self.feature_align_criterion is not None and self.teacher is not None:
+            with torch.no_grad():
+                teacher_feats = self.teacher._extract_features(images)
+            feat_loss = self.feature_align_criterion(student_feats, teacher_feats)
+            loss = loss + self.feature_align_weight * feat_loss
+            loss_log[_FEATURE_LOSS_NAME] = feat_loss.detach()
+
+        metrics.update_with_losses(
+            {"loss": loss.detach(), **loss_log},
+            weight=images.shape[0],
+        )
+        if compute_metrics:
+            # Zero out sky pixels so update_with_predictions' `target > 0` filter ignores
+            # them, matching the sky exclusion applied to the loss.
+            metric_target = torch.where(sky < 0.5, depth, torch.zeros_like(depth))
+            metrics.update_with_predictions(out["depth"].detach(), metric_target)
+
+        return TaskStepResult(
+            loss=loss,
+            log_dict={},
+            metrics=metrics,
+            visualization=DepthEstimationTaskStepVisualization(
+                batch=batch,
+                image_normalize=self.image_normalize,
+                max_images=self.viz_max_images,
+                pred_depth=out["depth"],
+            ),
+        )
+
+
+def _load_pretrained_backbone(
+    model: DepthAnythingDepthEstimation, *, backbone_weights: PathLike | None
+) -> None:
+    """Loads pretrained backbone weights into the student backbone in place.
+
+    A local ``backbone_weights`` checkpoint takes precedence. Otherwise the public
+    pretrained weights for the student's backbone are fetched and copied in. For backbones
+    without hosted weights (e.g. the ``_vittest14`` test backbone) this is a no-op and
+    the backbone keeps its random initialization.
+    """
+    if backbone_weights is not None:
+        state_dict = torch.load(backbone_weights, map_location="cpu", weights_only=True)
+        model.backbone.load_state_dict(state_dict, strict=True)
+        return
+
+    reference = model.backbone_package.get_model(
+        model_name=model.backbone_name,
+        model_args=model.backbone_model_args,
+        load_weights=True,
+    )
+    model.backbone.load_state_dict(reference.state_dict(), strict=True)
+
+
+def _build_teacher(
+    *, model_name: str, weights: PathLike | None
+) -> DepthAnythingDepthEstimation:
+    """Builds the frozen teacher used for feature-space distillation.
+
+    The full converted depth checkpoint is loaded so the teacher backbone matches the one
+    that produced the depth and sky pseudo-labels. Only the backbone is needed for feature
+    alignment, so the DPT head is dropped to save memory; features are read at the
+    teacher's own ``out_layers`` via ``_extract_features``. The teacher is frozen and set
+    to eval mode.
+    """
+    teacher = DepthAnythingDepthEstimation(
+        model_name=model_name,
+        load_weights=True,
+        weights=weights,
+    )
+    # The DPT head is unused for feature alignment; drop it to save memory. Replaced with
+    # an Identity so any accidental attribute access fails loudly rather than silently.
+    teacher.decoder = torch.nn.Identity()  # type: ignore[assignment]
+    teacher.eval()
+    for param in teacher.parameters():
+        param.requires_grad_(False)
+    return teacher

--- a/src/lightly_train/_task_models/depth_estimation/transforms.py
+++ b/src/lightly_train/_task_models/depth_estimation/transforms.py
@@ -1,0 +1,129 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from lightly_train._task_models.depth_estimation.task_model import (
+    get_model_image_size,
+    get_model_patch_size,
+)
+from lightly_train._transforms.depth_estimation_transform import (
+    DepthEstimationTransform,
+    DepthEstimationTransformArgs,
+)
+from lightly_train._transforms.transform import (
+    ColorJitterArgs,
+    GaussianBlurArgs,
+    NormalizeArgs,
+    RandomCropArgs,
+    RandomFlipArgs,
+)
+from lightly_train.types import ImageSizeTuple
+
+_DEFAULT_PATCH_SIZE = 14
+
+
+class DepthEstimationColorJitterArgs(ColorJitterArgs):
+    # Mild photometric jitter matching the values used by the EoMT semantic
+    # segmentation task (also a dense-prediction task with mask labels).
+    prob: float = 0.5
+    strength: float = 1.0
+    brightness: float = 32.0 / 255.0
+    contrast: float = 0.5
+    saturation: float = 0.5
+    hue: float = 18.0 / 360.0
+
+
+class DepthEstimationGaussianBlurArgs(GaussianBlurArgs):
+    # Light blur applied to a minority of samples. blur_limit=0 lets albumentations
+    # derive the kernel size from the sampled sigma.
+    prob: float = 0.2
+    sigmas: tuple[float, float] = Field(default=(0.1, 1.0), strict=False)
+    blur_limit: int | tuple[int, int] = 0
+
+
+class DepthEstimationTrainTransformArgs(DepthEstimationTransformArgs):
+    """Default transform arguments for depth estimation training."""
+
+    image_size: ImageSizeTuple | Literal["auto"] = "auto"
+    num_channels: int | Literal["auto"] = "auto"
+    normalize: NormalizeArgs | Literal["auto"] = "auto"
+    random_flip: RandomFlipArgs | None = Field(default_factory=RandomFlipArgs)
+    random_crop: RandomCropArgs | None = None
+    color_jitter: ColorJitterArgs | None = Field(
+        default_factory=DepthEstimationColorJitterArgs
+    )
+    gaussian_blur: GaussianBlurArgs | None = Field(
+        default_factory=DepthEstimationGaussianBlurArgs
+    )
+    random_gray_scale: float | None = 0.1
+
+    def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
+        _resolve_depth_transform_auto(self, model_init_args=model_init_args)
+
+
+class DepthEstimationValTransformArgs(DepthEstimationTransformArgs):
+    """Default transform arguments for depth estimation validation."""
+
+    image_size: ImageSizeTuple | Literal["auto"] = "auto"
+    num_channels: int | Literal["auto"] = "auto"
+    normalize: NormalizeArgs | Literal["auto"] = "auto"
+    random_flip: RandomFlipArgs | None = None
+    random_crop: RandomCropArgs | None = None
+    # Validation runs on clean images so metrics reflect true depth accuracy.
+    color_jitter: ColorJitterArgs | None = None
+    gaussian_blur: GaussianBlurArgs | None = None
+    random_gray_scale: float | None = None
+
+    def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
+        _resolve_depth_transform_auto(self, model_init_args=model_init_args)
+
+
+class DepthEstimationTrainTransform(DepthEstimationTransform):
+    transform_args_cls = DepthEstimationTrainTransformArgs
+
+
+class DepthEstimationValTransform(DepthEstimationTransform):
+    transform_args_cls = DepthEstimationValTransformArgs
+
+
+def _resolve_depth_transform_auto(
+    args: DepthEstimationTransformArgs, model_init_args: dict[str, Any]
+) -> None:
+    if args.image_size == "auto":
+        model_name = model_init_args.get("model_name")
+        if model_name is not None:
+            size = get_model_image_size(model_name=model_name)
+            args.image_size = (size, size)
+        else:
+            args.image_size = (504, 504)
+
+    model_name = model_init_args.get("model_name")
+    patch_size = (
+        get_model_patch_size(model_name=model_name)
+        if model_name is not None
+        else _DEFAULT_PATCH_SIZE
+    )
+    height, width = args.image_size
+    if height % patch_size != 0 or width % patch_size != 0:
+        raise ValueError(
+            f"image_size {args.image_size} (height, width) must be a multiple of the "
+            f"patch size {patch_size} in both dimensions. The DepthAnything V3 base "
+            f"resolution is (504, 504); other supported sizes from the paper include "
+            f"(504, 378), (504, 336), (504, 280), (336, 504), (896, 504), (756, 504), "
+            f"and (672, 504)."
+        )
+
+    if args.normalize == "auto":
+        args.normalize = NormalizeArgs()
+
+    if args.num_channels == "auto":
+        args.num_channels = len(args.normalize.mean)

--- a/src/lightly_train/_transforms/depth_estimation_transform.py
+++ b/src/lightly_train/_transforms/depth_estimation_transform.py
@@ -24,6 +24,7 @@ from albumentations import (
     VerticalFlip,
 )
 from albumentations.pytorch import ToTensorV2
+from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from typing_extensions import NotRequired
 
@@ -52,6 +53,11 @@ from lightly_train.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The RandomCrop padding kwargs (pad_if_needed, pad_position, fill) were added in
+# albumentations 1.4.21; older pinned versions (e.g. 1.3.1 for super-gradients) only
+# accept height/width/p. See _transforms/random_iou_crop.py for the same guard.
+ALBUMENTATIONS_GEQ_1_4_21 = RequirementCache("albumentations>=1.4.21")
 
 # Albumentations targets: depth and sky are passed through geometric ops as float
 # "mask" targets so they are not normalized or color-jittered.
@@ -126,16 +132,28 @@ class DepthEstimationTransform(TaskTransform):
         # During training the image is randomly cropped to a fixed size; the same
         # geometric crop is applied to depth and sky via the additional targets.
         if transform_args.random_crop is not None:
-            transform += [
-                RandomCrop(
-                    height=no_auto(transform_args.random_crop.height),
-                    width=no_auto(transform_args.random_crop.width),
+            crop_height = no_auto(transform_args.random_crop.height)
+            crop_width = no_auto(transform_args.random_crop.width)
+            crop_prob = transform_args.random_crop.prob
+            if ALBUMENTATIONS_GEQ_1_4_21:
+                random_crop = RandomCrop(
+                    height=crop_height,
+                    width=crop_width,
                     pad_if_needed=transform_args.random_crop.pad_if_needed,
                     pad_position=transform_args.random_crop.pad_position,
                     fill=transform_args.random_crop.fill,
-                    p=transform_args.random_crop.prob,
+                    p=crop_prob,
                 )
-            ]
+            else:
+                # Older albumentations has no padding support; fall back to a plain crop.
+                # The DepthAnything resolutions are always larger than the crop size, so
+                # pad_if_needed is a no-op in practice.
+                random_crop = RandomCrop(
+                    height=crop_height,
+                    width=crop_width,
+                    p=crop_prob,
+                )
+            transform += [random_crop]
 
         if transform_args.random_flip is not None:
             if transform_args.random_flip.horizontal_prob > 0.0:

--- a/src/lightly_train/_transforms/depth_estimation_transform.py
+++ b/src/lightly_train/_transforms/depth_estimation_transform.py
@@ -1,0 +1,215 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+import torch
+from albumentations import (
+    BasicTransform,
+    ColorJitter,
+    Compose,
+    GaussianBlur,
+    HorizontalFlip,
+    RandomCrop,
+    Resize,
+    ToGray,
+    VerticalFlip,
+)
+from albumentations.pytorch import ToTensorV2
+from torch import Tensor
+from typing_extensions import NotRequired
+
+from lightly_train._configs.validate import no_auto
+from lightly_train._transforms.normalize import NormalizeDtypeAware as Normalize
+from lightly_train._transforms.task_transform import (
+    TaskCollateFunction,
+    TaskTransform,
+    TaskTransformArgs,
+    TaskTransformInput,
+    TaskTransformOutput,
+)
+from lightly_train._transforms.transform import (
+    ColorJitterArgs,
+    GaussianBlurArgs,
+    NormalizeArgs,
+    RandomCropArgs,
+    RandomFlipArgs,
+)
+from lightly_train.types import (
+    DepthEstimationBatch,
+    DepthEstimationDatasetItem,
+    ImageSizeTuple,
+    NDArrayDepth,
+    NDArrayImage,
+)
+
+logger = logging.getLogger(__name__)
+
+# Albumentations targets: depth and sky are passed through geometric ops as float
+# "mask" targets so they are not normalized or color-jittered.
+_ADDITIONAL_TARGETS = {"depth": "mask", "sky": "mask"}
+
+
+class DepthEstimationTransformInput(TaskTransformInput):
+    image: NDArrayImage
+    depth: NotRequired[NDArrayDepth]
+    sky: NotRequired[NDArrayDepth]
+
+
+class DepthEstimationTransformOutput(TaskTransformOutput):
+    image: Tensor
+    depth: NotRequired[Tensor]
+    sky: NotRequired[Tensor]
+
+
+class DepthEstimationTransformArgs(TaskTransformArgs):
+    image_size: ImageSizeTuple | Literal["auto"]
+    num_channels: int | Literal["auto"]
+    normalize: NormalizeArgs | Literal["auto"]
+    random_flip: RandomFlipArgs | None
+    random_crop: RandomCropArgs | None
+    # Photometric augmentations applied to the image only; depth and sky are mask
+    # targets and are never color-jittered, blurred, or grayscaled.
+    color_jitter: ColorJitterArgs | None
+    gaussian_blur: GaussianBlurArgs | None
+    random_gray_scale: float | None
+
+    def resolve_auto(self, model_init_args: dict[str, Any]) -> None:
+        pass
+
+    def resolve_incompatible(self) -> None:
+        self.normalize = no_auto(self.normalize)
+        assert isinstance(self.normalize, NormalizeArgs)
+        num_channels = no_auto(self.num_channels)
+        assert isinstance(num_channels, int)
+
+        # Adjust normalization mean and std to match num_channels.
+        if len(self.normalize.mean) != num_channels:
+            self.normalize.mean = tuple(
+                self.normalize.mean[i % len(self.normalize.mean)]
+                for i in range(num_channels)
+            )
+        if len(self.normalize.std) != num_channels:
+            self.normalize.std = tuple(
+                self.normalize.std[i % len(self.normalize.std)]
+                for i in range(num_channels)
+            )
+
+        # Color jitter and grayscale only support 3-channel images.
+        if self.color_jitter is not None and num_channels != 3:
+            self.color_jitter = None
+        if self.random_gray_scale is not None and num_channels != 3:
+            self.random_gray_scale = None
+
+
+class DepthEstimationTransform(TaskTransform):
+    transform_args_cls: type[DepthEstimationTransformArgs] = (
+        DepthEstimationTransformArgs
+    )
+
+    def __init__(self, transform_args: DepthEstimationTransformArgs) -> None:
+        super().__init__(transform_args=transform_args)
+
+        image_size = no_auto(transform_args.image_size)
+        transform: list[BasicTransform] = [
+            Resize(height=image_size[0], width=image_size[1])
+        ]
+
+        # During training the image is randomly cropped to a fixed size; the same
+        # geometric crop is applied to depth and sky via the additional targets.
+        if transform_args.random_crop is not None:
+            transform += [
+                RandomCrop(
+                    height=no_auto(transform_args.random_crop.height),
+                    width=no_auto(transform_args.random_crop.width),
+                    pad_if_needed=transform_args.random_crop.pad_if_needed,
+                    pad_position=transform_args.random_crop.pad_position,
+                    fill=transform_args.random_crop.fill,
+                    p=transform_args.random_crop.prob,
+                )
+            ]
+
+        if transform_args.random_flip is not None:
+            if transform_args.random_flip.horizontal_prob > 0.0:
+                transform += [
+                    HorizontalFlip(p=transform_args.random_flip.horizontal_prob)
+                ]
+            if transform_args.random_flip.vertical_prob > 0.0:
+                transform += [VerticalFlip(p=transform_args.random_flip.vertical_prob)]
+
+        # Photometric augmentations are applied to the image only. Because depth and sky
+        # are registered as mask targets they are left untouched, so the pixel-to-label
+        # correspondence is preserved.
+        if transform_args.color_jitter is not None:
+            transform += [
+                ColorJitter(
+                    brightness=transform_args.color_jitter.strength
+                    * transform_args.color_jitter.brightness,
+                    contrast=transform_args.color_jitter.strength
+                    * transform_args.color_jitter.contrast,
+                    saturation=transform_args.color_jitter.strength
+                    * transform_args.color_jitter.saturation,
+                    hue=transform_args.color_jitter.strength
+                    * transform_args.color_jitter.hue,
+                    p=transform_args.color_jitter.prob,
+                )
+            ]
+
+        if transform_args.random_gray_scale:
+            transform += [ToGray(p=transform_args.random_gray_scale)]
+
+        if transform_args.gaussian_blur is not None:
+            transform += [
+                GaussianBlur(
+                    blur_limit=transform_args.gaussian_blur.blur_limit,
+                    sigma_limit=transform_args.gaussian_blur.sigmas,
+                    p=transform_args.gaussian_blur.prob,
+                )
+            ]
+
+        # Normalize only applies to the image; depth and sky are mask targets.
+        transform += [
+            Normalize(
+                mean=no_auto(transform_args.normalize).mean,
+                std=no_auto(transform_args.normalize).std,
+            ),
+            ToTensorV2(),
+        ]
+
+        self.transform = Compose(transform, additional_targets=_ADDITIONAL_TARGETS)
+
+    def __call__(
+        self, input: DepthEstimationTransformInput
+    ) -> DepthEstimationTransformOutput:
+        transformed = self.transform(
+            image=input["image"], depth=input["depth"], sky=input["sky"]
+        )
+        # ToTensorV2 leaves mask targets as (H, W); add the channel dimension and make
+        # sure depth/sky are float tensors for the regression losses.
+        depth = transformed["depth"].unsqueeze(0).float()
+        sky = transformed["sky"].unsqueeze(0).float()
+        return {"image": transformed["image"], "depth": depth, "sky": sky}
+
+
+class DepthEstimationCollateFunction(TaskCollateFunction):
+    def __call__(self, batch: list[DepthEstimationDatasetItem]) -> DepthEstimationBatch:
+        images = [item["image"] for item in batch]
+        depths = [item["depth"] for item in batch]
+        skies = [item["sky"] for item in batch]
+
+        # Train and val both use a fixed image size, so all samples are stackable.
+        out: DepthEstimationBatch = {
+            "image_path": [item["image_path"] for item in batch],
+            "image": torch.stack(images),
+            "depth": torch.stack(depths),
+            "sky": torch.stack(skies),
+        }
+        return out

--- a/src/lightly_train/_visualize/depth_estimation.py
+++ b/src/lightly_train/_visualize/depth_estimation.py
@@ -1,0 +1,209 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import matplotlib
+import torch
+from PIL import Image
+from PIL.Image import Image as PILImage
+from torch import Tensor
+from torchvision.transforms import functional as torchvision_functional
+
+from lightly_train._visualize import utils
+from lightly_train.types import DepthEstimationBatch
+
+# Colormap used to render depth maps during training. DAv3 predicts larger values for
+# farther pixels, so nearby pixels sit at the low end of ``magma`` and appear dark.
+_DEPTH_COLORMAP = "magma"
+
+# Apply a gamma curve after min-max normalization so low normalized values occupy more
+# of the visible range. This improves separation of close-range structure while keeping
+# the near-to-far ordering unchanged.
+_DEPTH_VISUALIZATION_GAMMA = 0.5
+
+
+@dataclass
+class DepthEstimationTaskStepVisualization:
+    batch: DepthEstimationBatch
+    image_normalize: dict[str, tuple[float, ...]] | None
+    max_images: int
+    pred_depth: Tensor | None = None
+
+    def create_label_image(self) -> PILImage | None:
+        return plot_depth_labels(
+            batch=self.batch,
+            image_normalize=self.image_normalize,
+            max_images=self.max_images,
+        )
+
+    def create_prediction_image(self) -> PILImage | None:
+        if self.pred_depth is None:
+            return None
+        return plot_depth_predictions(
+            batch=self.batch,
+            pred_depth=self.pred_depth,
+            image_normalize=self.image_normalize,
+            max_images=self.max_images,
+        )
+
+
+def plot_depth_labels(
+    batch: DepthEstimationBatch,
+    max_images: int,
+    image_normalize: dict[str, tuple[float, ...]] | None,
+) -> PILImage:
+    """Render a grid pairing each input image with depth and sky targets.
+
+    Args:
+        batch: Depth estimation batch with images and depth maps.
+        max_images: Maximum number of images to include in the grid.
+        image_normalize: Optional dict with "mean" and "std" tuples used to
+            denormalize images before rendering. If None, images pass through
+            unchanged.
+
+    Returns:
+        A single PIL image with up to max_images RGB/depth/sky triplets arranged in a
+        grid.
+    """
+    images = _as_tensor(batch["image"])
+    depth = _as_tensor(batch["depth"])
+    # The ground-truth depth in sky regions is garbage (the teacher has no valid depth
+    # there), so exclude sky pixels from the colorization and fill them as distant.
+    sky = _as_tensor(batch["sky"])
+    n = min(max_images, images.shape[0])
+
+    pil_images: list[PILImage] = []
+    for i in range(n):
+        rgb = _image_to_pil(image=images[i], image_normalize=image_normalize)
+        depth_img = _depth_to_pil(depth=depth[i], sky=sky[i] >= 0.5)
+        sky_img = _sky_to_pil(sky=sky[i])
+        pil_images.append(_concat_horizontal([rgb, depth_img, sky_img]))
+
+    return utils._render_grid(pil_images)
+
+
+def plot_depth_predictions(
+    batch: DepthEstimationBatch,
+    pred_depth: Tensor,
+    max_images: int,
+    image_normalize: dict[str, tuple[float, ...]] | None,
+) -> PILImage:
+    """Render a grid pairing each input image with predicted depth and sky target.
+
+    Args:
+        batch: Depth estimation batch with images.
+        pred_depth: Predicted depth of shape (batch_size, 1, H, W).
+        max_images: Maximum number of images to include in the grid.
+        image_normalize: Optional dict with "mean" and "std" tuples used to
+            denormalize images before rendering. If None, images pass through
+            unchanged.
+
+    Returns:
+        A single PIL image with up to max_images RGB/predicted-depth/sky triplets in a
+        grid.
+    """
+    images = _as_tensor(batch["image"])
+    pred = pred_depth.detach().to(device="cpu", dtype=torch.float32)
+    sky = _as_tensor(batch["sky"])
+    n = min(max_images, images.shape[0])
+
+    pil_images: list[PILImage] = []
+    for i in range(n):
+        rgb = _image_to_pil(image=images[i], image_normalize=image_normalize)
+        depth_img = _depth_to_pil(depth=pred[i])
+        sky_img = _sky_to_pil(sky=sky[i])
+        pil_images.append(_concat_horizontal([rgb, depth_img, sky_img]))
+
+    return utils._render_grid(pil_images)
+
+
+def _as_tensor(value: Tensor | list[Tensor]) -> Tensor:
+    """Returns a stacked, CPU float tensor for both batched and per-sample inputs."""
+    if isinstance(value, list):
+        value = torch.stack(value)
+    return value.detach().to(device="cpu", dtype=torch.float32)
+
+
+def _image_to_pil(
+    image: Tensor, image_normalize: dict[str, tuple[float, ...]] | None
+) -> PILImage:
+    image = image.clone().to(dtype=torch.float32)
+    if image_normalize is not None:
+        image = utils._denormalize_image(
+            image=image,
+            mean=image_normalize["mean"],
+            std=image_normalize["std"],
+        )
+    pil_image: PILImage = torchvision_functional.to_pil_image(image)
+    return pil_image
+
+
+def _depth_to_pil(depth: Tensor, sky: Tensor | None = None) -> PILImage:
+    """Colorizes a (1, H, W) depth map with a colormap, ignoring invalid pixels.
+
+    Depth is min-max normalized over the valid (positive) pixels of the sample so the
+    full colormap range is used regardless of the absolute depth scale.
+
+    Args:
+        depth: Depth map of shape ``(1, H, W)``.
+        sky: Optional boolean sky mask of shape ``(1, H, W)``. The ground-truth depth in
+            sky regions is garbage, so sky pixels are excluded from the normalization
+            and then filled with the 99th percentile of the non-sky depth, rendering
+            them as distant scenery (matching the ``predict`` postprocessing) instead of
+            as the colormap's far value.
+    """
+    depth = depth.squeeze(0)
+    valid = depth > 0
+    if sky is not None:
+        valid = valid & ~sky.squeeze(0).bool()
+    if bool(valid.any()):
+        finite = depth[valid]
+        d_min = finite.min()
+        d_max = finite.max()
+        depth = torch.where(valid, depth, torch.quantile(finite, 0.99))
+        normalized = (depth - d_min) / (d_max - d_min + 1e-6)
+    else:
+        normalized = torch.zeros_like(depth)
+    normalized = torch.clamp(normalized, 0.0, 1.0)
+    normalized = _apply_depth_visualization_curve(normalized)
+    # Non-positive (genuinely invalid) pixels are rendered as the colormap's far value.
+    normalized = torch.where(depth > 0, normalized, torch.zeros_like(normalized))
+
+    colormap = matplotlib.colormaps[_DEPTH_COLORMAP]
+    colored = colormap(normalized.numpy())[..., :3]  # Drop alpha, keep RGB.
+    colored_uint8 = (colored * 255).astype("uint8")
+    return Image.fromarray(colored_uint8)
+
+
+def _apply_depth_visualization_curve(normalized: Tensor) -> Tensor:
+    """Expands low normalized values so nearby structure gets more visual contrast."""
+    return torch.pow(normalized, _DEPTH_VISUALIZATION_GAMMA)
+
+
+def _sky_to_pil(sky: Tensor) -> PILImage:
+    """Renders a (1, H, W) sky mask as a simple RGB panel."""
+    sky_mask = sky.squeeze(0) >= 0.5
+    colored = torch.zeros((*sky_mask.shape, 3), dtype=torch.uint8)
+    colored[sky_mask] = torch.tensor((135, 206, 235), dtype=torch.uint8)
+    return Image.fromarray(colored.numpy())
+
+
+def _concat_horizontal(images: list[PILImage]) -> PILImage:
+    """Pastes equally sized images side by side into one."""
+    if not images:
+        raise ValueError("images must not be empty.")
+    height = max(image.size[1] for image in images)
+    width = sum(image.size[0] for image in images)
+    canvas = Image.new("RGB", (width, height))
+    x_offset = 0
+    for image in images:
+        canvas.paste(image, (x_offset, 0))
+        x_offset += image.size[0]
+    return canvas

--- a/src/lightly_train/types.py
+++ b/src/lightly_train/types.py
@@ -27,6 +27,7 @@ PackageModel = Any
 ImageDtypes = Union[np.uint8, np.float32]
 NDArrayImage = NDArray[ImageDtypes]  # (H, W) or (H, W, C)
 NDArrayMask = NDArray[Union[np.uint8, np.uint16, np.int_]]  # (H, W) or (H, W, C)
+NDArrayDepth = NDArray[np.float32]  # (H, W) float depth or sky confidence map
 NDArrayBBoxes = NDArray[np.float64]  # (n_boxes, 4)
 NDArrayOBBoxes = NDArray[
     np.float64
@@ -216,6 +217,23 @@ class ImageClassificationBatch(TypedDict):
     # multilabel classification, or (1,) with the class label for multiclass
     # classification.
     classes: list[Tensor]
+
+
+class DepthEstimationDatasetItem(TaskDatasetItem):
+    image_path: ImageFilename
+    image: Tensor  # Tensor with shape (3, H, W).
+    depth: Tensor  # Tensor with shape (1, H, W). Pixels with value <= 0 are invalid.
+    sky: Tensor  # Tensor with shape (1, H, W) with sky confidence in [0, 1].
+
+
+class DepthEstimationBatch(TypedDict):
+    image_path: list[ImageFilename]  # length==batch_size
+    # Tensor with shape (batch_size, 3, H, W) or list of Tensors with shape (3, H, W).
+    image: Tensor | list[Tensor]
+    # Tensor with shape (batch_size, 1, H, W) or list of Tensors with shape (1, H, W).
+    depth: Tensor | list[Tensor]
+    # Tensor with shape (batch_size, 1, H, W) or list of Tensors with shape (1, H, W).
+    sky: Tensor | list[Tensor]
 
 
 # Replaces torch.optim.optimizer.ParamsT

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -66,6 +66,9 @@ from lightly_train._commands.train_task import (
     SemanticSegmentationTrainTaskConfig,
 )
 from lightly_train._data import data_helpers as data_arg_helpers
+from lightly_train._task_models.depth_estimation.task_model import (
+    DepthAnythingDepthEstimation,
+)
 
 from .. import helpers
 
@@ -536,6 +539,101 @@ def test_train_semantic_segmentation(
     assert (image_examples_dir / "train_labels_0.jpg").exists()
     assert (image_examples_dir / "val_labels_0.jpg").exists()
     assert (image_examples_dir / "val_predictions_0.jpg").exists()
+
+
+def test_train_depth_estimation(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    train_images = tmp_path / "train_images"
+    train_depth = tmp_path / "train_depth"
+    train_sky = tmp_path / "train_sky"
+    val_images = tmp_path / "val_images"
+    val_depth = tmp_path / "val_depth"
+    val_sky = tmp_path / "val_sky"
+    helpers.create_images(train_images, files=4, height=70, width=70)
+    helpers.create_depth_pseudo_labels(
+        train_depth, train_sky, files=4, height=70, width=70
+    )
+    helpers.create_images(val_images, files=4, height=70, width=70)
+    helpers.create_depth_pseudo_labels(val_depth, val_sky, files=4, height=70, width=70)
+
+    lightly_train.train_depth_estimation(
+        out=out,
+        data={
+            "train": {
+                "images": train_images,
+                "depth": train_depth,
+                "sky": train_sky,
+            },
+            "val": {
+                "images": val_images,
+                "depth": val_depth,
+                "sky": val_sky,
+            },
+        },
+        model="dinov2/_vittest14-dav3",
+        accelerator="cpu",
+        devices=1,
+        batch_size=2,
+        num_workers=0,
+        steps=2,
+    )
+    assert out.exists()
+    assert out.is_dir()
+    assert (out / "train.log").exists()
+
+    model = lightly_train.load_model(model=out / "exported_models" / "exported_last.pt")
+    prediction = model.predict(torch.randn(3, 70, 70))
+    assert prediction.shape == (70, 70)
+    assert torch.isfinite(prediction).all()
+
+
+def test_train_depth_estimation__metric(tmp_path: Path) -> None:
+    # A metric-depth model (scale_mode="focal") trains through the same pipeline as the
+    # relative one; only the loss/metric branch differs. The trained model predicts
+    # metric depth from camera intrinsics.
+    out = tmp_path / "out"
+    train_images = tmp_path / "train_images"
+    train_depth = tmp_path / "train_depth"
+    train_sky = tmp_path / "train_sky"
+    val_images = tmp_path / "val_images"
+    val_depth = tmp_path / "val_depth"
+    val_sky = tmp_path / "val_sky"
+    helpers.create_images(train_images, files=4, height=70, width=70)
+    helpers.create_depth_pseudo_labels(
+        train_depth, train_sky, files=4, height=70, width=70
+    )
+    helpers.create_images(val_images, files=4, height=70, width=70)
+    helpers.create_depth_pseudo_labels(val_depth, val_sky, files=4, height=70, width=70)
+
+    lightly_train.train_depth_estimation(
+        out=out,
+        data={
+            "train": {
+                "images": train_images,
+                "depth": train_depth,
+                "sky": train_sky,
+            },
+            "val": {
+                "images": val_images,
+                "depth": val_depth,
+                "sky": val_sky,
+            },
+        },
+        model="dinov2/_vittest14-dav3-metric",
+        accelerator="cpu",
+        devices=1,
+        batch_size=2,
+        num_workers=0,
+        steps=2,
+    )
+    assert out.exists()
+
+    model = lightly_train.load_model(model=out / "exported_models" / "exported_last.pt")
+    assert isinstance(model, DepthAnythingDepthEstimation)
+    intrinsics = torch.tensor([[60.0, 0.0, 35.0], [0.0, 60.0, 35.0], [0.0, 0.0, 1.0]])
+    prediction = model.predict(torch.randn(3, 70, 70), intrinsics=intrinsics)
+    assert prediction.shape == (70, 70)
+    assert torch.isfinite(prediction).all()
 
 
 @pytest.mark.skipif(pydicom is None, reason="pydicom not installed")

--- a/tests/_data/test_depth_estimation_dataset.py
+++ b/tests/_data/test_depth_estimation_dataset.py
@@ -109,10 +109,12 @@ def test_depth_estimation_dataset___getitem___shape_mismatch(
     sky_dir = tmp_path / "sky"
     for d in (image_dir, depth_dir, sky_dir):
         d.mkdir()
-    Image.fromarray(np.zeros((16, 16, 3), dtype=np.uint8)).save(image_dir / "a.png")
-    # Write a mismatched label for the parametrized target.
-    depth_shape = (8, 8) if missing == "depth" else (16, 16)
-    sky_shape = (8, 8) if missing == "sky" else (16, 16)
+    Image.fromarray(np.zeros((28, 28, 3), dtype=np.uint8)).save(image_dir / "a.png")
+    # Write a mismatched label for the parametrized target. The mismatch is detected in
+    # __getitem__ before the transform runs, so image_size only needs to be valid (a
+    # multiple of the patch size 14).
+    depth_shape = (8, 8) if missing == "depth" else (28, 28)
+    sky_shape = (8, 8) if missing == "sky" else (28, 28)
     np.save(depth_dir / "a.npy", np.ones(depth_shape, dtype=np.float32))
     Image.fromarray(np.zeros(sky_shape, dtype=np.uint8), mode="L").save(
         sky_dir / "a.png"
@@ -123,7 +125,7 @@ def test_depth_estimation_dataset___getitem___shape_mismatch(
         val=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
     )
     dataset_args = data_args.get_train_args()
-    transform_args = DepthEstimationTrainTransformArgs(image_size=(16, 16))
+    transform_args = DepthEstimationTrainTransformArgs(image_size=(28, 28))
     transform_args.resolve_auto(model_init_args={})
     transform_args.resolve_incompatible()
     dataset = DepthEstimationDataset(

--- a/tests/_data/test_depth_estimation_dataset.py
+++ b/tests/_data/test_depth_estimation_dataset.py
@@ -1,0 +1,136 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from lightly_train._data.depth_estimation_dataset import (
+    DepthEstimationDataArgs,
+    DepthEstimationDataset,
+    SplitArgs,
+)
+from lightly_train._task_models.depth_estimation.transforms import (
+    DepthEstimationTrainTransform,
+    DepthEstimationTrainTransformArgs,
+)
+
+
+def _make_dataset(tmp_path: Path, *, height: int, width: int) -> DepthEstimationDataset:
+    image_dir = tmp_path / "images"
+    depth_dir = tmp_path / "depth"
+    sky_dir = tmp_path / "sky"
+    for d in (image_dir, depth_dir, sky_dir):
+        d.mkdir()
+    Image.fromarray((np.random.rand(height, width, 3) * 255).astype(np.uint8)).save(
+        image_dir / "a.png"
+    )
+    np.save(depth_dir / "a.npy", np.random.rand(height, width).astype(np.float32) + 0.5)
+    Image.fromarray(
+        (np.random.rand(height, width) > 0.5).astype(np.uint8) * 255, mode="L"
+    ).save(sky_dir / "a.png")
+
+    data_args = DepthEstimationDataArgs(
+        train=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
+        val=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
+    )
+    dataset_args = data_args.get_train_args()
+    image_info = list(dataset_args.list_image_info())
+
+    transform_args = DepthEstimationTrainTransformArgs(image_size=(28, 28))
+    transform_args.resolve_auto(model_init_args={})
+    transform_args.resolve_incompatible()
+    return DepthEstimationDataset(
+        dataset_args=dataset_args,
+        image_info=image_info,
+        transform=DepthEstimationTrainTransform(transform_args=transform_args),
+    )
+
+
+class TestDepthEstimationDataset:
+    def test___getitem__(self, tmp_path: Path) -> None:
+        dataset = _make_dataset(tmp_path, height=40, width=50)
+
+        item = dataset[0]
+
+        assert item["image"].shape == (3, 28, 28)
+        assert item["depth"].shape == (1, 28, 28)
+        assert item["sky"].shape == (1, 28, 28)
+        assert item["image_path"].endswith("a.png")
+
+
+class TestDepthEstimationDataArgs:
+    def test_included_classes__empty(self, tmp_path: Path) -> None:
+        data_args = DepthEstimationDataArgs(
+            train=SplitArgs(images=tmp_path, depth=tmp_path, sky=tmp_path),
+            val=SplitArgs(images=tmp_path, depth=tmp_path, sky=tmp_path),
+        )
+
+        assert data_args.included_classes == {}
+
+    def test_list_image_info__skips_unpaired_images(self, tmp_path: Path) -> None:
+        image_dir = tmp_path / "images"
+        depth_dir = tmp_path / "depth"
+        sky_dir = tmp_path / "sky"
+        for d in (image_dir, depth_dir, sky_dir):
+            d.mkdir()
+        # Two images, but only one has matching depth and sky labels.
+        for name in ("a.png", "b.png"):
+            Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(image_dir / name)
+        np.save(depth_dir / "a.npy", np.ones((8, 8), dtype=np.float32))
+        Image.fromarray(np.zeros((8, 8), dtype=np.uint8), mode="L").save(
+            sky_dir / "a.png"
+        )
+
+        data_args = DepthEstimationDataArgs(
+            train=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
+            val=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
+        )
+        info = list(data_args.get_train_args().list_image_info())
+
+        assert len(info) == 1
+        assert info[0]["image_filepaths"].endswith("a.png")
+
+
+@pytest.mark.parametrize("missing", ["depth", "sky"])
+def test_depth_estimation_dataset___getitem___shape_mismatch(
+    tmp_path: Path, missing: str
+) -> None:
+    image_dir = tmp_path / "images"
+    depth_dir = tmp_path / "depth"
+    sky_dir = tmp_path / "sky"
+    for d in (image_dir, depth_dir, sky_dir):
+        d.mkdir()
+    Image.fromarray(np.zeros((16, 16, 3), dtype=np.uint8)).save(image_dir / "a.png")
+    # Write a mismatched label for the parametrized target.
+    depth_shape = (8, 8) if missing == "depth" else (16, 16)
+    sky_shape = (8, 8) if missing == "sky" else (16, 16)
+    np.save(depth_dir / "a.npy", np.ones(depth_shape, dtype=np.float32))
+    Image.fromarray(np.zeros(sky_shape, dtype=np.uint8), mode="L").save(
+        sky_dir / "a.png"
+    )
+
+    data_args = DepthEstimationDataArgs(
+        train=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
+        val=SplitArgs(images=image_dir, depth=depth_dir, sky=sky_dir),
+    )
+    dataset_args = data_args.get_train_args()
+    transform_args = DepthEstimationTrainTransformArgs(image_size=(16, 16))
+    transform_args.resolve_auto(model_init_args={})
+    transform_args.resolve_incompatible()
+    dataset = DepthEstimationDataset(
+        dataset_args=dataset_args,
+        image_info=list(dataset_args.list_image_info()),
+        transform=DepthEstimationTrainTransform(transform_args=transform_args),
+    )
+
+    with pytest.raises(ValueError, match="Shape mismatch"):
+        dataset[0]

--- a/tests/_metrics/depth_estimation/__init__.py
+++ b/tests/_metrics/depth_estimation/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/tests/_metrics/depth_estimation/test_task_metric.py
+++ b/tests/_metrics/depth_estimation/test_task_metric.py
@@ -1,0 +1,198 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import pytest
+import torch
+
+from lightly_train._metrics.depth_estimation.task_metric import (
+    DepthEstimationTaskMetric,
+    DepthEstimationTaskMetricArgs,
+)
+
+
+class TestDepthEstimationTaskMetric:
+    def test___init___watch_metric_mode_min_for_abs_rel(self) -> None:
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+        )
+
+        assert metric.watch_metric == "val_metric/abs_rel"
+        assert metric.watch_metric_mode == "min"
+
+    def test_compute_aggregated_values__perfect_prediction(self) -> None:
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+        )
+        preds = torch.rand(2, 1, 8, 8) + 1.0
+        target = preds.clone()
+
+        metric.update_with_predictions(preds, target)
+        metric.update_with_losses({"loss": torch.tensor(0.5)}, weight=2)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/rmse"] == 0.0
+        assert agg.metric_values["val_metric/abs_rel"] == 0.0
+        assert agg.metric_values["val_metric/delta1"] == 1.0
+        assert agg.watch_metric == "val_metric/abs_rel"
+        assert agg.watch_metric_mode == "min"
+
+    def test_update_with_predictions__scale_shift_invariant(self) -> None:
+        # A prediction that is a global affine transform of the target is a perfect
+        # relative-depth prediction: alignment must recover it and report zero error.
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+        )
+        target = torch.rand(1, 1, 8, 8) + 1.0
+        preds = 3.0 * target + 2.0
+
+        metric.update_with_predictions(preds, target)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/abs_rel"] == pytest.approx(0.0, abs=1e-5)
+        assert agg.metric_values["val_metric/rmse"] == pytest.approx(0.0, abs=1e-5)
+        assert agg.metric_values["val_metric/delta1"] == 1.0
+
+    def test_update_with_predictions__aligns_each_image_independently(self) -> None:
+        # Two images with different (target = affine of pred) relationships. A single
+        # batch-wide fit could not zero both; per-image alignment does.
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+        )
+        target = torch.rand(2, 1, 8, 8) + 1.0
+        preds = torch.empty_like(target)
+        preds[0] = 3.0 * target[0] + 2.0
+        preds[1] = 0.5 * target[1] - 1.0
+
+        metric.update_with_predictions(preds, target)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/abs_rel"] == pytest.approx(0.0, abs=1e-5)
+        assert agg.metric_values["val_metric/rmse"] == pytest.approx(0.0, abs=1e-5)
+
+    def test_update_with_predictions__no_alignment_penalizes_scale(self) -> None:
+        # For a metric model (align=False) a globally scaled/shifted prediction is NOT a
+        # perfect prediction: the raw error must be non-zero (contrast with the aligned
+        # `test_update_with_predictions__scale_shift_invariant`).
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+            align=False,
+        )
+        target = torch.rand(1, 1, 8, 8) + 1.0
+        preds = 3.0 * target + 2.0
+
+        metric.update_with_predictions(preds, target)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/abs_rel"] > 0.0
+        assert agg.metric_values["val_metric/rmse"] > 0.0
+
+    def test_update_with_predictions__no_alignment_perfect_prediction(self) -> None:
+        # A perfect metric prediction still yields zero error without alignment.
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+            align=False,
+        )
+        preds = torch.rand(2, 1, 8, 8) + 1.0
+        target = preds.clone()
+
+        metric.update_with_predictions(preds, target)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/abs_rel"] == pytest.approx(0.0, abs=1e-5)
+        assert agg.metric_values["val_metric/rmse"] == pytest.approx(0.0, abs=1e-5)
+        assert agg.metric_values["val_metric/delta1"] == 1.0
+
+    def test_update_with_predictions__aligned_diagnostic_for_metric(self) -> None:
+        # A metric model (align=False) also emits the aligned diagnostic variants. For a
+        # globally scaled/shifted prediction the primary (unaligned) error is non-zero but
+        # the aligned diagnostic recovers the affine transform and reports ~zero error.
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+            align=False,
+        )
+        target = torch.rand(1, 1, 8, 8) + 1.0
+        preds = 3.0 * target + 2.0
+
+        metric.update_with_predictions(preds, target)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/abs_rel"] > 0.0
+        assert agg.metric_values["val_metric/abs_rel_aligned"] == pytest.approx(
+            0.0, abs=1e-5
+        )
+        assert agg.metric_values["val_metric/rmse_aligned"] == pytest.approx(
+            0.0, abs=1e-5
+        )
+        assert agg.metric_values["val_metric/delta1_aligned"] == 1.0
+
+    def test_update_with_predictions__no_aligned_diagnostic_for_relative(self) -> None:
+        # Relative models (align=True) do not emit the aligned diagnostic keys: their
+        # primary metrics are already aligned.
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+        )
+        preds = torch.rand(1, 1, 8, 8) + 1.0
+        target = preds.clone()
+
+        metric.update_with_predictions(preds, target)
+        agg = metric.compute_aggregated_values()
+
+        assert "val_metric/abs_rel_aligned" not in agg.metric_values
+
+    def test_update_with_predictions__masks_invalid(self) -> None:
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="val",
+            loss_names=["loss"],
+        )
+        preds = torch.rand(1, 1, 8, 8) + 1.0
+        target = preds.clone()
+        # Mark half the pixels invalid and corrupt the prediction there.
+        target[:, :, :4, :] = 0.0
+        preds_corrupt = preds.clone()
+        preds_corrupt[:, :, :4, :] = 999.0
+
+        metric.update_with_predictions(preds_corrupt, target)
+        agg = metric.compute_aggregated_values()
+
+        assert agg.metric_values["val_metric/rmse"] == 0.0
+
+    def test_update_with_predictions__not_computed_for_train_by_default(self) -> None:
+        # By default the train split does not compute quality metrics, only losses.
+        metric = DepthEstimationTaskMetric(
+            task_metric_args=DepthEstimationTaskMetricArgs(),
+            split="train",
+            loss_names=["loss"],
+            train_loss_running_mean_window=1,
+        )
+        preds = torch.rand(1, 1, 8, 8) + 1.0
+        target = torch.rand(1, 1, 8, 8) + 1.0
+
+        metric.update_with_predictions(preds, target)
+        metric.update_with_losses({"loss": torch.tensor(0.5)}, weight=1)
+        agg = metric.compute_aggregated_values()
+
+        assert "train_metric/rmse" not in agg.metric_values
+        assert "train_loss" in agg.metric_values

--- a/tests/_task_models/depth_estimation/test_criterion.py
+++ b/tests/_task_models/depth_estimation/test_criterion.py
@@ -1,0 +1,176 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import pytest
+import torch
+
+from lightly_train._task_models.depth_estimation.criterion import (
+    GradientMatchingLoss,
+    RelativeL1Loss,
+    SILogLoss,
+    SkyDistillLoss,
+)
+
+
+class TestSILogLoss:
+    def test_forward__zero_when_pred_equals_target(self) -> None:
+        pred = torch.rand(2, 1, 8, 8) + 0.5
+        target = pred.clone()
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = SILogLoss(eps=0.0)(pred, target, mask)
+
+        assert float(loss) == 0.0
+
+    def test_forward__ignores_invalid_pixels(self) -> None:
+        # Garbage predictions in the invalid region must not change the loss.
+        pred = torch.rand(1, 1, 4, 4) + 0.5
+        target = pred.clone()
+        target[:, :, :2, :] = 0.0  # Mark the top half invalid.
+        mask = target > 0
+        pred_garbage = pred.clone()
+        pred_garbage[:, :, :2, :] = 999.0
+
+        loss = SILogLoss(eps=0.0)(pred_garbage, target, mask)
+
+        assert float(loss) == 0.0
+
+    def test_forward__all_invalid_returns_finite_with_grad(self) -> None:
+        pred = (torch.rand(1, 1, 4, 4) + 0.5).requires_grad_()
+        target = torch.zeros(1, 1, 4, 4)
+        mask = target > 0
+
+        loss = SILogLoss()(pred, target, mask)
+
+        assert torch.isfinite(loss)
+        assert loss.requires_grad
+        assert float(loss.detach()) == 0.0
+
+    def test_forward__positive_for_mismatch(self) -> None:
+        pred = torch.rand(2, 1, 8, 8) + 0.5
+        target = torch.rand(2, 1, 8, 8) + 0.5
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = SILogLoss()(pred, target, mask)
+
+        assert float(loss) > 0.0
+
+    def test_forward__scale_invariant_when_lambd_one(self) -> None:
+        # With full scale-invariance, scaling the prediction by a global factor must not
+        # change the loss (used by the relative-depth student).
+        pred = torch.rand(2, 1, 8, 8) + 0.5
+        target = torch.rand(2, 1, 8, 8) + 0.5
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = SILogLoss(lambd=1.0, eps=0.0)(pred, target, mask)
+        loss_scaled = SILogLoss(lambd=1.0, eps=0.0)(pred * 3.0, target, mask)
+
+        assert float(loss_scaled) == pytest.approx(float(loss), abs=1e-6)
+
+    def test_forward__scale_aware_when_lambd_zero(self) -> None:
+        # With lambd=0 (log-space L2, used by the metric-depth student) scaling the
+        # prediction by a global factor changes the loss.
+        pred = torch.rand(2, 1, 8, 8) + 0.5
+        target = torch.rand(2, 1, 8, 8) + 0.5
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = SILogLoss(lambd=0.0, eps=0.0)(pred, target, mask)
+        loss_scaled = SILogLoss(lambd=0.0, eps=0.0)(pred * 3.0, target, mask)
+
+        assert float(loss_scaled) != pytest.approx(float(loss), abs=1e-3)
+
+
+class TestGradientMatchingLoss:
+    def test_forward__zero_when_pred_equals_target(self) -> None:
+        pred = torch.rand(2, 1, 16, 16) + 0.5
+        target = pred.clone()
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = GradientMatchingLoss()(pred, target, mask)
+
+        assert float(loss) == 0.0
+
+    def test_forward__penalizes_edge_mismatch(self) -> None:
+        # A sharp edge in the prediction that is absent in a flat target is penalized.
+        target = torch.ones(1, 1, 8, 8)
+        pred = torch.ones(1, 1, 8, 8)
+        pred[:, :, :, 4:] = 3.0
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = GradientMatchingLoss()(pred, target, mask)
+
+        assert float(loss) > 0.0
+
+
+class TestSkyDistillLoss:
+    def test_forward__low_for_perfect_match(self) -> None:
+        sky = torch.rand(2, 1, 8, 8)
+
+        loss_match = SkyDistillLoss()(sky, sky)
+        loss_mismatch = SkyDistillLoss()(sky, 1.0 - sky)
+
+        assert float(loss_match) < float(loss_mismatch)
+
+
+class TestRelativeL1Loss:
+    def test_forward__zero_when_pred_equals_target(self) -> None:
+        pred = torch.rand(2, 1, 8, 8) + 0.5
+        target = pred.clone()
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = RelativeL1Loss(eps=0.0)(pred, target, mask)
+
+        assert float(loss) == 0.0
+
+    def test_forward__equals_mean_relative_error(self) -> None:
+        # The loss is exactly mean(|pred - target| / target). A prediction that is a
+        # uniform factor of the target has relative error equal to that factor minus one.
+        target = torch.rand(2, 1, 8, 8) + 0.5
+        pred = 1.5 * target
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = RelativeL1Loss(eps=0.0)(pred, target, mask)
+
+        assert float(loss) == pytest.approx(0.5, abs=1e-6)
+
+    def test_forward__ignores_invalid_pixels(self) -> None:
+        # Garbage predictions in the invalid region must not change the loss.
+        pred = torch.rand(1, 1, 4, 4) + 0.5
+        target = pred.clone()
+        target[:, :, :2, :] = 0.0  # Mark the top half invalid.
+        mask = target > 0
+        pred_garbage = pred.clone()
+        pred_garbage[:, :, :2, :] = 999.0
+
+        loss = RelativeL1Loss(eps=0.0)(pred_garbage, target, mask)
+
+        assert float(loss) == 0.0
+
+    def test_forward__all_invalid_returns_finite_with_grad(self) -> None:
+        pred = (torch.rand(1, 1, 4, 4) + 0.5).requires_grad_()
+        target = torch.zeros(1, 1, 4, 4)
+        mask = target > 0
+
+        loss = RelativeL1Loss()(pred, target, mask)
+
+        assert torch.isfinite(loss)
+        assert loss.requires_grad
+        assert float(loss.detach()) == 0.0
+
+    def test_forward__scale_aware(self) -> None:
+        # Unlike the scale-invariant SILog and gradient terms, scaling the prediction by
+        # a global factor must change this loss (this is what pins the metric scale).
+        pred = torch.rand(2, 1, 8, 8) + 0.5
+        target = torch.rand(2, 1, 8, 8) + 0.5
+        mask = torch.ones_like(pred, dtype=torch.bool)
+
+        loss = RelativeL1Loss(eps=0.0)(pred, target, mask)
+        loss_scaled = RelativeL1Loss(eps=0.0)(pred * 3.0, target, mask)
+
+        assert float(loss_scaled) != pytest.approx(float(loss), abs=1e-3)

--- a/tests/_task_models/depth_estimation/test_task_model.py
+++ b/tests/_task_models/depth_estimation/test_task_model.py
@@ -20,20 +20,19 @@ from lightly_train._task_models.depth_estimation.task_model import (
     DepthAnythingDepthEstimation,
 )
 
+
 # Tiny per-variant model args so inference runs at a small resolution and tests stay
 # fast. DAv3 variants carry `use_sky_head` inside `model_args` exactly as the exported
 # checkpoints do; DAv2 metric variants carry `max_depth`.
-_TINY_BASE: dict[str, Any] = {
-    "out_layers": (0, 1, 2, 3),
-    "image_size": 56,
-    "patch_size": 14,
-    "features": 16,
-    "out_channels": (8, 16, 32, 32),
-}
-
-
 def _tiny_model_args(model_name: str) -> dict[str, Any]:
-    args = dict(_TINY_BASE)
+    patch_size = 16 if model_name.startswith("dinov3/") else 14
+    args: dict[str, Any] = {
+        "out_layers": (0, 1, 2, 3),
+        "image_size": patch_size * 4,
+        "patch_size": patch_size,
+        "features": 16,
+        "out_channels": (8, 16, 32, 32),
+    }
     if "metric" in model_name and "dav2" in model_name:
         args["max_depth"] = 20.0
     if "dav3" in model_name:
@@ -50,7 +49,7 @@ def _build(model_name: str, **overrides: Any) -> DepthAnythingDepthEstimation:
     )
     # Production fixes the image size per model; override it here so inference runs
     # at a tiny resolution and the tests stay fast.
-    model.image_size = 56
+    model.image_size = int(model_args["image_size"])
     return model
 
 
@@ -59,7 +58,7 @@ def _build(model_name: str, **overrides: Any) -> DepthAnythingDepthEstimation:
 # instead of the large (~303M) one to stay fast. The sky head is a decoder feature
 # toggled via `model_args`, so a single small backbone covers both export output sets.
 def _build_for_export(*, use_sky_head: bool) -> DepthAnythingDepthEstimation:
-    model_args = dict(_TINY_BASE)
+    model_args = _tiny_model_args("dinov2/dav2-relative-small")
     model_args["use_sky_head"] = use_sky_head
     model = DepthAnythingDepthEstimation(
         model_name="dinov2/dav2-relative-small",
@@ -75,9 +74,16 @@ _NON_FOCAL_NAMES = [
     "dinov2/dav2-relative-large",
     "dinov2/dav2-metric-large-hypersim",
     "dinov2/dav3-relative-large",
+    "dinov3/dav3-relative-tiny",
+    "dinov3/dav3-relative-tiny-plus",
 ]
 # Model names with a sky head (DAv3).
-_SKY_NAMES = ["dinov2/dav3-relative-large", "dinov2/dav3-metric-large"]
+_SKY_NAMES = [
+    "dinov2/dav3-relative-large",
+    "dinov2/dav3-metric-large",
+    "dinov3/dav3-relative-tiny",
+    "dinov3/dav3-relative-tiny-plus",
+]
 _NO_SKY_NAMES = ["dinov2/dav2-relative-large", "dinov2/dav2-metric-large-hypersim"]
 
 
@@ -180,6 +186,23 @@ class TestDepthAnythingDepthEstimation:
         assert torch.equal(metric_doubled[0], metric[0] * 2.0)
         assert torch.equal(metric_doubled[1], metric[1] * 2.0)
 
+    def test_list_model_names__includes_metric_small(self) -> None:
+        # The trainable metric student must be registered so it routes to the depth
+        # train model and is a valid `model` for `train_depth_estimation`.
+        assert (
+            "dinov2/dav3-metric-small"
+            in DepthAnythingDepthEstimation.list_model_names()
+        )
+
+    def test_predict__intrinsics_required_for_metric_small(self) -> None:
+        # The metric-small student is `scale_mode="focal"`, so it requires intrinsics
+        # exactly like the metric-large model.
+        model = _build("dinov2/dav3-metric-small")
+        image = Image.new("RGB", (56, 56), color=(32, 64, 128))
+
+        with pytest.raises(ValueError, match="requires per-image camera intrinsics"):
+            model.predict(image)
+
     def test_predict__intrinsics_required_for_focal_model(self) -> None:
         model = _build("dinov2/dav3-metric-large")
         image = Image.new("RGB", (56, 56), color=(32, 64, 128))
@@ -203,25 +226,27 @@ class TestDepthAnythingDepthEstimation:
     @pytest.mark.parametrize("model_name", _NO_SKY_NAMES)
     def test_forward__returns_depth(self, model_name: str) -> None:
         model = _build(model_name)
-        x = torch.randn(2, 3, 56, 70)
+        patch_size = model.patch_size
+        x = torch.randn(2, 3, patch_size * 4, patch_size * 5)
 
         out = model(x)
 
         # Depth Anything V2 has no sky head, so the forward output is (depth,) only.
         assert len(out) == 1
-        assert out[0].shape == (2, 1, 56, 70)
+        assert out[0].shape == (2, 1, patch_size * 4, patch_size * 5)
 
     @pytest.mark.parametrize("model_name", _SKY_NAMES)
     def test_forward__returns_depth_and_sky(self, model_name: str) -> None:
         model = _build(model_name)
-        x = torch.randn(2, 3, 56, 70)
+        patch_size = model.patch_size
+        x = torch.randn(2, 3, patch_size * 4, patch_size * 5)
 
         out = model(x)
 
         # A model with a sky head (DAv3) returns (depth, sky) in that order.
         depth, sky = out
-        assert depth.shape == (2, 1, 56, 70)
-        assert sky.shape == (2, 1, 56, 70)
+        assert depth.shape == (2, 1, patch_size * 4, patch_size * 5)
+        assert sky.shape == (2, 1, patch_size * 4, patch_size * 5)
 
     @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
     @pytest.mark.skipif(

--- a/tests/_task_models/depth_estimation/test_train_model.py
+++ b/tests/_task_models/depth_estimation/test_train_model.py
@@ -1,0 +1,374 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import Tensor
+
+from lightly_train._data.depth_estimation_dataset import (
+    DepthEstimationDataArgs,
+    SplitArgs,
+)
+from lightly_train._metrics.depth_estimation.task_metric import (
+    DepthEstimationTaskMetricArgs,
+)
+from lightly_train._task_models.depth_estimation.train_model import (
+    DepthEstimationTrain,
+    DepthEstimationTrainArgs,
+)
+from lightly_train._task_models.depth_estimation.transforms import (
+    DepthEstimationTrainTransformArgs,
+    DepthEstimationValTransformArgs,
+)
+from lightly_train.types import DepthEstimationBatch
+
+# Test-only V3 configs: real ViT-S backbone with a tiny DPT head and a 70px processing
+# resolution so depth fine-tuning runs fast on CPU. The metric variant only differs by
+# `scale_mode="focal"`, which switches on the scale-aware loss branch.
+_MODEL_NAME = "dinov2/_vittest14-dav3"
+_METRIC_MODEL_NAME = "dinov2/_vittest14-dav3-metric"
+
+
+def _make_train_model(
+    model_name: str = _MODEL_NAME,
+    *,
+    use_ema: bool = False,
+    abs_l1_loss_weight: float = 0.0,
+) -> DepthEstimationTrain:
+    data_args = DepthEstimationDataArgs(
+        train=SplitArgs(
+            images="/tmp/train/images", depth="/tmp/train/depth", sky="/tmp/train/sky"
+        ),
+        val=SplitArgs(
+            images="/tmp/val/images", depth="/tmp/val/depth", sky="/tmp/val/sky"
+        ),
+    )
+    train_transform_args = DepthEstimationTrainTransformArgs()
+    train_transform_args.resolve_auto(model_init_args={"model_name": model_name})
+    val_transform_args = DepthEstimationValTransformArgs()
+    val_transform_args.resolve_auto(model_init_args={"model_name": model_name})
+    model_args = DepthEstimationTrainArgs(
+        use_ema=use_ema, abs_l1_loss_weight=abs_l1_loss_weight
+    )
+    model_args.resolve_auto(
+        total_steps=10,
+        gradient_accumulation_steps=1,
+        train_num_batches=4,
+        model_name=model_name,
+        model_init_args={},
+        data_args=data_args,
+    )
+    return DepthEstimationTrain(
+        model_name=model_name,
+        model_args=model_args,
+        data_args=data_args,
+        train_transform_args=train_transform_args,
+        val_transform_args=val_transform_args,
+        load_weights=False,
+        metric_args=DepthEstimationTaskMetricArgs(),
+        gradient_accumulation_steps=1,
+    )
+
+
+def _make_batch(*, sky_depth_value: float) -> DepthEstimationBatch:
+    """Builds a fixed (B=1) batch whose top half is sky.
+
+    The sky region of the depth target is filled with ``sky_depth_value`` so a test can
+    vary only the (garbage) sky depth while everything else stays identical.
+    """
+    h = w = 70
+    image = torch.zeros(1, 3, h, w)
+    depth = torch.ones(1, 1, h, w)  # Valid positive depth everywhere.
+    sky = torch.zeros(1, 1, h, w)
+    sky[:, :, : h // 2, :] = 1.0  # Top half is sky.
+    depth[:, :, : h // 2, :] = sky_depth_value
+    return {
+        "image_path": ["0.png"],
+        "image": image,
+        "depth": depth,
+        "sky": sky,
+    }
+
+
+class TestDepthEstimationTrain:
+    def test__step__sky_depth_excluded_from_loss(self) -> None:
+        # The depth in sky regions is garbage, so it must not affect the depth losses.
+        # Two batches that differ only in the sky-region depth value must produce the
+        # same loss. The model is in eval mode with fixed weights, so the forward pass
+        # is deterministic.
+        train_model = _make_train_model()
+        train_model.eval()
+        metrics = train_model.val_metrics
+
+        with torch.no_grad():
+            result_a = train_model._step(
+                model=train_model.model,
+                batch=_make_batch(sky_depth_value=1e3),
+                metrics=metrics,
+                compute_metrics=False,
+            )
+            result_b = train_model._step(
+                model=train_model.model,
+                batch=_make_batch(sky_depth_value=1e-3),
+                metrics=metrics,
+                compute_metrics=False,
+            )
+
+        assert torch.equal(result_a.loss, result_b.loss)
+
+    def test__step__non_sky_depth_changes_loss(self) -> None:
+        # Sanity check that the loss is not trivially constant: changing the depth in the
+        # valid (non-sky) region must change the loss.
+        train_model = _make_train_model()
+        train_model.eval()
+        metrics = train_model.val_metrics
+
+        batch = _make_batch(sky_depth_value=1.0)
+        batch_changed = _make_batch(sky_depth_value=1.0)
+        # Perturb the non-sky (bottom half) depth, which is included in the loss.
+        assert isinstance(batch_changed["depth"], torch.Tensor)
+        batch_changed["depth"][:, :, 35:, :] = 5.0
+
+        with torch.no_grad():
+            result = train_model._step(
+                model=train_model.model,
+                batch=batch,
+                metrics=metrics,
+                compute_metrics=False,
+            )
+            result_changed = train_model._step(
+                model=train_model.model,
+                batch=batch_changed,
+                metrics=metrics,
+                compute_metrics=False,
+            )
+
+        assert not torch.equal(result.loss, result_changed.loss)
+
+
+class TestDepthEstimationTrainMetric:
+    def test___init___relative_is_scale_invariant(self) -> None:
+        # The relative student keeps the scale-invariant SILog (default lambd) and the
+        # scale-and-shift-aligned validation metric.
+        train_model = _make_train_model(_MODEL_NAME)
+
+        assert train_model._is_metric is False
+        assert train_model.silog_criterion.lambd == train_model.model_args.silog_lambda
+        assert train_model.val_metrics.metrics.align is True
+
+    def test___init___metric_is_scale_aware(self) -> None:
+        # The metric student switches SILog to scale-aware (lambd=0, i.e. log-space L2)
+        # and turns off metric alignment so the metrics reflect true metric accuracy.
+        train_model = _make_train_model(_METRIC_MODEL_NAME)
+
+        assert train_model._is_metric is True
+        assert train_model.silog_criterion.lambd == 0.0
+        assert train_model.val_metrics.metrics.align is False
+        assert train_model.train_metrics.metrics.align is False
+
+    def test__step__metric_loss_is_scale_aware(self) -> None:
+        # For a metric model, scaling the prediction by a global factor must change the
+        # loss (the opposite of the relative, scale-invariant case). The prediction is
+        # scaled by scaling the target instead: with fixed eval weights the forward pass
+        # is deterministic, so a target scaled by a constant is not free to be absorbed.
+        train_model = _make_train_model(_METRIC_MODEL_NAME)
+        train_model.eval()
+        metrics = train_model.val_metrics
+
+        batch = _make_batch(sky_depth_value=1.0)
+        batch_scaled = _make_batch(sky_depth_value=1.0)
+        assert isinstance(batch_scaled["depth"], torch.Tensor)
+        # Scale only the valid (non-sky) region so the depth loss sees the scale change.
+        batch_scaled["depth"][:, :, 35:, :] *= 4.0
+
+        with torch.no_grad():
+            result = train_model._step(
+                model=train_model.model,
+                batch=batch,
+                metrics=metrics,
+                compute_metrics=False,
+            )
+            result_scaled = train_model._step(
+                model=train_model.model,
+                batch=batch_scaled,
+                metrics=metrics,
+                compute_metrics=False,
+            )
+
+        assert torch.isfinite(result.loss)
+        assert not torch.equal(result.loss, result_scaled.loss)
+
+    def test__step__abs_l1_term_added_only_for_metric(self) -> None:
+        # The relative-L1 term is added to the total loss for a metric model with a
+        # positive weight, and its per-pixel value is logged in every case.
+        base = _make_train_model(_METRIC_MODEL_NAME, abs_l1_loss_weight=0.0)
+        weighted = _make_train_model(_METRIC_MODEL_NAME, abs_l1_loss_weight=1.0)
+        # Share weights so the two models produce the same forward pass, isolating the
+        # loss-composition difference.
+        weighted.model.load_state_dict(base.model.state_dict())
+        base.eval()
+        weighted.eval()
+        batch = _make_batch(sky_depth_value=1.0)
+        image = batch["image"]
+        depth = batch["depth"]
+        sky = batch["sky"]
+        assert isinstance(image, Tensor)
+        assert isinstance(depth, Tensor)
+        assert isinstance(sky, Tensor)
+
+        with torch.no_grad():
+            result_base = base._step(
+                model=base.model,
+                batch=batch,
+                metrics=base.val_metrics,
+                compute_metrics=False,
+            )
+            result_weighted = weighted._step(
+                model=weighted.model,
+                batch=batch,
+                metrics=weighted.val_metrics,
+                compute_metrics=False,
+            )
+
+        # With a positive weight the metric total loss is larger by exactly the term.
+        abs_l1 = weighted.abs_l1_criterion(
+            weighted._forward(model=weighted.model, images=image)["depth"],
+            depth,
+            (depth > 0) & (sky < 0.5),
+        ).detach()
+        assert float(abs_l1) > 0.0
+        assert float(result_weighted.loss) == pytest.approx(
+            float(result_base.loss) + float(abs_l1), abs=1e-5
+        )
+
+    def test__step__abs_l1_term_not_applied_for_relative(self) -> None:
+        # For a relative model the AbsRel term is removed entirely: a positive weight does
+        # not change the total loss and the logged abs_l1_loss stays 0.
+        base = _make_train_model(_MODEL_NAME, abs_l1_loss_weight=0.0)
+        weighted = _make_train_model(_MODEL_NAME, abs_l1_loss_weight=1.0)
+        # Share weights so the two models produce the same forward pass, isolating the
+        # loss-composition difference.
+        weighted.model.load_state_dict(base.model.state_dict())
+        base.eval()
+        weighted.eval()
+        batch = _make_batch(sky_depth_value=1.0)
+        image = batch["image"]
+        depth = batch["depth"]
+        sky = batch["sky"]
+        assert isinstance(image, Tensor)
+        assert isinstance(depth, Tensor)
+        assert isinstance(sky, Tensor)
+
+        with torch.no_grad():
+            result_base = base._step(
+                model=base.model,
+                batch=batch,
+                metrics=base.val_metrics,
+                compute_metrics=False,
+            )
+            result_weighted = weighted._step(
+                model=weighted.model,
+                batch=batch,
+                metrics=weighted.val_metrics,
+                compute_metrics=False,
+            )
+
+        # A positive weight leaves the relative total loss unchanged: the term is not added.
+        assert float(result_weighted.loss) == pytest.approx(
+            float(result_base.loss), abs=1e-5
+        )
+        # The logged abs_l1_loss is a constant 0 for relative models.
+        assert (
+            weighted.val_metrics.loss_metrics.compute()["val_loss/abs_l1_loss"] == 0.0
+        )
+
+
+class TestDepthEstimationTrainEMA:
+    def test___init___ema_disabled_by_default(self) -> None:
+        train_model = _make_train_model()
+
+        assert train_model.ema_model is None
+        # With EMA off, get_task_model returns the live model and the export has no
+        # ema_model keys.
+        assert train_model.get_task_model() is train_model.model
+        assert not any(
+            k.startswith("ema_model.") for k in train_model.get_export_state_dict()
+        )
+
+    def test___init___ema_enabled(self) -> None:
+        train_model = _make_train_model(use_ema=True)
+
+        assert train_model.ema_model is not None
+        # Inference/export use the EMA model when enabled.
+        assert train_model.get_task_model() is train_model.ema_model.model
+
+    def test_on_train_batch_end__updates_ema_toward_live_weights(self) -> None:
+        # After a live-weight change, an EMA update must move the shadow toward the live
+        # weights (but not all the way, since decay < 1).
+        train_model = _make_train_model(use_ema=True)
+        assert train_model.ema_model is not None
+
+        # Pick a representative decoder weight and force live/EMA apart.
+        (name, live_param) = next(
+            (n, p) for n, p in train_model.model.named_parameters()
+        )
+        with torch.no_grad():
+            live_param.add_(1.0)
+        ema_param = dict(train_model.ema_model.model.named_parameters())[name]
+        before = ema_param.clone()
+        assert not torch.allclose(before, live_param)
+
+        train_model.on_train_batch_end()
+
+        # The EMA weight moved toward the (larger) live weight but did not reach it.
+        assert torch.all(ema_param >= before)
+        assert not torch.allclose(ema_param, live_param)
+
+    def test_get_export_state_dict__holds_ema_weights_under_normal_keys(self) -> None:
+        # The export must contain the EMA weights, stored under the live-model `model.`
+        # keys, with no `ema_model.` keys — indistinguishable from a non-EMA export.
+        train_model = _make_train_model(use_ema=True)
+        assert train_model.ema_model is not None
+
+        # Drive live and EMA apart so the two weight sets are distinguishable.
+        with torch.no_grad():
+            for p in train_model.model.parameters():
+                p.add_(1.0)
+
+        export = train_model.get_export_state_dict()
+
+        assert not any(k.startswith("ema_model.") for k in export)
+        ema_sd = train_model.ema_model.model.state_dict()
+        live_sd = train_model.model.state_dict()
+        # A representative weight in the export matches the EMA value, not the live value.
+        key = "model.decoder.scratch.output_conv1.weight"
+        assert torch.equal(export[key], ema_sd["decoder.scratch.output_conv1.weight"])
+        assert not torch.equal(
+            export[key], live_sd["decoder.scratch.output_conv1.weight"]
+        )
+
+    def test_load_train_state_dict__seeds_ema_from_ema_free_checkpoint(self) -> None:
+        # Loading an export/relative checkpoint (which has no ema_model. keys) into an
+        # EMA-enabled model must succeed and seed the EMA shadow from the loaded weights.
+        # This is the metric-fine-tune-from-a-relative-checkpoint path.
+        source = _make_train_model()  # EMA off -> export has no ema_model keys.
+        with torch.no_grad():
+            for p in source.model.parameters():
+                p.add_(0.5)
+        export = source.get_export_state_dict()
+        assert not any(k.startswith("ema_model.") for k in export)
+
+        target = _make_train_model(use_ema=True)
+        target.load_train_state_dict(export, strict=True)
+
+        assert target.ema_model is not None
+        # Live model loaded from the checkpoint, and the EMA shadow was seeded to match.
+        for name, live_p in target.model.named_parameters():
+            ema_p = dict(target.ema_model.model.named_parameters())[name]
+            assert torch.equal(live_p, ema_p)

--- a/tests/_transforms/test_depth_estimation_transform.py
+++ b/tests/_transforms/test_depth_estimation_transform.py
@@ -1,0 +1,156 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lightly_train._task_models.depth_estimation import transforms
+from lightly_train._task_models.depth_estimation.transforms import (
+    DepthEstimationColorJitterArgs,
+    DepthEstimationGaussianBlurArgs,
+    DepthEstimationTrainTransform,
+    DepthEstimationTrainTransformArgs,
+    DepthEstimationValTransformArgs,
+)
+from lightly_train._transforms.transform import (
+    ColorJitterArgs,
+    GaussianBlurArgs,
+    RandomCropArgs,
+    RandomFlipArgs,
+)
+
+
+def _build_transform(
+    *,
+    image_size: tuple[int, int] = (28, 28),
+    random_flip: RandomFlipArgs | None = None,
+    random_crop: RandomCropArgs | None = None,
+    color_jitter: ColorJitterArgs | None = None,
+    gaussian_blur: GaussianBlurArgs | None = None,
+    random_gray_scale: float | None = None,
+) -> DepthEstimationTrainTransform:
+    args = DepthEstimationTrainTransformArgs(
+        image_size=image_size,
+        random_flip=random_flip,
+        random_crop=random_crop,
+        color_jitter=color_jitter,
+        gaussian_blur=gaussian_blur,
+        random_gray_scale=random_gray_scale,
+    )
+    args.resolve_auto(model_init_args={})
+    args.resolve_incompatible()
+    return DepthEstimationTrainTransform(transform_args=args)
+
+
+class TestDepthEstimationTransform:
+    def test___call___hflip_syncs_image_depth_sky(self) -> None:
+        # With a guaranteed horizontal flip, image, depth and sky must all be flipped.
+        transform = _build_transform(
+            image_size=(28, 28),
+            random_flip=RandomFlipArgs(horizontal_prob=1.0, vertical_prob=0.0),
+        )
+        image = (np.random.rand(28, 28, 3) * 255).astype(np.uint8)
+        depth = np.arange(28 * 28, dtype=np.float32).reshape(28, 28)
+        sky = (np.arange(28 * 28, dtype=np.float32).reshape(28, 28) / (28 * 28)).astype(
+            np.float32
+        )
+
+        out = transform({"image": image, "depth": depth, "sky": sky})
+
+        expected_depth = np.ascontiguousarray(depth[:, ::-1])
+        expected_sky = np.ascontiguousarray(sky[:, ::-1])
+        assert np.allclose(out["depth"][0].numpy(), expected_depth)
+        assert np.allclose(out["sky"][0].numpy(), expected_sky)
+
+    def test___call___random_crop_syncs_image_depth_sky(self) -> None:
+        transform = _build_transform(
+            image_size=(28, 28),
+            random_crop=RandomCropArgs(
+                height=14,
+                width=14,
+                pad_position="center",
+                pad_if_needed=True,
+                fill=0.0,
+                prob=1.0,
+            ),
+        )
+        image = (np.random.rand(28, 28, 3) * 255).astype(np.uint8)
+        depth = np.random.rand(28, 28).astype(np.float32) + 0.5
+        sky = np.random.rand(28, 28).astype(np.float32)
+
+        out = transform({"image": image, "depth": depth, "sky": sky})
+
+        assert out["image"].shape == (3, 14, 14)
+        assert out["depth"].shape == (1, 14, 14)
+        assert out["sky"].shape == (1, 14, 14)
+
+    def test___call___depth_and_sky_not_normalized(self) -> None:
+        # Normalize only applies to the image; depth and sky pass through unchanged
+        # (up to the resize, which here is a no-op since input already matches).
+        transform = _build_transform(image_size=(28, 28))
+        image = np.full((28, 28, 3), 128, dtype=np.uint8)
+        depth = np.full((28, 28), 5.0, dtype=np.float32)
+        sky = np.full((28, 28), 0.7, dtype=np.float32)
+
+        out = transform({"image": image, "depth": depth, "sky": sky})
+
+        # Depth and sky keep their original values.
+        assert np.allclose(out["depth"].numpy(), 5.0)
+        assert np.allclose(out["sky"].numpy(), 0.7)
+        # The image is normalized, so its values are no longer the raw 128/255.
+        assert not np.allclose(out["image"].numpy(), 128.0 / 255.0)
+
+    def test___call___photometric_augments_image_only(self) -> None:
+        # Photometric augmentations must change the image but never the depth or sky
+        # labels, since those are mask targets. Run with guaranteed color jitter, blur
+        # and grayscale, and compare against the same seed with photometrics disabled.
+        image = (np.random.rand(28, 28, 3) * 255).astype(np.uint8)
+        depth = np.random.rand(28, 28).astype(np.float32) + 0.5
+        sky = np.random.rand(28, 28).astype(np.float32)
+
+        clean = _build_transform(image_size=(28, 28))
+        augmented = _build_transform(
+            image_size=(28, 28),
+            color_jitter=DepthEstimationColorJitterArgs(prob=1.0),
+            gaussian_blur=DepthEstimationGaussianBlurArgs(prob=1.0),
+            random_gray_scale=1.0,
+        )
+
+        np.random.seed(0)
+        out_clean = clean({"image": image, "depth": depth, "sky": sky})
+        np.random.seed(0)
+        out_aug = augmented({"image": image, "depth": depth, "sky": sky})
+
+        # The image is modified by the photometric ops.
+        assert not np.allclose(out_aug["image"].numpy(), out_clean["image"].numpy())
+        # Depth and sky are bit-identical: photometric ops never touch mask targets.
+        assert np.array_equal(out_aug["depth"].numpy(), out_clean["depth"].numpy())
+        assert np.array_equal(out_aug["sky"].numpy(), out_clean["sky"].numpy())
+
+
+def test__resolve_depth_transform_auto__multiple_of_patch_size() -> None:
+    # The base 504x504 and a non-square size from the paper both resolve without error.
+    for image_size in [(504, 504), (504, 378)]:
+        args = DepthEstimationTrainTransformArgs(image_size=image_size)
+        transforms._resolve_depth_transform_auto(args, model_init_args={})
+        assert args.image_size == image_size
+
+
+def test__resolve_depth_transform_auto__rejects_non_multiple_of_patch_size() -> None:
+    args = DepthEstimationTrainTransformArgs(image_size=(500, 500))
+    with pytest.raises(ValueError, match="must be a multiple of the patch size 14"):
+        transforms._resolve_depth_transform_auto(args, model_init_args={})
+
+
+def test_DepthEstimationValTransformArgs__no_photometric_augmentation() -> None:
+    # Validation must run on clean images so metrics reflect true depth accuracy.
+    args = DepthEstimationValTransformArgs(image_size=(28, 28))
+    assert args.color_jitter is None
+    assert args.gaussian_blur is None
+    assert args.random_gray_scale is None

--- a/tests/_visualize/test_depth_estimation.py
+++ b/tests/_visualize/test_depth_estimation.py
@@ -18,8 +18,8 @@ from lightly_train.types import DepthEstimationBatch
 
 def _far_pixel() -> tuple[int, int, int]:
     # Non-positive depth is rendered with the low end of the active colormap.
-    rgb = matplotlib.colormaps[depth_estimation._DEPTH_COLORMAP](0.0)[:3]
-    return tuple(int(channel * 255) for channel in rgb)
+    r, g, b = matplotlib.colormaps[depth_estimation._DEPTH_COLORMAP](0.0)[:3]
+    return int(r * 255), int(g * 255), int(b * 255)
 
 
 def _make_batch(*, depth: Tensor, sky: Tensor) -> DepthEstimationBatch:

--- a/tests/_visualize/test_depth_estimation.py
+++ b/tests/_visualize/test_depth_estimation.py
@@ -1,0 +1,138 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import matplotlib
+import torch
+from PIL import ImageChops
+from torch import Tensor
+
+from lightly_train._visualize import depth_estimation
+from lightly_train.types import DepthEstimationBatch
+
+
+def _far_pixel() -> tuple[int, int, int]:
+    # Non-positive depth is rendered with the low end of the active colormap.
+    rgb = matplotlib.colormaps[depth_estimation._DEPTH_COLORMAP](0.0)[:3]
+    return tuple(int(channel * 255) for channel in rgb)
+
+
+def _make_batch(*, depth: Tensor, sky: Tensor) -> DepthEstimationBatch:
+    batch_size, _, height, width = depth.shape
+    return DepthEstimationBatch(
+        image_path=[f"img_{i}.png" for i in range(batch_size)],
+        image=torch.zeros(batch_size, 3, height, width),
+        depth=depth,
+        sky=sky,
+    )
+
+
+def test_plot_depth_labels__sky_does_not_affect_non_sky_colors() -> None:
+    # The depth in sky regions is garbage. Two label images that differ only in the
+    # sky-region depth must render identically in the non-sky region: if sky leaked into
+    # the min-max normalization, its extreme value would recolor every non-sky pixel.
+    depth = torch.ones(1, 1, 32, 32)
+    depth[:, :, :16, :] = 50.0  # Garbage in the top-half sky region.
+    sky = torch.zeros(1, 1, 32, 32)
+    sky[:, :, :16, :] = 1.0
+
+    depth_other = depth.clone()
+    depth_other[:, :, :16, :] = 999.0  # Different garbage in the same sky region.
+
+    image = depth_estimation.plot_depth_labels(
+        batch=_make_batch(depth=depth, sky=sky),
+        max_images=1,
+        image_normalize=None,
+    )
+    image_other = depth_estimation.plot_depth_labels(
+        batch=_make_batch(depth=depth_other, sky=sky),
+        max_images=1,
+        image_normalize=None,
+    )
+
+    assert ImageChops.difference(image, image_other).getbbox() is None
+
+
+def test_plot_depth_labels__sky_filled_as_distant_not_black() -> None:
+    # Sky pixels are excluded from the normalization and then filled with the 99th
+    # percentile of the non-sky depth, so they render as distant scenery (not as the
+    # black far value) and take the same color as the farthest valid pixel.
+    depth = torch.ones(1, 1, 32, 32)
+    depth[:, :, :16, :] = 50.0  # Garbage in the top-half sky region.
+    # A vertical gradient in the valid (bottom-half) region so its pixels span the
+    # colormap; the largest valid depth is the 99th-percentile fill value used for sky.
+    depth[:, :, 16:, :] = torch.arange(1, 17, dtype=torch.float32).reshape(1, 1, 16, 1)
+    sky = torch.zeros(1, 1, 32, 32)
+    sky[:, :, :16, :] = 1.0
+
+    depth_panel = depth_estimation._depth_to_pil(depth=depth[0], sky=sky[0] >= 0.5)
+
+    # A sky pixel is not black; it matches the color of the farthest valid pixel
+    # (bottom row, the largest non-sky depth ~= the 99th percentile).
+    farthest_valid = depth_panel.getpixel((0, 31))
+    assert depth_panel.getpixel((0, 0)) != _far_pixel()
+    assert depth_panel.getpixel((0, 0)) == farthest_valid
+
+
+def test_plot_depth_labels__nonpositive_depth_rendered_as_far_value() -> None:
+    # Genuinely invalid (non-positive) depth pixels still collapse to the far value.
+    depth = torch.full((1, 1, 32, 32), 5.0)
+    depth[:, :, :16, :] = 0.0  # Invalid top half.
+    sky = torch.zeros(1, 1, 32, 32)
+
+    depth_panel = depth_estimation._depth_to_pil(depth=depth[0], sky=sky[0] >= 0.5)
+
+    assert depth_panel.getpixel((0, 0)) == _far_pixel()
+
+
+def test_apply_depth_visualization_curve__expands_close_range() -> None:
+    # Nearby pixels live at the low end of the normalized range. The visualization
+    # curve should stretch that region so small close-range differences are easier to
+    # see while preserving the endpoints.
+    normalized = torch.tensor([0.0, 0.04, 0.25, 1.0], dtype=torch.float32)
+
+    curved = depth_estimation._apply_depth_visualization_curve(normalized)
+
+    assert torch.equal(curved[[0, -1]], normalized[[0, -1]])
+    assert curved[1] > normalized[1]
+    assert curved[2] > normalized[2]
+
+
+def test_plot_depth_labels__renders_rgb_depth_and_sky_triplet() -> None:
+    depth = torch.ones(1, 1, 32, 32)
+    sky = torch.zeros(1, 1, 32, 32)
+    sky[:, :, :16, :] = 1.0
+
+    panel = depth_estimation.plot_depth_labels(
+        batch=_make_batch(depth=depth, sky=sky),
+        max_images=1,
+        image_normalize=None,
+    )
+
+    assert panel.size == (96, 32)
+    assert panel.getpixel((80, 0)) == (135, 206, 235)
+    assert panel.getpixel((80, 31)) == (0, 0, 0)
+
+
+def test_plot_depth_predictions__renders_rgb_depth_and_sky_triplet() -> None:
+    sky = torch.zeros(1, 1, 32, 32)
+    sky[:, :, :16, :] = 1.0
+    batch = _make_batch(depth=torch.ones(1, 1, 32, 32), sky=sky)
+    pred_depth = torch.linspace(1.0, 16.0, 32, dtype=torch.float32).reshape(1, 1, 32, 1)
+    pred_depth = pred_depth.expand(1, 1, 32, 32)
+
+    panel = depth_estimation.plot_depth_predictions(
+        batch=batch,
+        pred_depth=pred_depth,
+        max_images=1,
+        image_normalize=None,
+    )
+
+    assert panel.size == (96, 32)
+    assert panel.getpixel((80, 0)) == (135, 206, 235)
+    assert panel.getpixel((80, 31)) == (0, 0, 0)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -276,6 +276,30 @@ def create_images(
         )
 
 
+def create_depth_pseudo_labels(
+    depth_dir: Path,
+    sky_dir: Path,
+    files: int | Iterable[str] = 10,
+    height: int = 128,
+    width: int = 128,
+) -> None:
+    """Creates depth and sky pseudo-labels matching ``create_images`` stems.
+
+    Depth is stored as a strictly positive float ``.npy``; sky is stored as a binary
+    ``{0, 255}`` 8-bit grayscale ``.png`` mask (white = sky).
+    """
+    depth_dir.mkdir(parents=True, exist_ok=True)
+    sky_dir.mkdir(parents=True, exist_ok=True)
+    if isinstance(files, int):
+        files = [f"{i}.png" for i in range(files)]
+    for filename in files:
+        stem = Path(filename).stem
+        depth = np.random.rand(height, width).astype(np.float32) + 0.5
+        sky = (np.random.rand(height, width) > 0.5).astype(np.uint8) * 255
+        np.save(depth_dir / f"{stem}.npy", depth)
+        Image.fromarray(sky, mode="L").save(sky_dir / f"{stem}.png")
+
+
 def create_semantic_segmentation_mask(
     path: Path,
     height: int = 128,


### PR DESCRIPTION
## What has changed and why?

This PR adds a **depth estimation training path** to LightlyTrain that fine-tunes Depth Anything V3 student models by distilling depth and sky pseudo-labels from a larger V3 ViT-L teacher into smaller, faster backbones. It exposes a new public entrypoint `lightly_train.train_depth_estimation(...)` and supports both **relative-depth** and **metric-depth** models:

- Relative depth — e.g. `dinov3/dav3-relative-tiny`, `dinov3/dav3-relative-tiny-plus`, `dinov2/dav3-relative-small`.
- Metric depth — e.g. `dinov3/dav3-metric-tiny`, `dinov3/dav3-metric-tiny-plus`, `dinov2/dav3-metric-small`. A metric model is typically fine-tuned from a trained relative checkpoint (matching architectures, so weights transfer cleanly), with the pseudo-labels stored in the canonical-camera depth space.

What's included:

- **New public API**: `train_depth_estimation` added to `lightly_train.__init__` and wired through `train_task.py` / `train_task_helpers.py`.
- **Distillation criterion** (`criterion.py`):
    - `SILogLoss` — scale-invariant log depth loss (the depth term).
    - `GradientMatchingLoss` — multi-scale gradient matching (L_grad).
    - `SkyDistillLoss` — BCE on the sigmoid sky head against the teacher's soft sky map (L_sky).
    - `RelativeL1Loss` — scale-aware AbsRel term used only for metric depth to pin the absolute scale to the teacher (it does not vanish under global-scale error, unlike the scale-invariant term).
    - `FeatureAlignmentLoss` — feature-space distillation of the teacher's DPT-input patch tokens via per-stage learnable projections + mean cosine distance (training-only, discarded at export).
- **Data pipeline** — `DepthEstimationDataArgs` / dataset (depth_estimation_dataset.py) reading RGB images plus `.npy` depth and sky pseudo-labels matched by filename stem (`depth <= 0` treated as invalid), and depth-specific transforms.
- **Metrics** (`task_metric.py`) — AbsRel, RMSE, and delta1 over valid pixels, computed after per-image least-squares scale-and-shift alignment (the standard MiDaS/DAv3 relative-depth protocol). Default `watch_metric` is `val_metric`/`abs_rel`.
- **Visualization** (`depth_estimation.py`) — logs predicted depth and sky-mask overlays to TensorBoard.
- **Train model** (`train_model.py`) — orchestrates the online teacher, loss weighting, and student updates.

## How has it been tested?

- Added unit tests covering every new component:
    - Criterion: `test_criterion.py`
    - Train model & task model: `test_train_model.py`, `test_task_model.py`
    - Data & transforms: `test_depth_estimation_dataset.py`, `test_depth_estimation_transform.py`
    - Metrics: `test_task_metric.py`
    - Visualization: `test_depth_estimation.py`
    - Command wiring: `test_train_task.py`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
