### PR TITLE
Add LT-DETRv2 instance segmentation tutorials

### DIFF
--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -32,6 +32,7 @@ image_classification
 depth_estimation
 eomt_semantic_segmentation
 eomt_instance_segmentation
+ltdetr_instance_segmentation
 eomt_panoptic_segmentation
 ```
 
@@ -42,6 +43,7 @@ caption: ONNX & TENSORRT EXPORT TUTORIALS
 ---
 object_detection_export
 eomt_instance_segmentation_export
+ltdetr_instance_segmentation_export
 eomt_semantic_segmentation_export
 eomt_panoptic_segmentation_export
 depth_estimation_export

--- a/examples/notebooks/ltdetr_instance_segmentation.ipynb
+++ b/examples/notebooks/ltdetr_instance_segmentation.ipynb
@@ -1,0 +1,321 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Instance Segmentation with LTDETRv2\n",
+    "\n",
+    "This notebook demonstrates how to use LightlyTrain for instance segmentation with our state-of-the-art LTDETRv2 model and publicly released weights trained on the [COCO](https://arxiv.org/abs/1612.03716) dataset.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/ltdetr_instance_segmentation.ipynb)\n",
+    "\n",
+    "> **Important**: When running on Google Colab make sure to select a GPU runtime for faster processing. You can do this by going to `Runtime` > `Change runtime type` and selecting a GPU hardware accelerator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly-train"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "> **Important**: LightlyTrain is officially supported on\n",
+    "> - Linux: CPU or CUDA\n",
+    "> - MacOS: CPU only\n",
+    "> - Windows (experimental): CPU or CUDA\n",
+    ">\n",
+    "> We are planning to support MPS for MacOS.\n",
+    ">\n",
+    "> Check the [installation instructions](https://docs.lightly.ai/train/stable/installation.html) for more details on installation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## Train an instance segmentation model\n",
+    "\n",
+    "Training your own LTDETRv2 instance segmentation model is straightforward with LightlyTrain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "### Download dataset\n",
+    "\n",
+    "First download a dataset in YOLO segmentation format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -O coco128-seg.zip https://github.com/ultralytics/assets/releases/download/v0.0.0/coco128-seg.zip && unzip -q coco128-seg.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "The example archive contains a single image directory. Move a small subset into a validation split so that the tutorial demonstrates both training and validation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "dataset_dir = Path(\"coco128-seg\")\n",
+    "val_images_dir = dataset_dir / \"images/val2017\"\n",
+    "val_labels_dir = dataset_dir / \"labels/val2017\"\n",
+    "val_images_dir.mkdir(parents=True, exist_ok=True)\n",
+    "val_labels_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "if not any(val_images_dir.iterdir()):\n",
+    "    train_images_dir = dataset_dir / \"images/train2017\"\n",
+    "    train_labels_dir = dataset_dir / \"labels/train2017\"\n",
+    "    for image_path in sorted(train_images_dir.glob(\"*.jpg\"))[-16:]:\n",
+    "        image_path.rename(val_images_dir / image_path.name)\n",
+    "        label_path = train_labels_dir / image_path.with_suffix(\".txt\").name\n",
+    "        if label_path.exists():\n",
+    "            label_path.rename(val_labels_dir / label_path.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "Then start training with `train_instance_segmentation`. LightlyTrain automatically configures the model and augmentations, while still allowing every setting to be customized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lightly_train\n",
+    "\n",
+    "lightly_train.train_instance_segmentation(\n",
+    "    out=\"out/my_experiment\",\n",
+    "    model=\"ltdetrv2-seg-s-coco\",\n",
+    "    steps=100,  # Small number of steps for demonstration.\n",
+    "    batch_size=4,  # Small batch size for demonstration.\n",
+    "    data={\n",
+    "        \"path\": \"coco128-seg\",\n",
+    "        \"train\": \"images/train2017\",\n",
+    "        \"val\": \"images/val2017\",\n",
+    "        \"names\": {\n",
+    "            0: \"person\",\n",
+    "            1: \"bicycle\",\n",
+    "            2: \"car\",\n",
+    "            3: \"motorcycle\",\n",
+    "            4: \"airplane\",\n",
+    "            5: \"bus\",\n",
+    "            6: \"train\",\n",
+    "            7: \"truck\",\n",
+    "            8: \"boat\",\n",
+    "            9: \"traffic light\",\n",
+    "            10: \"fire hydrant\",\n",
+    "            11: \"stop sign\",\n",
+    "            12: \"parking meter\",\n",
+    "            13: \"bench\",\n",
+    "            14: \"bird\",\n",
+    "            15: \"cat\",\n",
+    "            16: \"dog\",\n",
+    "            17: \"horse\",\n",
+    "            18: \"sheep\",\n",
+    "            19: \"cow\",\n",
+    "            20: \"elephant\",\n",
+    "            21: \"bear\",\n",
+    "            22: \"zebra\",\n",
+    "            23: \"giraffe\",\n",
+    "            24: \"backpack\",\n",
+    "            25: \"umbrella\",\n",
+    "            26: \"handbag\",\n",
+    "            27: \"tie\",\n",
+    "            28: \"suitcase\",\n",
+    "            29: \"frisbee\",\n",
+    "            30: \"skis\",\n",
+    "            31: \"snowboard\",\n",
+    "            32: \"sports ball\",\n",
+    "            33: \"kite\",\n",
+    "            34: \"baseball bat\",\n",
+    "            35: \"baseball glove\",\n",
+    "            36: \"skateboard\",\n",
+    "            37: \"surfboard\",\n",
+    "            38: \"tennis racket\",\n",
+    "            39: \"bottle\",\n",
+    "            40: \"wine glass\",\n",
+    "            41: \"cup\",\n",
+    "            42: \"fork\",\n",
+    "            43: \"knife\",\n",
+    "            44: \"spoon\",\n",
+    "            45: \"bowl\",\n",
+    "            46: \"banana\",\n",
+    "            47: \"apple\",\n",
+    "            48: \"sandwich\",\n",
+    "            49: \"orange\",\n",
+    "            50: \"broccoli\",\n",
+    "            51: \"carrot\",\n",
+    "            52: \"hot dog\",\n",
+    "            53: \"pizza\",\n",
+    "            54: \"donut\",\n",
+    "            55: \"cake\",\n",
+    "            56: \"chair\",\n",
+    "            57: \"couch\",\n",
+    "            58: \"potted plant\",\n",
+    "            59: \"bed\",\n",
+    "            60: \"dining table\",\n",
+    "            61: \"toilet\",\n",
+    "            62: \"tv\",\n",
+    "            63: \"laptop\",\n",
+    "            64: \"mouse\",\n",
+    "            65: \"remote\",\n",
+    "            66: \"keyboard\",\n",
+    "            67: \"cell phone\",\n",
+    "            68: \"microwave\",\n",
+    "            69: \"oven\",\n",
+    "            70: \"toaster\",\n",
+    "            71: \"sink\",\n",
+    "            72: \"refrigerator\",\n",
+    "            73: \"book\",\n",
+    "            74: \"clock\",\n",
+    "            75: \"vase\",\n",
+    "            76: \"scissors\",\n",
+    "            77: \"teddy bear\",\n",
+    "            78: \"hair drier\",\n",
+    "            79: \"toothbrush\",\n",
+    "        },\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "Once training completes, the final model checkpoint is saved in `out/my_experiment/exported_models/exported_last.pt`. The best model according to the validation mask mAP is saved in `out/my_experiment/exported_models/exported_best.pt`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Predict with your own LTDETRv2 weights"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Load the model weights\n",
+    "\n",
+    "Load the best model exported during training with LightlyTrain's `load_model` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = lightly_train.load_model(\"out/my_experiment/exported_models/exported_best.pt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "### Predict and visualize the instances\n",
+    "\n",
+    "Run prediction on the example image with your trained model and visualize its masks, bounding boxes, and class labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from torchvision.io import read_image\n",
+    "from torchvision.utils import draw_bounding_boxes, draw_segmentation_masks\n",
+    "\n",
+    "prediction = model.predict(\"image.jpg\")\n",
+    "\n",
+    "image = read_image(\"image.jpg\")\n",
+    "image_with_masks = draw_segmentation_masks(image, masks=prediction[\"masks\"], alpha=0.6)\n",
+    "image_with_instances = draw_bounding_boxes(\n",
+    "    image_with_masks,\n",
+    "    boxes=prediction[\"bboxes\"],\n",
+    "    labels=[model.classes[label.item()] for label in prediction[\"labels\"]],\n",
+    ")\n",
+    "plt.imshow(image_with_instances.permute(1, 2, 0))\n",
+    "plt.axis(\"off\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "- [Instance Segmentation Documentation](https://docs.lightly.ai/train/stable/instance_segmentation.html): Learn more about training, inference, data formats, and available models.\n",
+    "- [LTDETRv2 Instance Segmentation Model Export](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/ltdetr_instance_segmentation_export.ipynb): Export an LTDETRv2 instance segmentation model to ONNX and TensorRT."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/ltdetr_instance_segmentation_export.ipynb
+++ b/examples/notebooks/ltdetr_instance_segmentation_export.ipynb
@@ -1,0 +1,427 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Instance Segmentation Model Export - LTDETRv2\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/ltdetr_instance_segmentation_export.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to export an LTDETRv2 instance segmentation model to ONNX and TensorRT.\n",
+    "\n",
+    "The notebook covers the following steps:\n",
+    "1. Install LightlyTrain\n",
+    "2. Export a trained LTDETRv2 model to ONNX\n",
+    "3. Run inference with the ONNX model\n",
+    "4. Export the model to TensorRT\n",
+    "5. Run inference with the TensorRT engine\n",
+    "\n",
+    "> **Important**: When running on Google Colab make sure to select a GPU runtime. You can do this by going to `Runtime` > `Change runtime type` and selecting a GPU hardware accelerator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"lightly-train[onnx,onnxruntime,onnxslim]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Export to ONNX\n",
+    "\n",
+    "### Load the model weights\n",
+    "\n",
+    "Load the COCO-trained LTDETRv2 instance segmentation model with LightlyTrain's `load_model` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lightly_train\n",
+    "\n",
+    "model = lightly_train.load_model(\"ltdetrv2-seg-s-coco\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "### Download an example image\n",
+    "\n",
+    "Download an example image for inference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -O image.jpg http://images.cocodataset.org/val2017/000000039769.jpg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "### Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import torchvision.transforms.v2 as T\n",
+    "from PIL import Image\n",
+    "from torchvision.transforms.functional import pil_to_tensor\n",
+    "\n",
+    "image_pil = Image.open(\"image.jpg\").convert(\"RGB\")\n",
+    "image_tensor = pil_to_tensor(image_pil)\n",
+    "\n",
+    "w, h = image_pil.size\n",
+    "transforms = T.Compose(\n",
+    "    [\n",
+    "        T.Resize(model.image_size),\n",
+    "        T.ToTensor(),\n",
+    "        T.Normalize(**model.image_normalize) if model.image_normalize else T.Identity(),\n",
+    "    ]\n",
+    ")\n",
+    "image_tensor_transformed = transforms(image_pil)[None]\n",
+    "orig_target_size = np.array([[h, w]], dtype=np.int64)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "### Get the model predictions for reference\n",
+    "\n",
+    "Define a helper that displays each instance's mask, bounding box, and class label. We will use it for the PyTorch, ONNX, and TensorRT predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "from torchvision.utils import draw_bounding_boxes, draw_segmentation_masks\n",
+    "\n",
+    "\n",
+    "def visualize_instances(image, boxes, masks, labels, classes):\n",
+    "    image_with_masks = draw_segmentation_masks(image, masks=masks.cpu(), alpha=0.6)\n",
+    "    image_with_instances = draw_bounding_boxes(\n",
+    "        image_with_masks,\n",
+    "        boxes=boxes.cpu(),\n",
+    "        labels=[classes[label.item()] for label in labels.cpu()],\n",
+    "    )\n",
+    "    fig, axs = plt.subplots(1, 2, figsize=(12, 8))\n",
+    "    axs[0].imshow(image.permute(1, 2, 0))\n",
+    "    axs[0].axis(\"off\")\n",
+    "    axs[1].imshow(image_with_instances.permute(1, 2, 0))\n",
+    "    axs[1].axis(\"off\")\n",
+    "    fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = model.predict(image_tensor, threshold=0.6)\n",
+    "visualize_instances(\n",
+    "    image_tensor,\n",
+    "    boxes=results[\"bboxes\"],\n",
+    "    masks=results[\"masks\"],\n",
+    "    labels=results[\"labels\"],\n",
+    "    classes=model.classes,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "### Export the model to ONNX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.export_onnx(\n",
+    "    out=\"model.onnx\",\n",
+    "    # precision=\"fp16\",  # Use FP16 weights for a smaller and faster model.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "See [`export_onnx`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.ltdetr_instance_segmentation.task_model.LTDETRInstanceSegmentation.export_onnx) for all available options."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Run inference with the ONNX model\n",
+    "\n",
+    "The exported graph takes the preprocessed image and the original image size in `(height, width)` order. It returns all queries, so apply the same score and mask thresholds as `model.predict`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import onnxruntime as ort\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "sess = ort.InferenceSession(\"model.onnx\")\n",
+    "input_dtype = sess.get_inputs()[0].type\n",
+    "input_dtype_numpy = {\n",
+    "    \"tensor(float)\": \"float32\",\n",
+    "    \"tensor(float16)\": \"float16\",\n",
+    "}[input_dtype]\n",
+    "\n",
+    "labels_onnx, boxes_onnx, masks_onnx, scores_onnx = sess.run(\n",
+    "    output_names=None,\n",
+    "    input_feed={\n",
+    "        \"images\": image_tensor_transformed.numpy().astype(input_dtype_numpy),\n",
+    "        \"orig_target_size\": orig_target_size,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "labels_onnx = labels_onnx[0]\n",
+    "boxes_onnx = boxes_onnx[0]\n",
+    "masks_onnx = masks_onnx[0]\n",
+    "scores_onnx = scores_onnx[0]\n",
+    "\n",
+    "keep = scores_onnx > 0.6\n",
+    "labels_onnx = torch.from_numpy(labels_onnx[keep])\n",
+    "boxes_onnx = torch.from_numpy(boxes_onnx[keep])\n",
+    "masks_onnx = torch.from_numpy(masks_onnx[keep])\n",
+    "masks_onnx = (\n",
+    "    F.interpolate(\n",
+    "        masks_onnx.unsqueeze(1),\n",
+    "        size=(h, w),\n",
+    "        mode=\"bilinear\",\n",
+    "        align_corners=False,\n",
+    "    ).squeeze(1)\n",
+    "    > 0.0\n",
+    ")\n",
+    "\n",
+    "visualize_instances(\n",
+    "    image_tensor,\n",
+    "    boxes=boxes_onnx,\n",
+    "    masks=masks_onnx,\n",
+    "    labels=labels_onnx,\n",
+    "    classes=model.classes,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## Export to TensorRT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "### Requirements\n",
+    "\n",
+    "TensorRT is not part of LightlyTrain's dependencies and must be installed separately. Installation depends on your OS, Python version, GPU, and NVIDIA driver/CUDA setup. See the [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html) for details.\n",
+    "\n",
+    "On CUDA 12.x systems, install the TensorRT version tested with this tutorial. Pinning the version prevents pip from installing TensorRT 11, which is not yet supported by LightlyTrain:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"tensorrt-cu12==10.13.3.9\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.export_tensorrt(\n",
+    "    out=\"model.trt\",\n",
+    "    # precision=\"fp16\",  # Use FP16 weights for a smaller and faster engine.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "See [`export_tensorrt`](https://docs.lightly.ai/train/stable/python_api/lightly_train.html#lightly_train._task_models.ltdetr_instance_segmentation.task_model.LTDETRInstanceSegmentation.export_tensorrt) for all available options."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "### Run inference with the TensorRT engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorrt as trt\n",
+    "\n",
+    "\n",
+    "class TRT:\n",
+    "    def __init__(self, engine_path: str, device: str = \"cuda:0\", verbose: bool = False):\n",
+    "        self.device = torch.device(device)\n",
+    "        logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.INFO)\n",
+    "        trt.init_libnvinfer_plugins(logger, \"\")\n",
+    "        runtime = trt.Runtime(logger)\n",
+    "\n",
+    "        with open(engine_path, \"rb\") as f:\n",
+    "            self.engine = runtime.deserialize_cuda_engine(f.read())\n",
+    "        self.context = self.engine.create_execution_context()\n",
+    "\n",
+    "        io_names = [\n",
+    "            self.engine.get_tensor_name(i) for i in range(self.engine.num_io_tensors)\n",
+    "        ]\n",
+    "        self.in_names = [\n",
+    "            name\n",
+    "            for name in io_names\n",
+    "            if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT\n",
+    "        ]\n",
+    "        self.out_names = [\n",
+    "            name\n",
+    "            for name in io_names\n",
+    "            if self.engine.get_tensor_mode(name) == trt.TensorIOMode.OUTPUT\n",
+    "        ]\n",
+    "\n",
+    "        self.buffers = {}\n",
+    "        self.bindings = []\n",
+    "        for name in io_names:\n",
+    "            shape = tuple(self.context.get_tensor_shape(name))\n",
+    "            np_dtype = trt.nptype(self.engine.get_tensor_dtype(name))\n",
+    "            torch_dtype = torch.from_numpy(np.empty((), dtype=np_dtype)).dtype\n",
+    "            buffer = torch.empty(\n",
+    "                shape, device=self.device, dtype=torch_dtype\n",
+    "            ).contiguous()\n",
+    "            self.buffers[name] = buffer\n",
+    "            self.bindings.append(buffer.data_ptr())\n",
+    "\n",
+    "    @torch.no_grad()\n",
+    "    def __call__(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:\n",
+    "        for name in self.in_names:\n",
+    "            self.buffers[name].copy_(inputs[name].to(self.device))\n",
+    "        if not self.context.execute_v2(self.bindings):\n",
+    "            raise RuntimeError(\"TensorRT execution failed\")\n",
+    "        return {name: self.buffers[name] for name in self.out_names}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trt_model = TRT(\"model.trt\")\n",
+    "outputs_trt = trt_model(\n",
+    "    {\n",
+    "        \"images\": image_tensor_transformed,\n",
+    "        \"orig_target_size\": torch.from_numpy(orig_target_size),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "labels_trt = outputs_trt[\"labels\"][0]\n",
+    "boxes_trt = outputs_trt[\"boxes\"][0]\n",
+    "masks_trt = outputs_trt[\"masks\"][0]\n",
+    "scores_trt = outputs_trt[\"scores\"][0]\n",
+    "\n",
+    "keep = scores_trt > 0.6\n",
+    "labels_trt = labels_trt[keep]\n",
+    "boxes_trt = boxes_trt[keep]\n",
+    "masks_trt = masks_trt[keep]\n",
+    "masks_trt = (\n",
+    "    F.interpolate(\n",
+    "        masks_trt.unsqueeze(1),\n",
+    "        size=(h, w),\n",
+    "        mode=\"bilinear\",\n",
+    "        align_corners=False,\n",
+    "    ).squeeze(1)\n",
+    "    > 0.0\n",
+    ")\n",
+    "\n",
+    "visualize_instances(\n",
+    "    image_tensor,\n",
+    "    boxes=boxes_trt,\n",
+    "    masks=masks_trt,\n",
+    "    labels=labels_trt,\n",
+    "    classes=model.classes,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What has changed and why?

Add two LT-DETRv2 instance segmentation tutorials:

- a train-to-predict workflow using an exported LightlyTrain checkpoint
- an export workflow covering ONNX and TensorRT inference

Link both notebooks from the tutorials index so users can discover the training and export workflows from the documentation.

This updates the tutorials for LT-DETRv2 instance segmentation as part of TRN-2320.

Note that the checkpoints will be uploaded in a later PR.

## How has it been tested?

On a Google Colab T4.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)