### PR TITLE
perf: release train DataLoader workers before validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- `persistent_workers` passed via `loader_args` is now ignored (forced to `False`) for
+  task training, so DataLoader workers can be released between the training and
+  validation phases.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Release training DataLoader workers before each validation run so the training and
+  validation worker pools no longer coexist, avoiding excess worker processes (and GPU
+  memory pressure) during validation.
 
 ### Security
 

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -1511,9 +1511,11 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
         )
         train_dataloader.collate_fn = train_collate_fn  # type: ignore[assignment]
         val_dataloader.collate_fn = val_collate_fn  # type: ignore[assignment]
-        helpers.disable_persistent_workers_for_step_aware_transforms(
-            train_dataloader, train_transform, train_collate_fn
-        )
+        # NOTE: persistent_workers is forced to False for both dataloaders at
+        # construction time (see helpers.get_train_dataloader / get_val_dataloader).
+        # Persistent workers are owned by the DataLoader and survive StopIteration, so
+        # they cannot be released between the training and validation phases, which
+        # would keep both worker pools alive at once.
         # Wrap dataloaders with fabric *after* installing the collate function.
         # fabric's _FabricDataLoader snapshots the underlying dataloader; assigning
         # collate_fn on the wrapper would not reach the iterator.
@@ -1867,6 +1869,17 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
                     )
 
                 if is_val_step or is_last_step:
+                    if config.num_workers > 0:
+                        # Release train DataLoader workers before validation starts so
+                        # the train and validation worker pools never coexist (which
+                        # would multiply the live worker processes per rank).
+                        #
+                        # Training is step-based rather than epoch-based, so resetting
+                        # mid-epoch is acceptable: it re-shuffles from the top and drops
+                        # the current epoch's remaining batches, but we make no
+                        # per-epoch coverage guarantees anyway. The next next() call
+                        # re-creates the iterator and respawns the workers.
+                        infinite_train_dataloader.reset()
                     fabric.barrier()
                     logger.info("Validating...")
                     train_model.eval()
@@ -1879,125 +1892,129 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
                     val_dataloader_iter = iter(val_dataloader)
                     # TODO (Lionel, 02/26): Average metrics during validation instead of
                     # only singular metrics at the end of the epoch.
-                    for val_step in range(len(val_dataloader)):
-                        is_last_val_step = val_step + 1 == len(val_dataloader)
-                        is_val_log_step = (
-                            val_step + 1 in val_log_steps
-                            or (val_step + 1) % val_log_every_num_steps == 0
-                        )
-
-                        timer.start_step("val_step")
-                        timer.start_step("val_dataload")
-                        val_batch = next(val_dataloader_iter)
-                        timer.end_step("val_dataload")
-
-                        # Validation forward pass.
-                        with torch.no_grad():
-                            val_result = train_model.validation_step(
-                                fabric=fabric,
-                                batch=val_batch,
-                                step=val_step,
+                    try:
+                        for val_step in range(len(val_dataloader)):
+                            is_last_val_step = val_step + 1 == len(val_dataloader)
+                            is_val_log_step = (
+                                val_step + 1 in val_log_steps
+                                or (val_step + 1) % val_log_every_num_steps == 0
                             )
 
-                        if val_step < 3 and fabric.global_rank == 0:
-                            helpers.save_val_step_visualizations(
-                                result=val_result,
-                                out_dir=out_dir,
-                                val_step=val_step,
-                                global_step=step,
-                                loggers=fabric.loggers,
-                            )
+                            timer.start_step("val_step")
+                            timer.start_step("val_dataload")
+                            val_batch = next(val_dataloader_iter)
+                            timer.end_step("val_dataload")
 
-                        timer.end_step("val_step")
-                        timer.record_gpu_stats("val")
-
-                        if is_last_val_step:
-                            val_agg_metric_values = (
-                                val_result.metrics.compute_aggregated_values()
-                            )
-                            val_result.metrics.reset()
-                            best_agg_metric_values = helpers.get_best_metrics(
-                                best_agg_metric_values=best_agg_metric_values,
-                                last_agg_metric_values=val_agg_metric_values,
-                                step=step,
-                                metric_args=config.metric_args,
-                            )
-
-                            timer_agg = timer.get_aggregated_metrics(fabric)
-
-                            helpers.log_step(
-                                split="val",
-                                step=val_step,
-                                max_steps=len(val_dataloader),
-                                epoch=current_epoch,
-                                agg_metric_values=val_agg_metric_values,
-                                task=config.task,
-                                timer_agg=timer_agg,
-                                global_batch_size=config.batch_size,
-                            )
-                            helpers.add_timer_logs(
-                                timer_agg=timer_agg,
-                                log_dict=val_result.log_dict,
-                                split="val",
-                                global_batch_size=config.batch_size,
-                                gradient_accumulation_steps=config.gradient_accumulation_steps,
-                            )
-                            helpers.log_fabric(
-                                fabric=fabric,
-                                log_dict=val_result.log_dict,
-                                agg_metric_values=val_agg_metric_values,
-                                step=step,
-                                epoch=current_epoch,
-                            )
-
-                            if (
-                                config.save_checkpoint_args.save_best
-                                and best_agg_metric_values.step == step
-                            ):
-                                helpers.save_checkpoint(
+                            # Validation forward pass.
+                            with torch.no_grad():
+                                val_result = train_model.validation_step(
                                     fabric=fabric,
-                                    out_dir=out_dir,
-                                    state=state,
-                                    best_or_last="best",
-                                )
-                                model_dict = {
-                                    "model_class_path": state["model_class_path"],
-                                    "model_init_args": state["model_init_args"],
-                                    "train_model": train_model.get_export_state_dict(),
-                                    "license_info": state.get("license_info", ""),
-                                }
-                                helpers.export_model(
-                                    out_dir=out_dir,
-                                    model_dict=model_dict,
-                                    best_or_last="best",
+                                    batch=val_batch,
+                                    step=val_step,
                                 )
 
-                            # Log training summary after validation.
-                            timer_agg = timer.get_aggregated_metrics(fabric)
-                            helpers.log_training_summary(
-                                timer_agg=timer_agg,
-                                fabric=fabric,
-                                last_val_agg_metric_values=val_agg_metric_values,
-                                best_val_agg_metric_values=best_agg_metric_values,
-                                step=step,
-                                global_batch_size=config.batch_size,
-                                gradient_accumulation_steps=config.gradient_accumulation_steps,
-                            )
+                            if val_step < 3 and fabric.global_rank == 0:
+                                helpers.save_val_step_visualizations(
+                                    result=val_result,
+                                    out_dir=out_dir,
+                                    val_step=val_step,
+                                    global_step=step,
+                                    loggers=fabric.loggers,
+                                )
 
-                        elif is_val_log_step:
-                            # Show that we are making progress. Metrics are only calculated
-                            # at the end of the validation loop.
-                            timer_agg = timer.get_aggregated_metrics(fabric)
-                            helpers.log_step(
-                                split="val",
-                                step=val_step,
-                                max_steps=len(val_dataloader),
-                                epoch=current_epoch,
-                                agg_metric_values=None,
-                                task=config.task,
-                                timer_agg=timer_agg,
-                                global_batch_size=config.batch_size,
-                            )
+                            timer.end_step("val_step")
+                            timer.record_gpu_stats("val")
+
+                            if is_last_val_step:
+                                val_agg_metric_values = (
+                                    val_result.metrics.compute_aggregated_values()
+                                )
+                                val_result.metrics.reset()
+                                best_agg_metric_values = helpers.get_best_metrics(
+                                    best_agg_metric_values=best_agg_metric_values,
+                                    last_agg_metric_values=val_agg_metric_values,
+                                    step=step,
+                                    metric_args=config.metric_args,
+                                )
+
+                                timer_agg = timer.get_aggregated_metrics(fabric)
+
+                                helpers.log_step(
+                                    split="val",
+                                    step=val_step,
+                                    max_steps=len(val_dataloader),
+                                    epoch=current_epoch,
+                                    agg_metric_values=val_agg_metric_values,
+                                    task=config.task,
+                                    timer_agg=timer_agg,
+                                    global_batch_size=config.batch_size,
+                                )
+                                helpers.add_timer_logs(
+                                    timer_agg=timer_agg,
+                                    log_dict=val_result.log_dict,
+                                    split="val",
+                                    global_batch_size=config.batch_size,
+                                    gradient_accumulation_steps=config.gradient_accumulation_steps,
+                                )
+                                helpers.log_fabric(
+                                    fabric=fabric,
+                                    log_dict=val_result.log_dict,
+                                    agg_metric_values=val_agg_metric_values,
+                                    step=step,
+                                    epoch=current_epoch,
+                                )
+
+                                if (
+                                    config.save_checkpoint_args.save_best
+                                    and best_agg_metric_values.step == step
+                                ):
+                                    helpers.save_checkpoint(
+                                        fabric=fabric,
+                                        out_dir=out_dir,
+                                        state=state,
+                                        best_or_last="best",
+                                    )
+                                    model_dict = {
+                                        "model_class_path": state["model_class_path"],
+                                        "model_init_args": state["model_init_args"],
+                                        "train_model": train_model.get_export_state_dict(),
+                                        "license_info": state.get("license_info", ""),
+                                    }
+                                    helpers.export_model(
+                                        out_dir=out_dir,
+                                        model_dict=model_dict,
+                                        best_or_last="best",
+                                    )
+
+                                # Log training summary after validation.
+                                timer_agg = timer.get_aggregated_metrics(fabric)
+                                helpers.log_training_summary(
+                                    timer_agg=timer_agg,
+                                    fabric=fabric,
+                                    last_val_agg_metric_values=val_agg_metric_values,
+                                    best_val_agg_metric_values=best_agg_metric_values,
+                                    step=step,
+                                    global_batch_size=config.batch_size,
+                                    gradient_accumulation_steps=config.gradient_accumulation_steps,
+                                )
+
+                            elif is_val_log_step:
+                                # Show that we are making progress. Metrics are only calculated
+                                # at the end of the validation loop.
+                                timer_agg = timer.get_aggregated_metrics(fabric)
+                                helpers.log_step(
+                                    split="val",
+                                    step=val_step,
+                                    max_steps=len(val_dataloader),
+                                    epoch=current_epoch,
+                                    agg_metric_values=None,
+                                    task=config.task,
+                                    timer_agg=timer_agg,
+                                    global_batch_size=config.batch_size,
+                                )
+                    finally:
+                        # Release validation DataLoader workers before training resumes.
+                        del val_dataloader_iter
                     train_model.set_train_mode()
                     fabric.barrier()
         timer.stop()

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -112,7 +112,6 @@ from lightly_train._train_task_state import (
 )
 from lightly_train._training_step_timer import TimerAggregateMetrics
 from lightly_train._transforms.task_transform import (
-    TaskCollateFunction,
     TaskTransform,
     TaskTransformArgs,
 )
@@ -675,7 +674,6 @@ def get_train_dataloader(
     loader_args: dict[str, Any] | None = None,
 ) -> DataLoader[TaskDatasetItem]:
     timeout = Env.LIGHTLY_TRAIN_DATALOADER_TIMEOUT_SEC.value if num_workers > 0 else 0
-    # TODO(Guarin, 07/25): Persistent workers by default?
     dataloader_kwargs: dict[str, Any] = dict(
         dataset=dataset,
         batch_size=batch_size // fabric.world_size,
@@ -690,6 +688,7 @@ def get_train_dataloader(
         # handled through dedicated function arguments.
         loader_args.pop("batch_size", None)
         loader_args.pop("num_workers", None)
+        _drop_unsupported_persistent_workers(loader_args, split="train")
         dataloader_kwargs.update(**loader_args)
     return DataLoader(**dataloader_kwargs)
 
@@ -716,26 +715,30 @@ def get_val_dataloader(
         # handled through dedicated function arguments.
         loader_args.pop("batch_size", None)
         loader_args.pop("num_workers", None)
+        _drop_unsupported_persistent_workers(loader_args, split="validation")
         dataloader_kwargs.update(**loader_args)
     return DataLoader(**dataloader_kwargs)
 
 
-def disable_persistent_workers_for_step_aware_transforms(
-    dataloader: DataLoader[Any],
-    transform: TaskTransform,
-    collate_fn: TaskCollateFunction,
+def _drop_unsupported_persistent_workers(
+    loader_args: dict[str, Any], split: str
 ) -> None:
-    """Force ``persistent_workers=False`` when transform/collate are step-aware."""
-    needs_refresh = (
-        transform.uses_step_dependent_worker_state()
-        or collate_fn.uses_step_dependent_worker_state()
-    )
-    if needs_refresh and dataloader.num_workers > 0 and dataloader.persistent_workers:
+    """Remove ``persistent_workers`` from user-provided loader args.
+
+    Persistent workers are owned by the DataLoader (not by the iterator), so they
+    survive ``StopIteration`` and cannot be released between the training and
+    validation phases. Keeping them alive means the train and validation worker
+    pools coexist (num_workers per split, per rank), which is exactly the process
+    blow-up we want to avoid. We therefore always run with ``persistent_workers=
+    False`` for the internal train/validation dataloaders and ignore any user
+    override.
+    """
+    if loader_args.pop("persistent_workers", None):
         logger.warning(
-            "Step-aware transform/collate requires persistent_workers=False. "
-            "Overriding user-provided persistent_workers=True."
+            f"'persistent_workers' is not supported for the {split} dataloader and "
+            "will be ignored: workers must be released between the training and "
+            "validation phases. Continuing with persistent_workers=False."
         )
-        dataloader.persistent_workers = False
 
 
 def get_steps(steps: int | Literal["auto"], default_steps: int) -> int:


### PR DESCRIPTION
## What has changed and why?

During task training, two DataLoader worker pools could be alive at the same time throughout every validation phase.

`InfiniteCycleIterator` caches its underlying iterator and keeps it alive across training steps, so the train workers did not shut down before validation. When validation started, `iter(val_dataloader)` spawned a second pool while the train pool was still held. Because the validation loader uses the same `num_workers` as training, the number of live worker processes doubled during validation (for example, 2 GPUs x 8 workers = 16 -> 32).

This PR ensures only one task DataLoader worker pool is alive at a time:

1. **Release train workers before validation**: when `num_workers > 0`, `infinite_train_dataloader.reset()` drops the cached train iterator before validation starts, allowing its workers to shut down before validation workers spawn.
2. **Release validation workers before training resumes**: the validation iterator is scoped with `try/finally` and deleted in the `finally`, so validation workers are released even if validation exits early or raises.
3. **Disallow persistent task workers**: `persistent_workers` passed through `loader_args` is now ignored for both task train and validation dataloaders. Persistent workers are owned by the DataLoader and survive iterator shutdown, so allowing this override would defeat the release-before-validation behavior.

## How has it been tested?

Ran a 2-GPU / `num_workers=4` job under SLURM on a small COCO instance-segmentation subset (`ltdetrv2-seg-s`, 30 steps, validating at steps 10/20/30 plus the final step). A `psutil` monitor sampled the number of live DataLoader worker processes, matched by their `pt_data_worker` process name and isolated to the job by run name, every 0.25 s.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)