### PR TITLE
Fix ckpt loading for fine-tuning

### DIFF
--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -153,19 +153,20 @@ def train_image_classification(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Any downloadable
-            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
-            training progress from the checkpoint are also not restored. Use
-            ``resume_interrupted`` instead to restore a crashed run.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint. The checkpoint must be a path to a checkpoint file, for example
+            "checkpoints/model.ckpt". This will only load the model weights from the
+            previous run. All other training state (e.g. optimizer state, epochs) from
+            the previous run are not loaded.
+
+            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter instead.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step. The checkpoint at
-            ``out/checkpoints/last.ckpt`` determines the architecture and full training
-            state; ``model`` is not resolved or downloaded while resuming.
+            off, including the optimizer state and the current step.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -332,16 +333,11 @@ def train_image_classification_multihead(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Downloadable model
-            weights and training progress are not restored from other sources.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint.
         resume_interrupted:
             Set this to True if you want to resume training from an interrupted or
-            crashed training run. The checkpoint at ``out/checkpoints/last.ckpt``
-            determines the architecture and full training state; ``model`` is not
-            resolved or downloaded while resuming.
+            crashed training run.
         reuse_class_head:
             Set this to True if you want to keep the class head from the provided
             checkpoint.
@@ -491,22 +487,23 @@ def train_instance_segmentation(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Any downloadable
-            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
-            training progress from the checkpoint are also not restored. Use
-            ``resume_interrupted`` instead to restore a crashed run.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint. The checkpoint must be a path to a checkpoint file, for example
+            "checkpoints/model.ckpt". This will only load the model weights from the
+            previous run. All other training state (e.g. optimizer state, epochs) from
+            the previous run are not loaded.
+
+            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter instead.
         reuse_class_head:
             Deprecated. Now the model will reuse the classification head by default only when the num_classes
             in the data config matches that in the checkpoint. Otherwise, the classification head will be re-initialized.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step. The checkpoint at
-            ``out/checkpoints/last.ckpt`` determines the architecture and full training
-            state; ``model`` is not resolved or downloaded while resuming.
+            off, including the optimizer state and the current step.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -659,22 +656,23 @@ def train_object_detection(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Any downloadable
-            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
-            training progress from the checkpoint are also not restored. Use
-            ``resume_interrupted`` instead to restore a crashed run.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint. The checkpoint must be a path to a checkpoint file, for example
+            "checkpoints/model.ckpt". This will only load the model weights from the
+            previous run. All other training state (e.g. optimizer state, epochs) from
+            the previous run are not loaded.
+
+            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter instead.
         reuse_class_head:
             Deprecated. Now the model will reuse the classification head by default only when the num_classes
             in the data config matches that in the checkpoint. Otherwise, the classification head will be re-initialized.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step. The checkpoint at
-            ``out/checkpoints/last.ckpt`` determines the architecture and full training
-            state; ``model`` is not resolved or downloaded while resuming.
+            off, including the optimizer state and the current step.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -827,13 +825,16 @@ def train_panoptic_segmentation(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Any downloadable
-            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
-            training progress from the checkpoint are also not restored. Use
-            ``resume_interrupted`` instead to restore a crashed run.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint. The checkpoint must be a path to a checkpoint file, for example
+            "checkpoints/model.ckpt". This will only load the model weights from the
+            previous run. All other training state (e.g. optimizer state, epochs) from
+            the previous run are not loaded.
+
+            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter instead.
         reuse_class_head:
             Set this to True if you want to keep the class head from the provided
             checkpoint. The default behavior removes the class head before loading so
@@ -841,9 +842,7 @@ def train_panoptic_segmentation(
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step. The checkpoint at
-            ``out/checkpoints/last.ckpt`` determines the architecture and full training
-            state; ``model`` is not resolved or downloaded while resuming.
+            off, including the optimizer state and the current step.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -996,22 +995,23 @@ def train_semantic_segmentation(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Any downloadable
-            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
-            training progress from the checkpoint are also not restored. Use
-            ``resume_interrupted`` instead to restore a crashed run.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint. The checkpoint must be a path to a checkpoint file, for example
+            "checkpoints/model.ckpt". This will only load the model weights from the
+            previous run. All other training state (e.g. optimizer state, epochs) from
+            the previous run are not loaded.
+
+            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
+
+            If you want to resume training from an interrupted or crashed run, use the
+            ``resume_interrupted`` parameter instead.
         reuse_class_head:
             Deprecated. Now the model will reuse the classification head by default only when the num_classes
             in the data config matches that in the checkpoint. Otherwise, the classification head will be re-initialized.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step. The checkpoint at
-            ``out/checkpoints/last.ckpt`` determines the architecture and full training
-            state; ``model`` is not resolved or downloaded while resuming.
+            off, including the optimizer state and the current step.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -1160,16 +1160,11 @@ def train_semantic_segmentation_multihead(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Path to a checkpoint whose model weights initialize a new fine-tuning run.
-            The checkpoint metadata determines the exact architecture. ``model`` must
-            name a supported model from the same task-model family and is used as a
-            fallback for legacy checkpoints without model metadata. Downloadable model
-            weights and training progress are not restored from other sources.
+            Use this parameter to further fine-tune a model from a previous fine-tuned
+            checkpoint.
         resume_interrupted:
             Set this to True if you want to resume training from an interrupted or
-            crashed training run. The checkpoint at ``out/checkpoints/last.ckpt``
-            determines the architecture and full training state; ``model`` is not
-            resolved or downloaded while resuming.
+            crashed training run.
         overwrite:
             Overwrite the output directory if it already exists.
         accelerator:

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -153,20 +153,19 @@ def train_image_classification(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint. The checkpoint must be a path to a checkpoint file, for example
-            "checkpoints/model.ckpt". This will only load the model weights from the
-            previous run. All other training state (e.g. optimizer state, epochs) from
-            the previous run are not loaded.
-
-            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
-
-            If you want to resume training from an interrupted or crashed run, use the
-            ``resume_interrupted`` parameter instead.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Any downloadable
+            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
+            training progress from the checkpoint are also not restored. Use
+            ``resume_interrupted`` instead to restore a crashed run.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step.
+            off, including the optimizer state and the current step. The checkpoint at
+            ``out/checkpoints/last.ckpt`` determines the architecture and full training
+            state; ``model`` is not resolved or downloaded while resuming.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -333,11 +332,16 @@ def train_image_classification_multihead(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Downloadable model
+            weights and training progress are not restored from other sources.
         resume_interrupted:
             Set this to True if you want to resume training from an interrupted or
-            crashed training run.
+            crashed training run. The checkpoint at ``out/checkpoints/last.ckpt``
+            determines the architecture and full training state; ``model`` is not
+            resolved or downloaded while resuming.
         reuse_class_head:
             Set this to True if you want to keep the class head from the provided
             checkpoint.
@@ -487,23 +491,22 @@ def train_instance_segmentation(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint. The checkpoint must be a path to a checkpoint file, for example
-            "checkpoints/model.ckpt". This will only load the model weights from the
-            previous run. All other training state (e.g. optimizer state, epochs) from
-            the previous run are not loaded.
-
-            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
-
-            If you want to resume training from an interrupted or crashed run, use the
-            ``resume_interrupted`` parameter instead.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Any downloadable
+            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
+            training progress from the checkpoint are also not restored. Use
+            ``resume_interrupted`` instead to restore a crashed run.
         reuse_class_head:
             Deprecated. Now the model will reuse the classification head by default only when the num_classes
             in the data config matches that in the checkpoint. Otherwise, the classification head will be re-initialized.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step.
+            off, including the optimizer state and the current step. The checkpoint at
+            ``out/checkpoints/last.ckpt`` determines the architecture and full training
+            state; ``model`` is not resolved or downloaded while resuming.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -656,23 +659,22 @@ def train_object_detection(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint. The checkpoint must be a path to a checkpoint file, for example
-            "checkpoints/model.ckpt". This will only load the model weights from the
-            previous run. All other training state (e.g. optimizer state, epochs) from
-            the previous run are not loaded.
-
-            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
-
-            If you want to resume training from an interrupted or crashed run, use the
-            ``resume_interrupted`` parameter instead.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Any downloadable
+            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
+            training progress from the checkpoint are also not restored. Use
+            ``resume_interrupted`` instead to restore a crashed run.
         reuse_class_head:
             Deprecated. Now the model will reuse the classification head by default only when the num_classes
             in the data config matches that in the checkpoint. Otherwise, the classification head will be re-initialized.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step.
+            off, including the optimizer state and the current step. The checkpoint at
+            ``out/checkpoints/last.ckpt`` determines the architecture and full training
+            state; ``model`` is not resolved or downloaded while resuming.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -825,16 +827,13 @@ def train_panoptic_segmentation(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint. The checkpoint must be a path to a checkpoint file, for example
-            "checkpoints/model.ckpt". This will only load the model weights from the
-            previous run. All other training state (e.g. optimizer state, epochs) from
-            the previous run are not loaded.
-
-            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
-
-            If you want to resume training from an interrupted or crashed run, use the
-            ``resume_interrupted`` parameter instead.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Any downloadable
+            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
+            training progress from the checkpoint are also not restored. Use
+            ``resume_interrupted`` instead to restore a crashed run.
         reuse_class_head:
             Set this to True if you want to keep the class head from the provided
             checkpoint. The default behavior removes the class head before loading so
@@ -842,7 +841,9 @@ def train_panoptic_segmentation(
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step.
+            off, including the optimizer state and the current step. The checkpoint at
+            ``out/checkpoints/last.ckpt`` determines the architecture and full training
+            state; ``model`` is not resolved or downloaded while resuming.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -995,23 +996,22 @@ def train_semantic_segmentation(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint. The checkpoint must be a path to a checkpoint file, for example
-            "checkpoints/model.ckpt". This will only load the model weights from the
-            previous run. All other training state (e.g. optimizer state, epochs) from
-            the previous run are not loaded.
-
-            This option is equivalent to setting ``model="<path_to_checkpoint>"``.
-
-            If you want to resume training from an interrupted or crashed run, use the
-            ``resume_interrupted`` parameter instead.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Any downloadable
+            weights associated with ``model`` are not loaded. Optimizer, scheduler, and
+            training progress from the checkpoint are also not restored. Use
+            ``resume_interrupted`` instead to restore a crashed run.
         reuse_class_head:
             Deprecated. Now the model will reuse the classification head by default only when the num_classes
             in the data config matches that in the checkpoint. Otherwise, the classification head will be re-initialized.
         resume_interrupted:
             Set this to True if you want to resume training from an **interrupted or
             crashed** training run. This will pick up exactly where the training left
-            off, including the optimizer state and the current step.
+            off, including the optimizer state and the current step. The checkpoint at
+            ``out/checkpoints/last.ckpt`` determines the architecture and full training
+            state; ``model`` is not resolved or downloaded while resuming.
 
             - You must use the same ``out`` directory as the interrupted run.
             - You must **NOT** change any training parameters (e.g., learning rate, batch size, data, etc.).
@@ -1160,11 +1160,16 @@ def train_semantic_segmentation_multihead(
         num_nodes:
             Number of nodes for distributed training.
         checkpoint:
-            Use this parameter to further fine-tune a model from a previous fine-tuned
-            checkpoint.
+            Path to a checkpoint whose model weights initialize a new fine-tuning run.
+            The checkpoint metadata determines the exact architecture. ``model`` must
+            name a supported model from the same task-model family and is used as a
+            fallback for legacy checkpoints without model metadata. Downloadable model
+            weights and training progress are not restored from other sources.
         resume_interrupted:
             Set this to True if you want to resume training from an interrupted or
-            crashed training run.
+            crashed training run. The checkpoint at ``out/checkpoints/last.ckpt``
+            determines the architecture and full training state; ``model`` is not
+            resolved or downloaded while resuming.
         overwrite:
             Overwrite the output directory if it already exists.
         accelerator:

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -1648,9 +1648,11 @@ def _train_task_from_config(config: TrainTaskConfig) -> None:
                     checkpoint_path=checkpoint_path,
                 )
             elif checkpoint is not None:
+                assert checkpoint_path is not None
                 helpers.finetune_from_checkpoint(
                     state=state,
                     checkpoint=checkpoint,
+                    checkpoint_path=checkpoint_path,
                 )
 
             # Add license info after loading as it might be missing from the checkpoint.

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -1306,7 +1306,8 @@ def read_model_init_args_from_ckpt(ckpt_path: PathLike) -> dict[str, Any]:
     except (TypeError, RuntimeError, NotImplementedError, AttributeError):
         ckpt = torch.load(p, map_location="cpu", weights_only=False)
 
-    return cast(dict[str, Any], ckpt["model_init_args"])
+    model_init_args: dict[str, Any] = ckpt["model_init_args"]
+    return model_init_args
 
 
 def load_checkpoint(

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -1317,7 +1317,23 @@ def load_checkpoint(
     checkpoint: PathLike | None,
     task: str,
 ) -> tuple[CheckpointDict | None, Path | None, str, dict[str, Any] | None]:
-    """Build a checkpoint context from the current run configuration.
+    """Resolve model initialization and resume checkpoints.
+
+    Resolution follows these rules, in order:
+
+    1. ``resume_interrupted=True`` restores the full training state from
+       ``out/checkpoints/last.ckpt``. The ``model`` argument is not resolved because
+       the resume checkpoint is authoritative.
+    2. An explicit ``checkpoint`` starts a new fine-tuning run. Its metadata determines
+       the exact architecture, while ``model`` is used to verify the task-model family
+       and as a fallback for legacy checkpoints without model metadata. Only model
+       weights are returned.
+    3. A local path passed as ``model`` starts a new fine-tuning run from that file.
+    4. A downloadable model alias is downloaded and used to initialize the model.
+    5. Any other supported model name is treated as an architecture-only model.
+
+    Local paths take precedence over downloadable aliases. Downloadable weights for
+    ``model`` are never resolved when ``checkpoint`` or ``resume_interrupted`` is used.
 
     Args:
         fabric: Fabric instance used to load checkpoint files.
@@ -1337,27 +1353,11 @@ def load_checkpoint(
         ValueError: If resume and checkpoint options are requested simultaneously.
         FileNotFoundError: If the resolved checkpoint file does not exist.
     """
-    model_path: Path | None
     model_name = model
-    model_name_from_checkpoint = False
-    try:
-        get_train_model_cls(model_name=model, task=task)
-    except ValueError:
-        # Download checkpoint only from rank zero. Other ranks will load from cache.
-        with fabric.rank_zero_first():
-            model_path = task_model_helpers.download_checkpoint(checkpoint=model)
-        model_name_from_checkpoint = True
-    else:
-        model_path = None
 
-    ckpt_path: Path
+    # Resume checkpoints are authoritative. In particular, do not resolve or download
+    # model here: users normally repeat the original model argument when resuming.
     if resume_interrupted:
-        if model_path is not None:
-            logger.warning(
-                "`model` is set to a pretrained checkpoint while `resume_interrupted` "
-                "is True. Loading weights from the interrupted run and ignoring "
-                f"model='{model}'."
-            )
         if checkpoint is not None:
             raise ValueError(
                 f"resume_interrupted={resume_interrupted} and checkpoint='{checkpoint}' "
@@ -1378,19 +1378,39 @@ def load_checkpoint(
             model_name,
             model_init_args,
         )
-    elif checkpoint is not None:
-        if model_path is not None:
-            logger.warning(
-                "`model` is set to a pretrained checkpoint while `checkpoint` is also "
-                "set to a pretrained checkpoint. Loading weights from checkpoint "
-                f"'{checkpoint}' and ignoring model='{model}'."
-            )
+
+    model_name_from_checkpoint = False
+    if checkpoint is not None:
+        # The explicit checkpoint supplies the weights and exact architecture. Resolve
+        # model only as an architecture to validate the task-model family; a hosted
+        # alias must not trigger a second checkpoint download in this branch.
+        requested_train_model_cls = get_train_model_cls(model_name=model, task=task)
         ckpt_path = Path(checkpoint).resolve()
-    elif model_path is not None:
-        ckpt_path = model_path
     else:
-        # No checkpoint to load. Backbone will be initialized from model name.
-        return (None, None, model_name, None)
+        requested_train_model_cls = None
+        model_path = Path(model).resolve()
+        if model_path.exists():
+            should_load_model_checkpoint = True
+        elif model in task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH:
+            should_load_model_checkpoint = True
+        else:
+            try:
+                get_train_model_cls(model_name=model, task=task)
+            except ValueError:
+                # Preserve the established error handling for missing paths and unknown
+                # model names in download_checkpoint().
+                should_load_model_checkpoint = True
+            else:
+                should_load_model_checkpoint = False
+
+        if not should_load_model_checkpoint:
+            # No checkpoint to load. Backbone will be initialized from model name.
+            return (None, None, model_name, None)
+
+        # Download/resolve checkpoint only from rank zero. Other ranks load from cache.
+        with fabric.rank_zero_first():
+            ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+        model_name_from_checkpoint = True
 
     if not ckpt_path.exists():
         raise FileNotFoundError(f"Checkpoint file '{ckpt_path}' does not exist.")
@@ -1403,7 +1423,19 @@ def load_checkpoint(
         ckpt = fabric.load(path=ckpt_path)
 
     model_init_args = ckpt.get("model_init_args", {})
-    if model_name_from_checkpoint:
+    checkpoint_model_name = model_init_args.get("model_name")
+    if checkpoint is not None and checkpoint_model_name is not None:
+        checkpoint_train_model_cls = get_train_model_cls(
+            model_name=checkpoint_model_name,
+            task=task,
+        )
+        if checkpoint_train_model_cls is not requested_train_model_cls:
+            raise ValueError(
+                f"Model '{model}' and checkpoint '{ckpt_path}' use incompatible "
+                "task-model families."
+            )
+        model_name = checkpoint_model_name
+    elif model_name_from_checkpoint:
         model_name = model_init_args.get("model_name", model)
 
     model_class_path = ckpt.get("model_class_path", "")

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -1354,9 +1354,12 @@ def load_checkpoint(
         FileNotFoundError: If the resolved checkpoint file does not exist.
     """
     model_name = model
+    model_name_from_checkpoint = False
+    requested_train_model_cls: type[TrainModel] | None = None
 
-    # Resume checkpoints are authoritative. In particular, do not resolve or download
-    # model here: users normally repeat the original model argument when resuming.
+    # Case 1: Resume checkpoints are authoritative. In particular, do not resolve or
+    # download model here: users normally repeat the original model argument when
+    # resuming.
     if resume_interrupted:
         if checkpoint is not None:
             raise ValueError(
@@ -1378,39 +1381,39 @@ def load_checkpoint(
             model_name,
             model_init_args,
         )
-
-    model_name_from_checkpoint = False
-    if checkpoint is not None:
+    # Case 2: An explicit checkpoint supplies the weights and exact architecture.
+    elif checkpoint is not None:
         # The explicit checkpoint supplies the weights and exact architecture. Resolve
         # model only as an architecture to validate the task-model family; a hosted
         # alias must not trigger a second checkpoint download in this branch.
         requested_train_model_cls = get_train_model_cls(model_name=model, task=task)
         ckpt_path = Path(checkpoint).resolve()
     else:
-        requested_train_model_cls = None
         model_path = Path(model).resolve()
+
+        # Case 3: A local path passed as model starts a new fine-tuning run.
         if model_path.exists():
-            should_load_model_checkpoint = True
+            with fabric.rank_zero_first():
+                ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+            model_name_from_checkpoint = True
+        # Case 4: A downloadable model alias initializes the model from hosted weights.
         elif model in task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH:
-            should_load_model_checkpoint = True
+            with fabric.rank_zero_first():
+                ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+            model_name_from_checkpoint = True
         else:
             try:
                 get_train_model_cls(model_name=model, task=task)
             except ValueError:
                 # Preserve the established error handling for missing paths and unknown
                 # model names in download_checkpoint().
-                should_load_model_checkpoint = True
+                with fabric.rank_zero_first():
+                    ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+                model_name_from_checkpoint = True
             else:
-                should_load_model_checkpoint = False
-
-        if not should_load_model_checkpoint:
-            # No checkpoint to load. Backbone will be initialized from model name.
-            return (None, None, model_name, None)
-
-        # Download/resolve checkpoint only from rank zero. Other ranks load from cache.
-        with fabric.rank_zero_first():
-            ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
-        model_name_from_checkpoint = True
+                # Case 5: A supported model name initializes the architecture without
+                # loading a checkpoint.
+                return (None, None, model_name, None)
 
     if not ckpt_path.exists():
         raise FileNotFoundError(f"Checkpoint file '{ckpt_path}' does not exist.")
@@ -1425,6 +1428,8 @@ def load_checkpoint(
     model_init_args = ckpt.get("model_init_args", {})
     checkpoint_model_name = model_init_args.get("model_name")
     if checkpoint is not None and checkpoint_model_name is not None:
+        # Case 2: Prefer the explicit checkpoint's exact architecture after validating
+        # that it belongs to the requested task-model family.
         checkpoint_train_model_cls = get_train_model_cls(
             model_name=checkpoint_model_name,
             task=task,
@@ -1436,6 +1441,7 @@ def load_checkpoint(
             )
         model_name = checkpoint_model_name
     elif model_name_from_checkpoint:
+        # Cases 3 and 4: Initialize from the architecture stored in the checkpoint.
         model_name = model_init_args.get("model_name", model)
 
     model_class_path = ckpt.get("model_class_path", "")

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -1473,6 +1473,7 @@ def resume_from_checkpoint(
 def finetune_from_checkpoint(
     state: TrainTaskState,
     checkpoint: CheckpointDict,
+    checkpoint_path: PathLike,
 ) -> None:
     """Restore model state from the checkpoint for fine-tuning.
 
@@ -1480,6 +1481,7 @@ def finetune_from_checkpoint(
         state: Training state container to populate with checkpoint data.
         checkpoint: Checkpoint context the state dicts to load.
     """
+    logger.info(f"Fine-tuning from checkpoint '{checkpoint_path}'")
 
     train_model = cast(TrainModel, state["train_model"])
 

--- a/src/lightly_train/_commands/train_task_helpers.py
+++ b/src/lightly_train/_commands/train_task_helpers.py
@@ -14,7 +14,17 @@ import logging
 from dataclasses import dataclass
 from json import JSONEncoder
 from pathlib import Path
-from typing import Any, Generator, Iterable, Literal, Mapping, cast
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    cast,
+)
 
 import torch
 from filelock import FileLock
@@ -27,6 +37,7 @@ from torch.nn import Module
 from torch.optim import Optimizer  # type: ignore[attr-defined]
 from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader
+from typing_extensions import TypeAlias
 
 from lightly_train._configs import validate
 from lightly_train._data import cache
@@ -116,6 +127,13 @@ except ImportError:
     mlflow = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
+
+_CheckpointLoadResult: TypeAlias = Tuple[
+    Optional[CheckpointDict],
+    Optional[Path],
+    str,
+    Optional[Dict[str, Any]],
+]
 
 
 TASK_TRAIN_MODEL_CLASSES: list[type[TrainModel]] = [
@@ -1317,8 +1335,8 @@ def load_checkpoint(
     model: str,
     checkpoint: PathLike | None,
     task: str,
-) -> tuple[CheckpointDict | None, Path | None, str, dict[str, Any] | None]:
-    """Resolve model initialization and resume checkpoints.
+) -> _CheckpointLoadResult:
+    """Dispatch to the checkpoint flow selected by the training configuration.
 
     Resolution follows these rules, in order:
 
@@ -1345,92 +1363,71 @@ def load_checkpoint(
         task: The training task.
 
     Returns:
-        (checkpoint, checkpoint_path, model_name) tuple. Checkpoint contains the loaded
-        checkpoint if available. model_name is the name of the model to initialize the
-        backbone from. Checkpoint is None if no checkpoint was loaded or if
-        resume_interrupted is True.
+        A tuple containing the checkpoint weights, checkpoint path, resolved model name,
+        and model initialization arguments. Checkpoint weights are None when no
+        checkpoint is loaded or when resuming an interrupted run.
 
     Raises:
         ValueError: If resume and checkpoint options are requested simultaneously.
         FileNotFoundError: If the resolved checkpoint file does not exist.
     """
-    model_name = model
-    model_name_from_checkpoint = False
-    requested_train_model_cls: type[TrainModel] | None = None
-
-    # Case 1: Resume checkpoints are authoritative. In particular, do not resolve or
-    # download model here: users normally repeat the original model argument when
-    # resuming.
     if resume_interrupted:
         if checkpoint is not None:
             raise ValueError(
                 f"resume_interrupted={resume_interrupted} and checkpoint='{checkpoint}' "
                 "cannot be set at the same time! Please set only one of them. "
             )
-        ckpt_path = get_checkpoint_path(out_dir, best_or_last="last")
-        # We don't return the loaded checkpoint here because it has to be loaded with
-        # fabric.load(ckpt_path, state) for resume to work properly.
+        return _load_resume_checkpoint(out_dir=out_dir)
 
-        # Get the model_init_args and update the model_name from the checkpoint.
-        # This is needed when resuming from a crashed run and the model_name contains
-        # an extra suffix, e.g., '-coco'.
-        model_init_args = read_model_init_args_from_ckpt(ckpt_path)
-        model_name = model_init_args["model_name"]
-        return (
-            None,
-            ckpt_path,
-            model_name,
-            model_init_args,
+    if checkpoint is not None:
+        return _load_explicit_checkpoint(
+            fabric=fabric,
+            model=model,
+            checkpoint=checkpoint,
+            task=task,
         )
-    # Case 2: An explicit checkpoint supplies the weights and exact architecture.
-    elif checkpoint is not None:
-        # The explicit checkpoint supplies the weights and exact architecture. Resolve
-        # model only as an architecture to validate the task-model family; a hosted
-        # alias must not trigger a second checkpoint download in this branch.
-        requested_train_model_cls = get_train_model_cls(model_name=model, task=task)
-        ckpt_path = Path(checkpoint).resolve()
-    else:
-        model_path = Path(model).resolve()
 
-        # Case 3: A local path passed as model starts a new fine-tuning run.
-        if model_path.exists():
-            with fabric.rank_zero_first():
-                ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
-            model_name_from_checkpoint = True
-        # Case 4: A downloadable model alias initializes the model from hosted weights.
-        elif model in task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH:
-            with fabric.rank_zero_first():
-                ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
-            model_name_from_checkpoint = True
-        else:
-            try:
-                get_train_model_cls(model_name=model, task=task)
-            except ValueError:
-                # Preserve the established error handling for missing paths and unknown
-                # model names in download_checkpoint().
-                with fabric.rank_zero_first():
-                    ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
-                model_name_from_checkpoint = True
-            else:
-                # Case 5: A supported model name initializes the architecture without
-                # loading a checkpoint.
-                return (None, None, model_name, None)
+    if Path(model).resolve().exists():
+        return _load_local_model_checkpoint(fabric=fabric, model=model)
+
+    if model in task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH:
+        return _load_downloadable_model_checkpoint(fabric=fabric, model=model)
+
+    try:
+        return _load_architecture_only_model(model=model, task=task)
+    except ValueError:
+        return _load_unknown_model_checkpoint(fabric=fabric, model=model)
+
+
+def _load_resume_checkpoint(out_dir: Path) -> _CheckpointLoadResult:
+    ckpt_path = get_checkpoint_path(out_dir, best_or_last="last")
+    # The checkpoint must later be loaded with fabric.load(ckpt_path, state) for a full
+    # training resume, so only its model initialization arguments are read here.
+    model_init_args = read_model_init_args_from_ckpt(ckpt_path)
+    model_name = model_init_args["model_name"]
+    return (None, ckpt_path, model_name, model_init_args)
+
+
+def _load_explicit_checkpoint(
+    fabric: Fabric,
+    model: str,
+    checkpoint: PathLike,
+    task: str,
+) -> _CheckpointLoadResult:
+    requested_train_model_cls = get_train_model_cls(model_name=model, task=task)
+    ckpt_path = Path(checkpoint).resolve()
 
     if not ckpt_path.exists():
         raise FileNotFoundError(f"Checkpoint file '{ckpt_path}' does not exist.")
 
     logger.info(f"Loading model checkpoint from '{ckpt_path}'")
-
-    # Need context manager because fabric.load doesn't expose weights_only parameter and
-    # the checkpoint might contain more than just model weights.
     with _torch_weights_only_false():
         ckpt = fabric.load(path=ckpt_path)
 
     model_init_args = ckpt.get("model_init_args", {})
     checkpoint_model_name = model_init_args.get("model_name")
-    if checkpoint is not None and checkpoint_model_name is not None:
-        # Case 2: Prefer the explicit checkpoint's exact architecture after validating
-        # that it belongs to the requested task-model family.
+    model_name = model
+    if checkpoint_model_name is not None:
         checkpoint_train_model_cls = get_train_model_cls(
             model_name=checkpoint_model_name,
             task=task,
@@ -1441,10 +1438,120 @@ def load_checkpoint(
                 "task-model families."
             )
         model_name = checkpoint_model_name
-    elif model_name_from_checkpoint:
-        # Cases 3 and 4: Initialize from the architecture stored in the checkpoint.
-        model_name = model_init_args.get("model_name", model)
 
+    model_class_path = ckpt.get("model_class_path", "")
+    train_model_state_dict = ckpt.get("train_model")
+    if train_model_state_dict is None:
+        raise ValueError(
+            f"Checkpoint file '{ckpt_path}' does not contain model state dict."
+        )
+
+    return (
+        CheckpointDict(
+            train_model_state_dict=train_model_state_dict,
+            model_class_path=model_class_path,
+            model_init_args=model_init_args,
+        ),
+        ckpt_path,
+        model_name,
+        model_init_args,
+    )
+
+
+def _load_local_model_checkpoint(
+    fabric: Fabric,
+    model: str,
+) -> _CheckpointLoadResult:
+    with fabric.rank_zero_first():
+        ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"Checkpoint file '{ckpt_path}' does not exist.")
+
+    logger.info(f"Loading model checkpoint from '{ckpt_path}'")
+    with _torch_weights_only_false():
+        ckpt = fabric.load(path=ckpt_path)
+
+    model_init_args = ckpt.get("model_init_args", {})
+    model_name = model_init_args.get("model_name", model)
+    model_class_path = ckpt.get("model_class_path", "")
+    train_model_state_dict = ckpt.get("train_model")
+    if train_model_state_dict is None:
+        raise ValueError(
+            f"Checkpoint file '{ckpt_path}' does not contain model state dict."
+        )
+
+    return (
+        CheckpointDict(
+            train_model_state_dict=train_model_state_dict,
+            model_class_path=model_class_path,
+            model_init_args=model_init_args,
+        ),
+        ckpt_path,
+        model_name,
+        model_init_args,
+    )
+
+
+def _load_downloadable_model_checkpoint(
+    fabric: Fabric,
+    model: str,
+) -> _CheckpointLoadResult:
+    with fabric.rank_zero_first():
+        ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"Checkpoint file '{ckpt_path}' does not exist.")
+
+    logger.info(f"Loading model checkpoint from '{ckpt_path}'")
+    with _torch_weights_only_false():
+        ckpt = fabric.load(path=ckpt_path)
+
+    model_init_args = ckpt.get("model_init_args", {})
+    model_name = model_init_args.get("model_name", model)
+    model_class_path = ckpt.get("model_class_path", "")
+    train_model_state_dict = ckpt.get("train_model")
+    if train_model_state_dict is None:
+        raise ValueError(
+            f"Checkpoint file '{ckpt_path}' does not contain model state dict."
+        )
+
+    return (
+        CheckpointDict(
+            train_model_state_dict=train_model_state_dict,
+            model_class_path=model_class_path,
+            model_init_args=model_init_args,
+        ),
+        ckpt_path,
+        model_name,
+        model_init_args,
+    )
+
+
+def _load_architecture_only_model(model: str, task: str) -> _CheckpointLoadResult:
+    get_train_model_cls(model_name=model, task=task)
+    return (None, None, model, None)
+
+
+def _load_unknown_model_checkpoint(
+    fabric: Fabric,
+    model: str,
+) -> _CheckpointLoadResult:
+    # Calling download_checkpoint preserves the detailed error for unknown paths and
+    # non-hosted models. Keep this as a complete flow in case it resolves a model added
+    # by a downstream registry.
+    with fabric.rank_zero_first():
+        ckpt_path = task_model_helpers.download_checkpoint(checkpoint=model)
+
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"Checkpoint file '{ckpt_path}' does not exist.")
+
+    logger.info(f"Loading model checkpoint from '{ckpt_path}'")
+    with _torch_weights_only_false():
+        ckpt = fabric.load(path=ckpt_path)
+
+    model_init_args = ckpt.get("model_init_args", {})
+    model_name = model_init_args.get("model_name", model)
     model_class_path = ckpt.get("model_class_path", "")
     train_model_state_dict = ckpt.get("train_model")
     if train_model_state_dict is None:

--- a/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
@@ -130,8 +130,9 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
 
     Only holds fields whose defaults are identical across both subclasses.
     Fields that differ (lr, backbone_lr_factor, scheduler_name, lr_warmup_steps,
-    patch_size) as well as default_batch_size/default_steps and resolve_auto are
-    defined individually on each subclass.
+    patch_size) as well as default_batch_size/default_steps, resolve_auto, and the
+    effective_loss_weight_dict/effective_losses computed fields are defined
+    individually on each subclass.
     """
 
     backbone_weights: PathLike | None = None
@@ -197,24 +198,6 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
         else:
             config = LTDETR_MODEL_REGISTRY.get(alias=model_name)()
             self.decoder_name = config.transformer.decoder_name
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def effective_loss_weight_dict(self) -> dict[str, float]:
-        if no_auto(self.decoder_name) == "dfine":
-            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
-        return dict(self.loss_weight_dict)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def effective_losses(self) -> list[str]:
-        if no_auto(self.decoder_name) == "dfine":
-            return [
-                *self.losses,
-                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
-            ]
-        return list(self.losses)
-
 
 class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
     default_batch_size: ClassVar[int] = 32
@@ -312,6 +295,23 @@ class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
                     total_steps - scheduler_step_schedule.step_stop
                 )
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if self.decoder_name == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if self.decoder_name == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
+
 
 class DINOv2LTDETRObjectDetectionTrainArgsV2(BaseLTDETRObjectDetectionTrainArgs):
     default_batch_size: ClassVar[int] = 16
@@ -363,6 +363,23 @@ class DINOv2LTDETRObjectDetectionTrainArgsV2(BaseLTDETRObjectDetectionTrainArgs)
                 self.scheduler_no_aug_steps = (
                     total_steps - scheduler_step_schedule.step_stop
                 )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if self.decoder_name == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if self.decoder_name == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
 
 
 class LTDETRObjectDetectionTrain(TrainModel):

--- a/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
@@ -11,7 +11,7 @@ import copy
 import logging
 import math
 import re
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 
 import torch
 from lightning_fabric import Fabric
@@ -37,6 +37,9 @@ from lightly_train._metrics.detection.task_metric import (
 )
 from lightly_train._optim import optimizer_helpers
 from lightly_train._pre_post_processing.object_detection import ObjectDetectionOutput
+from lightly_train._task_models.ltdetr_object_detection.config import (
+    LTDETR_MODEL_REGISTRY,
+)
 from lightly_train._task_models.ltdetr_object_detection.dino_vit_wrapper import (
     DINOSTAs,
 )
@@ -126,16 +129,16 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
     DINOv2LTDETRObjectDetectionTrainArgsV2.
 
     Only holds fields whose defaults are identical across both subclasses.
-    Fields that differ (decoder_name, lr, backbone_lr_factor, scheduler_name,
-    lr_warmup_steps, patch_size) as well as default_batch_size/default_steps,
-    resolve_auto, and the effective_loss_weight_dict/effective_losses computed
-    fields are defined individually on each subclass.
+    Fields that differ (lr, backbone_lr_factor, scheduler_name, lr_warmup_steps,
+    patch_size) as well as default_batch_size/default_steps and resolve_auto are
+    defined individually on each subclass.
     """
 
     backbone_weights: PathLike | None = None
     backbone_url: str = ""
     backbone_args: dict[str, Any] = {}
     backbone_freeze: bool = False
+    decoder_name: Literal["auto", "rtdetrv2", "dfine"] = "auto"
 
     use_ema_model: bool = True
     ema_momentum: float = 0.9999
@@ -172,6 +175,46 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
     scheduler_flat_steps: int | Literal["auto"] = "auto"
     scheduler_no_aug_steps: int | Literal["auto"] = "auto"
 
+    def _resolve_decoder_name(
+        self, model_name: str, model_init_args: dict[str, Any]
+    ) -> None:
+        """Resolve the decoder from user args, checkpoint metadata, or architecture."""
+        checkpoint_decoder_name = model_init_args.get("decoder_name")
+        if self.decoder_name != "auto":
+            if (
+                checkpoint_decoder_name is not None
+                and self.decoder_name != checkpoint_decoder_name
+            ):
+                logger.warning(
+                    f"Requested decoder_name={self.decoder_name!r} differs from "
+                    f"the checkpoint's decoder_name={checkpoint_decoder_name!r}; "
+                    "the checkpoint decoder weights will not load cleanly."
+                )
+            return
+
+        if checkpoint_decoder_name is not None:
+            self.decoder_name = checkpoint_decoder_name
+        else:
+            config = LTDETR_MODEL_REGISTRY.get(alias=model_name)()
+            self.decoder_name = config.transformer.decoder_name
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_loss_weight_dict(self) -> dict[str, float]:
+        if no_auto(self.decoder_name) == "dfine":
+            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
+        return dict(self.loss_weight_dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_losses(self) -> list[str]:
+        if no_auto(self.decoder_name) == "dfine":
+            return [
+                *self.losses,
+                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
+            ]
+        return list(self.losses)
+
 
 class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
     default_batch_size: ClassVar[int] = 32
@@ -180,7 +223,6 @@ class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
     )
 
     patch_size: int | Literal["auto"] | None = "auto"
-    decoder_name: Literal["rtdetrv2", "dfine"] = "dfine"
 
     # Optimizer configuration
     lr: float = Field(
@@ -247,23 +289,9 @@ class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
                             "Unable to resolve patch_size='auto' for model "
                             f"{model_name!r}. Please provide a concrete patch_size."
                         )
-        # Resolve ``decoder_name`` against the checkpoint architecture when
-        # the user did not explicitly set it. This preserves backward
-        # compatibility for hosted/local checkpoints trained with the previous
-        # RTDETRv2 default: loading those checkpoints builds a D-FINE model by
-        # default and would otherwise leave the decoder partially initialized.
-        # TODO(TRN-2243): Replace this compatibility shim with separate
-        # LTDETRv2/LTDETRv3 train-args classes once the config split lands.
-        checkpoint_decoder_name = model_init_args.get("decoder_name")
-        if checkpoint_decoder_name is not None:
-            if "decoder_name" not in self.model_fields_set:
-                self.decoder_name = checkpoint_decoder_name
-            elif self.decoder_name != checkpoint_decoder_name:
-                logger.warning(
-                    f"Requested decoder_name={self.decoder_name!r} differs from "
-                    f"the checkpoint's decoder_name={checkpoint_decoder_name!r}; "
-                    "the checkpoint decoder weights will not load cleanly."
-                )
+        self._resolve_decoder_name(
+            model_name=model_name, model_init_args=model_init_args
+        )
 
         if (
             self.lr_warmup_steps == "auto"
@@ -284,31 +312,12 @@ class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
                     total_steps - scheduler_step_schedule.step_stop
                 )
 
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def effective_loss_weight_dict(self) -> dict[str, float]:
-        if self.decoder_name == "dfine":
-            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
-        return dict(self.loss_weight_dict)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def effective_losses(self) -> list[str]:
-        if self.decoder_name == "dfine":
-            return [
-                *self.losses,
-                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
-            ]
-        return list(self.losses)
-
 
 class DINOv2LTDETRObjectDetectionTrainArgsV2(BaseLTDETRObjectDetectionTrainArgs):
     default_batch_size: ClassVar[int] = 16
     default_steps: ClassVar[int] = (
         100_000 // 16 * 72
     )  # TODO (Lionel, 10/25): Adjust default steps.
-
-    decoder_name: Literal["rtdetrv2", "dfine"] = "rtdetrv2"
 
     # DINOv2 ViT backbones are always patch-14 (vits14/vitb14/vitl14/vitg14), matching
     # LTDETR_MODEL_REGISTRY's dinov2 backbone_args.
@@ -339,6 +348,9 @@ class DINOv2LTDETRObjectDetectionTrainArgsV2(BaseLTDETRObjectDetectionTrainArgs)
         model_init_args: dict[str, Any],
         data_args: TaskDataArgs,
     ) -> None:
+        self._resolve_decoder_name(
+            model_name=model_name, model_init_args=model_init_args
+        )
         if self.scheduler_flat_steps == "auto" or self.scheduler_no_aug_steps == "auto":
             scheduler_step_schedule = resolve_ltdetr_step_schedule(
                 total_steps=total_steps,
@@ -351,23 +363,6 @@ class DINOv2LTDETRObjectDetectionTrainArgsV2(BaseLTDETRObjectDetectionTrainArgs)
                 self.scheduler_no_aug_steps = (
                     total_steps - scheduler_step_schedule.step_stop
                 )
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def effective_loss_weight_dict(self) -> dict[str, float]:
-        if self.decoder_name == "dfine":
-            return {**_DFINE_EXTRA_LOSS_WEIGHT_DICT, **self.loss_weight_dict}
-        return dict(self.loss_weight_dict)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def effective_losses(self) -> list[str]:
-        if self.decoder_name == "dfine":
-            return [
-                *self.losses,
-                *(name for name in _DFINE_EXTRA_LOSSES if name not in self.losses),
-            ]
-        return list(self.losses)
 
 
 class LTDETRObjectDetectionTrain(TrainModel):
@@ -442,6 +437,9 @@ class LTDETRObjectDetectionTrain(TrainModel):
         backbone_args: dict[str, Any] | None = model_args.backbone_args
         if not backbone_args:
             backbone_args = None
+        decoder_name = cast(
+            Literal["rtdetrv2", "dfine"], no_auto(model_args.decoder_name)
+        )
         self.model: LTDETRObjectDetection = LTDETRObjectDetection(
             model_name=model_name,
             image_size=no_auto(val_transform_args.image_size),
@@ -451,7 +449,7 @@ class LTDETRObjectDetectionTrain(TrainModel):
             backbone_args=backbone_args,
             patch_size=no_auto(model_args.patch_size),
             backbone_weights=model_args.backbone_weights,
-            decoder_name=model_args.decoder_name,
+            decoder_name=decoder_name,
             load_weights=load_weights,
         )
 
@@ -472,7 +470,7 @@ class LTDETRObjectDetectionTrain(TrainModel):
         )
 
         criterion: DFINECriterion | RTDETRCriterionv2
-        if model_args.decoder_name == "dfine":
+        if decoder_name == "dfine":
             self.train_loss_names = _DFINE_LOSS_NAMES
             self.val_loss_names = _RTDETRV2_LOSS_NAMES
             if not isinstance(self.model.decoder, DFINETransformer):

--- a/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
@@ -179,7 +179,12 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
     def _resolve_decoder_name(
         self, model_name: str, model_init_args: dict[str, Any]
     ) -> None:
-        """Resolve the decoder from user args, checkpoint metadata, or architecture."""
+        """Resolve the decoder from user args, checkpoint metadata, or architecture.
+
+        ``decoder_name`` is optional checkpoint metadata, not a checkpoint-version
+        marker. If it is absent, the checkpoint's stored model name determines the
+        versioned architecture through ``LTDETR_MODEL_REGISTRY``.
+        """
         checkpoint_decoder_name = model_init_args.get("decoder_name")
         if self.decoder_name != "auto":
             if (
@@ -195,9 +200,10 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
 
         if checkpoint_decoder_name is not None:
             self.decoder_name = checkpoint_decoder_name
-        else:
-            config = LTDETR_MODEL_REGISTRY.get(alias=model_name)()
-            self.decoder_name = config.transformer.decoder_name
+            return
+
+        config = LTDETR_MODEL_REGISTRY.get(alias=model_name)()
+        self.decoder_name = config.transformer.decoder_name
 
 
 class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):

--- a/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/train_model.py
@@ -199,6 +199,7 @@ class BaseLTDETRObjectDetectionTrainArgs(TrainModelArgs):
             config = LTDETR_MODEL_REGISTRY.get(alias=model_name)()
             self.decoder_name = config.transformer.decoder_name
 
+
 class LTDETRObjectDetectionTrainArgs(BaseLTDETRObjectDetectionTrainArgs):
     default_batch_size: ClassVar[int] = 32
     default_steps: ClassVar[int] = (

--- a/src/lightly_train/_task_models/task_model_helpers.py
+++ b/src/lightly_train/_task_models/task_model_helpers.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import hashlib
 import importlib
-import inspect
 import logging
 import os
 import urllib.parse
@@ -264,16 +263,6 @@ def init_model_from_checkpoint(
     model_class = getattr(module, class_name)
     model_init_args = checkpoint["model_init_args"]
     model_init_args["load_weights"] = False
-
-    # Backward compat: This is similar to the fix in dinov3_ltdetr_object_detection/train_model.py:210–226
-    # and should be fixed together
-    # TODO(TRN-2243): Replace this compatibility shim with separate
-    # LTDETRv2/LTDETRv3 taskmodel args classes once the config split lands.
-    if (
-        "decoder_name" not in model_init_args
-        and "decoder_name" in inspect.signature(model_class.__init__).parameters
-    ):
-        model_init_args["decoder_name"] = "rtdetrv2"
 
     # Create model instance
     model: TaskModel = model_class(**model_init_args)

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -11,7 +11,9 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+import torch
 from pytest import LogCaptureFixture
+from pytest_mock import MockerFixture
 
 from lightly_train._commands.train_task_helpers import (
     BestAggregatedMetricValues,
@@ -19,6 +21,7 @@ from lightly_train._commands.train_task_helpers import (
     get_train_model_args,
     get_train_model_cls,
     get_transform_args,
+    load_checkpoint,
     log_step,
 )
 from lightly_train._data.yolo_object_detection_dataset import (
@@ -39,6 +42,195 @@ from lightly_train._task_models.ltdetr_object_detection.transforms import (
     LTDETRObjectDetectionValTransform,
 )
 from lightly_train._training_step_timer import TimerAggregateMetrics
+
+
+@pytest.mark.parametrize(
+    ("model", "task", "checkpoint_model_name"),
+    [
+        ("ltdetrv2-s-coco", "object_detection", "edgecrafter/ecvitt-ltdetr"),
+        (
+            "dinov3/vits16-eomt-coco",
+            "semantic_segmentation",
+            "dinov3/vits16-eomt",
+        ),
+    ],
+)
+def test_load_checkpoint__downloadable_supported_alias_loads_checkpoint(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    model: str,
+    task: str,
+    checkpoint_model_name: str,
+) -> None:
+    checkpoint_path = tmp_path / "model.pt"
+    checkpoint_path.touch()
+    train_model_state_dict = {"model.weight": "pretrained"}
+    checkpoint_dict = {
+        "train_model": train_model_state_dict,
+        "model_class_path": "package.TaskModel",
+        "model_init_args": {"model_name": checkpoint_model_name},
+    }
+    fabric = mocker.MagicMock()
+    fabric.load.return_value = checkpoint_dict
+    download_checkpoint = mocker.patch(
+        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint",
+        return_value=checkpoint_path,
+    )
+
+    checkpoint, resolved_path, resolved_model, model_init_args = load_checkpoint(
+        fabric=fabric,
+        out_dir=tmp_path / "out",
+        resume_interrupted=False,
+        model=model,
+        checkpoint=None,
+        task=task,
+    )
+
+    download_checkpoint.assert_called_once_with(checkpoint=model)
+    fabric.load.assert_called_once_with(path=checkpoint_path)
+    assert resolved_path == checkpoint_path
+    assert resolved_model == checkpoint_model_name
+    assert model_init_args == checkpoint_dict["model_init_args"]
+    assert checkpoint == {
+        "train_model_state_dict": train_model_state_dict,
+        "model_class_path": "package.TaskModel",
+        "model_init_args": checkpoint_dict["model_init_args"],
+    }
+
+
+def test_load_checkpoint__supported_architecture_does_not_load_checkpoint(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    fabric = mocker.MagicMock()
+    download_checkpoint = mocker.patch(
+        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint"
+    )
+
+    result = load_checkpoint(
+        fabric=fabric,
+        out_dir=tmp_path / "out",
+        resume_interrupted=False,
+        model="ltdetrv2-s",
+        checkpoint=None,
+        task="object_detection",
+    )
+
+    assert result == (None, None, "ltdetrv2-s", None)
+    download_checkpoint.assert_not_called()
+    fabric.load.assert_not_called()
+
+
+def test_load_checkpoint__explicit_checkpoint_overrides_downloadable_model(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    checkpoint_path = tmp_path / "explicit.pt"
+    checkpoint_path.touch()
+    checkpoint_dict = {
+        "train_model": {"model.weight": "explicit"},
+        "model_class_path": "package.TaskModel",
+        "model_init_args": {"model_name": "edgecrafter/ecvitt-ltdetr"},
+    }
+    fabric = mocker.MagicMock()
+    fabric.load.return_value = checkpoint_dict
+    download_checkpoint = mocker.patch(
+        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint"
+    )
+
+    _, resolved_path, resolved_model, _ = load_checkpoint(
+        fabric=fabric,
+        out_dir=tmp_path / "out",
+        resume_interrupted=False,
+        model="ltdetrv2-s-coco",
+        checkpoint=checkpoint_path,
+        task="object_detection",
+    )
+
+    assert resolved_path == checkpoint_path.resolve()
+    assert resolved_model == "edgecrafter/ecvitt-ltdetr"
+    download_checkpoint.assert_not_called()
+
+
+def test_load_checkpoint__explicit_checkpoint_rejects_incompatible_model_family(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    checkpoint_path = tmp_path / "explicit.pt"
+    checkpoint_path.touch()
+    fabric = mocker.MagicMock()
+    fabric.load.return_value = {
+        "train_model": {"model.weight": "explicit"},
+        "model_class_path": "package.TaskModel",
+        "model_init_args": {"model_name": "edgecrafter/ecvitt-ltdetr"},
+    }
+
+    with pytest.raises(ValueError, match="incompatible task-model families"):
+        load_checkpoint(
+            fabric=fabric,
+            out_dir=tmp_path / "out",
+            resume_interrupted=False,
+            model="picodet/s-416",
+            checkpoint=checkpoint_path,
+            task="object_detection",
+        )
+
+
+def test_load_checkpoint__explicit_legacy_checkpoint_uses_model_fallback(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    checkpoint_path = tmp_path / "legacy.ckpt"
+    checkpoint_path.touch()
+    fabric = mocker.MagicMock()
+    fabric.load.return_value = {
+        "train_model": {"model.weight": "legacy"},
+        "model_class_path": "",
+    }
+
+    checkpoint, _, resolved_model, model_init_args = load_checkpoint(
+        fabric=fabric,
+        out_dir=tmp_path / "out",
+        resume_interrupted=False,
+        model="ltdetrv2-s",
+        checkpoint=checkpoint_path,
+        task="object_detection",
+    )
+
+    assert resolved_model == "ltdetrv2-s"
+    assert model_init_args == {}
+    assert checkpoint is not None
+    assert checkpoint["train_model_state_dict"] == {"model.weight": "legacy"}
+
+
+def test_load_checkpoint__resume_ignores_downloadable_model(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    out_dir = tmp_path / "out"
+    checkpoint_path = out_dir / "checkpoints" / "last.ckpt"
+    checkpoint_path.parent.mkdir(parents=True)
+    torch.save(
+        {"model_init_args": {"model_name": "edgecrafter/ecvitt-ltdetr"}},
+        checkpoint_path,
+    )
+    fabric = mocker.MagicMock()
+    download_checkpoint = mocker.patch(
+        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint"
+    )
+
+    result = load_checkpoint(
+        fabric=fabric,
+        out_dir=out_dir,
+        resume_interrupted=True,
+        model="ltdetrv2-s-coco",
+        checkpoint=None,
+        task="object_detection",
+    )
+
+    assert result == (
+        None,
+        checkpoint_path,
+        "edgecrafter/ecvitt-ltdetr",
+        {"model_name": "edgecrafter/ecvitt-ltdetr"},
+    )
+    download_checkpoint.assert_not_called()
+    fabric.load.assert_not_called()
 
 
 def test_get_train_model_args_and_transform_args__propagate_patch_size_to_scale_jitter() -> (

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -47,6 +47,11 @@ from lightly_train._training_step_timer import TimerAggregateMetrics
 @pytest.mark.parametrize(
     ("model", "task", "checkpoint_model_name"),
     [
+        (
+            "dinov2/vits14-noreg-ltdetr-coco",
+            "object_detection",
+            "dinov2/vits14-noreg-ltdetr",
+        ),
         ("ltdetrv2-s-coco", "object_detection", "edgecrafter/ecvitt-ltdetr"),
         (
             "dinov3/vits16-eomt-coco",

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -98,60 +98,6 @@ def test_load_checkpoint__downloadable_supported_alias_loads_checkpoint(
     }
 
 
-def test_load_checkpoint__legacy_ltdetr_metadata_resolves_architecture_decoder(
-    mocker: MockerFixture, tmp_path: Path
-) -> None:
-    checkpoint_path = tmp_path / "model.pt"
-    checkpoint_path.touch()
-    fabric = mocker.MagicMock()
-    fabric.load.return_value = {
-        "train_model": {"model.weight": "pretrained"},
-        "model_class_path": (
-            "lightly_train._task_models.dinov3_ltdetr_object_detection.task_model"
-            ".DINOv3LTDETRObjectDetection"
-        ),
-        "model_init_args": {
-            "model_name": "dinov3/vitt16-ltdetr",
-            # Legacy hosted checkpoints do not contain decoder_name.
-        },
-    }
-    mocker.patch(
-        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint",
-        return_value=checkpoint_path,
-    )
-
-    _, _, model_name, model_init_args = load_checkpoint(
-        fabric=fabric,
-        out_dir=tmp_path / "out",
-        resume_interrupted=False,
-        model="dinov3/vitt16-ltdetr-coco",
-        checkpoint=None,
-        task="object_detection",
-    )
-    assert model_init_args is not None
-
-    model_args = cast(
-        LTDETRObjectDetectionTrainArgs,
-        get_train_model_args(
-            model_args=None,
-            model_args_cls=LTDETRObjectDetectionTrainArgs,
-            total_steps=1000,
-            gradient_accumulation_steps=1,
-            train_num_batches=100,
-            model_name=model_name,
-            model_init_args=model_init_args,
-            data_args=YOLOObjectDetectionDataArgs(
-                path=tmp_path,
-                train=Path("train/images"),
-                val=Path("val/images"),
-                names={0: "class_0", 1: "class_1"},
-            ),
-        ),
-    )
-
-    assert model_args.decoder_name == "rtdetrv2"
-
-
 def test_load_checkpoint__supported_architecture_does_not_load_checkpoint(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -174,6 +174,41 @@ def test_load_checkpoint__supported_architecture_does_not_load_checkpoint(
     fabric.load.assert_not_called()
 
 
+def test_load_checkpoint__local_model_path_loads_checkpoint(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    model_path = tmp_path / "model.pt"
+    model_path.touch()
+    checkpoint_dict = {
+        "train_model": {"model.weight": "pretrained"},
+        "model_class_path": "package.TaskModel",
+        "model_init_args": {"model_name": "ltdetrv2-s"},
+    }
+    fabric = mocker.MagicMock()
+    fabric.load.return_value = checkpoint_dict
+    download_checkpoint = mocker.patch(
+        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint",
+        return_value=model_path,
+    )
+
+    checkpoint, resolved_path, resolved_model, model_init_args = load_checkpoint(
+        fabric=fabric,
+        out_dir=tmp_path / "out",
+        resume_interrupted=False,
+        model=str(model_path),
+        checkpoint=None,
+        task="object_detection",
+    )
+
+    download_checkpoint.assert_called_once_with(checkpoint=str(model_path))
+    fabric.load.assert_called_once_with(path=model_path)
+    assert resolved_path == model_path
+    assert resolved_model == "ltdetrv2-s"
+    assert model_init_args == checkpoint_dict["model_init_args"]
+    assert checkpoint is not None
+    assert checkpoint["train_model_state_dict"] == checkpoint_dict["train_model"]
+
+
 def test_load_checkpoint__explicit_checkpoint_overrides_downloadable_model(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:

--- a/tests/_commands/test_train_task_helpers.py
+++ b/tests/_commands/test_train_task_helpers.py
@@ -98,6 +98,60 @@ def test_load_checkpoint__downloadable_supported_alias_loads_checkpoint(
     }
 
 
+def test_load_checkpoint__legacy_ltdetr_metadata_resolves_architecture_decoder(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    checkpoint_path = tmp_path / "model.pt"
+    checkpoint_path.touch()
+    fabric = mocker.MagicMock()
+    fabric.load.return_value = {
+        "train_model": {"model.weight": "pretrained"},
+        "model_class_path": (
+            "lightly_train._task_models.dinov3_ltdetr_object_detection.task_model"
+            ".DINOv3LTDETRObjectDetection"
+        ),
+        "model_init_args": {
+            "model_name": "dinov3/vitt16-ltdetr",
+            # Legacy hosted checkpoints do not contain decoder_name.
+        },
+    }
+    mocker.patch(
+        "lightly_train._commands.train_task_helpers.task_model_helpers.download_checkpoint",
+        return_value=checkpoint_path,
+    )
+
+    _, _, model_name, model_init_args = load_checkpoint(
+        fabric=fabric,
+        out_dir=tmp_path / "out",
+        resume_interrupted=False,
+        model="dinov3/vitt16-ltdetr-coco",
+        checkpoint=None,
+        task="object_detection",
+    )
+    assert model_init_args is not None
+
+    model_args = cast(
+        LTDETRObjectDetectionTrainArgs,
+        get_train_model_args(
+            model_args=None,
+            model_args_cls=LTDETRObjectDetectionTrainArgs,
+            total_steps=1000,
+            gradient_accumulation_steps=1,
+            train_num_batches=100,
+            model_name=model_name,
+            model_init_args=model_init_args,
+            data_args=YOLOObjectDetectionDataArgs(
+                path=tmp_path,
+                train=Path("train/images"),
+                val=Path("val/images"),
+                names={0: "class_0", 1: "class_1"},
+            ),
+        ),
+    )
+
+    assert model_args.decoder_name == "rtdetrv2"
+
+
 def test_load_checkpoint__supported_architecture_does_not_load_checkpoint(
     mocker: MockerFixture, tmp_path: Path
 ) -> None:

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -256,15 +256,8 @@ def test_dino_legacy_backbone_prefix_is_remapped() -> None:
 
 
 def test_checkpoint_roundtrip__rtdetrv2_decoder_preserved_when_not_explicit() -> None:
-    # Backwards compatibility: a checkpoint trained with the previous
-    # RTDETRv2 default must reconstruct with the RTDETRv2 architecture when
-    # the user does not explicitly set ``decoder_name``, even though the new
-    # default is dfine. This round-trip simulates loading such a checkpoint:
-    # we save the task model's ``init_args`` and ``state_dict`` (mirroring
-    # what ``lightly_train`` persists in the checkpoint file), build a fresh
-    # train model from defaults, feed it the saved ``init_args`` as the
-    # checkpoint payload, and verify the state dict loads cleanly into an
-    # RTDETRv2 decoder.
+    # Legacy checkpoints do not store ``decoder_name``. In that case the train
+    # args must resolve it from the registered architecture before loading weights.
     model_name = "dinov3/vitt16-notpretrained-ltdetr"
 
     # Source: an old-style RTDETRv2 checkpoint.
@@ -276,8 +269,9 @@ def test_checkpoint_roundtrip__rtdetrv2_decoder_preserved_when_not_explicit() ->
         source_args,
         model_name=model_name,
     )
-    checkpoint_model_init_args = source_train_model.get_task_model().init_args
+    checkpoint_model_init_args = dict(source_train_model.get_task_model().init_args)
     assert checkpoint_model_init_args["decoder_name"] == "rtdetrv2"
+    checkpoint_model_init_args.pop("decoder_name")
     checkpoint_state_dict = source_train_model.state_dict()
 
     # Pick a stable decoder tensor to compare before/after the round trip.
@@ -285,9 +279,8 @@ def test_checkpoint_roundtrip__rtdetrv2_decoder_preserved_when_not_explicit() ->
     assert decoder_keys, "expected at least one decoder tensor in the state dict"
     source_decoder_tensor = checkpoint_state_dict[decoder_keys[0]].clone()
 
-    # Target: a fresh train model built from the new defaults. The user does
-    # not explicitly set ``decoder_name``; ``model_init_args`` carries the
-    # checkpoint payload.
+    # Target: the user does not explicitly set ``decoder_name`` and the legacy
+    # checkpoint does not contain it either.
     target_args = LTDETRObjectDetectionTrainArgs(use_ema_model=False)
     target_train_model = _create_train_model(
         target_args,
@@ -295,7 +288,7 @@ def test_checkpoint_roundtrip__rtdetrv2_decoder_preserved_when_not_explicit() ->
         model_init_args=dict(checkpoint_model_init_args),
     )
 
-    # Architecture was reconstructed as RTDETRv2 via the compatibility shim.
+    # The DINOv3 v1 architecture selects RTDETRv2.
     assert target_args.decoder_name == "rtdetrv2"
     target_task_model = target_train_model.get_task_model()
     assert isinstance(target_task_model.decoder, RTDETRTransformerv2)
@@ -331,6 +324,49 @@ def test_resolve_transformer_config__selects_decoder_family(
     )
 
     assert isinstance(transformer_config, expected_config_type)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_decoder_name"),
+    [
+        ("dinov3/vitt16-notpretrained-ltdetr", "rtdetrv2"),
+        ("ltdetrv2-s", "dfine"),
+    ],
+)
+def test_resolve_auto__uses_architecture_decoder(
+    model_name: str,
+    expected_decoder_name: Literal["rtdetrv2", "dfine"],
+    dummy_yolo_detection_data_args: YOLOObjectDetectionDataArgs,
+) -> None:
+    model_args = LTDETRObjectDetectionTrainArgs()
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        gradient_accumulation_steps=1,
+        train_num_batches=100,
+        model_name=model_name,
+        model_init_args={},
+        data_args=dummy_yolo_detection_data_args,
+    )
+
+    assert model_args.decoder_name == expected_decoder_name
+
+
+def test_resolve_auto__checkpoint_decoder_overrides_architecture(
+    dummy_yolo_detection_data_args: YOLOObjectDetectionDataArgs,
+) -> None:
+    model_args = LTDETRObjectDetectionTrainArgs()
+
+    model_args.resolve_auto(
+        total_steps=1000,
+        gradient_accumulation_steps=1,
+        train_num_batches=100,
+        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        model_init_args={"decoder_name": "dfine"},
+        data_args=dummy_yolo_detection_data_args,
+    )
+
+    assert model_args.decoder_name == "dfine"
 
 
 def test_resolve_auto__warns_on_explicit_checkpoint_decoder_conflict(

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -335,6 +335,11 @@ def test_resolve_transformer_config__selects_decoder_family(
             DINOv2LTDETRObjectDetectionTrainArgsV2,
             "rtdetrv2",
         ),
+        (
+            "dinov2/vits14-noreg-ltdetr",
+            DINOv2LTDETRObjectDetectionTrainArgsV2,
+            "rtdetrv2",
+        ),
         ("dinov3/vitt16-ltdetr", LTDETRObjectDetectionTrainArgs, "rtdetrv2"),
         ("ltdetrv2-s", LTDETRObjectDetectionTrainArgs, "dfine"),
     ],

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -40,6 +40,7 @@ from lightly_train._task_models.ltdetr_object_detection.task_model import (
     _resolve_transformer_config,
 )
 from lightly_train._task_models.ltdetr_object_detection.train_model import (
+    DINOv2LTDETRObjectDetectionTrainArgsV2,
     LTDETRObjectDetectionTrain,
     LTDETRObjectDetectionTrainArgs,
 )
@@ -327,18 +328,26 @@ def test_resolve_transformer_config__selects_decoder_family(
 
 
 @pytest.mark.parametrize(
-    ("model_name", "expected_decoder_name"),
+    ("model_name", "train_args_cls", "expected_decoder_name"),
     [
-        ("dinov3/vitt16-notpretrained-ltdetr", "rtdetrv2"),
-        ("ltdetrv2-s", "dfine"),
+        (
+            "dinov2/vits14-noreg-ltdetr-coco",
+            DINOv2LTDETRObjectDetectionTrainArgsV2,
+            "rtdetrv2",
+        ),
+        ("dinov3/vitt16-ltdetr", LTDETRObjectDetectionTrainArgs, "rtdetrv2"),
+        ("ltdetrv2-s", LTDETRObjectDetectionTrainArgs, "dfine"),
     ],
 )
 def test_resolve_auto__uses_architecture_decoder(
     model_name: str,
+    train_args_cls: type[
+        LTDETRObjectDetectionTrainArgs | DINOv2LTDETRObjectDetectionTrainArgsV2
+    ],
     expected_decoder_name: Literal["rtdetrv2", "dfine"],
     dummy_yolo_detection_data_args: YOLOObjectDetectionDataArgs,
 ) -> None:
-    model_args = LTDETRObjectDetectionTrainArgs()
+    model_args = train_args_cls()
 
     model_args.resolve_auto(
         total_steps=1000,

--- a/tests/_task_models/test_task_model_helpers.py
+++ b/tests/_task_models/test_task_model_helpers.py
@@ -29,9 +29,6 @@ from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model imp
 from lightly_train._task_models.ltdetr_object_detection.task_model import (
     LTDETRObjectDetection,
 )
-from lightly_train._task_models.object_detection_components.dfine_decoder import (
-    DFINETransformer,
-)
 from lightly_train._task_models.object_detection_components.rtdetrv2_decoder import (
     RTDETRTransformerv2,
 )
@@ -164,9 +161,10 @@ def test_download_checkpoint__unknown_name__raises_generic() -> None:
     assert "convert_checkpoint_dav2" not in message
 
 
-def test_init_model_from_checkpoint__legacy_dinov2_ltdetr_reroutes_to_generic() -> None:
+def test_init_model_from_checkpoint__legacy_dinov2_uses_registered_decoder() -> None:
+    model_name = "dinov2/vits14-noreg-ltdetr"
     reference_model = LTDETRObjectDetection(
-        model_name="dinov3/vitt16-notpretrained-ltdetr",
+        model_name=model_name,
         classes={0: "class_0", 1: "class_1"},
         image_size=(256, 256),
         load_weights=False,
@@ -182,9 +180,11 @@ def test_init_model_from_checkpoint__legacy_dinov2_ltdetr_reroutes_to_generic() 
                 ".DINOv2LTDETRObjectDetection"
             ),
             "model_init_args": {
-                "model_name": "dinov3/vitt16-notpretrained-ltdetr",
+                "model_name": model_name,
                 "classes": {0: "class_0", 1: "class_1"},
                 "image_size": (256, 256),
+                # This matches the hosted legacy checkpoint: decoder_name was not
+                # stored, so the versioned model registry defines the architecture.
             },
             "train_model": train_state_dict,
         },
@@ -192,40 +192,8 @@ def test_init_model_from_checkpoint__legacy_dinov2_ltdetr_reroutes_to_generic() 
     )
 
     assert isinstance(model, LTDETRObjectDetection)
-    assert model.init_args["model_name"] == "dinov3/vitt16-notpretrained-ltdetr"
+    assert model.init_args["model_name"] == model_name
     assert model.init_args["decoder_name"] is None
     assert isinstance(model.decoder, RTDETRTransformerv2)
     for name, param in model.state_dict().items():
-        assert torch.equal(param, reference_model.state_dict()[name])
-
-
-def test_init_model_from_checkpoint__missing_decoder_uses_dfine_architecture() -> None:
-    reference_model = LTDETRObjectDetection(
-        model_name="ltdetrv2-s",
-        classes={0: "class_0", 1: "class_1"},
-        image_size=(256, 256),
-        load_weights=False,
-    )
-    train_state_dict = {
-        f"model.{name}": param for name, param in reference_model.state_dict().items()
-    }
-
-    model = task_model_helpers.init_model_from_checkpoint(
-        {
-            "model_class_path": (
-                "lightly_train._task_models.ltdetr_object_detection.task_model"
-                ".LTDETRObjectDetection"
-            ),
-            "model_init_args": {
-                "model_name": "ltdetrv2-s",
-                "classes": {0: "class_0", 1: "class_1"},
-                "image_size": (256, 256),
-            },
-            "train_model": train_state_dict,
-        },
-        device="cpu",
-    )
-
-    assert isinstance(model.decoder, DFINETransformer)
-    for name, param in model.state_dict().items():
-        assert torch.equal(param, reference_model.state_dict()[name])
+        torch.testing.assert_close(param, reference_model.state_dict()[name])

--- a/tests/_task_models/test_task_model_helpers.py
+++ b/tests/_task_models/test_task_model_helpers.py
@@ -29,6 +29,12 @@ from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model imp
 from lightly_train._task_models.ltdetr_object_detection.task_model import (
     LTDETRObjectDetection,
 )
+from lightly_train._task_models.object_detection_components.dfine_decoder import (
+    DFINETransformer,
+)
+from lightly_train._task_models.object_detection_components.rtdetrv2_decoder import (
+    RTDETRTransformerv2,
+)
 from lightly_train._task_models.picodet_object_detection.config import (
     PICODET_OBJECT_DETECTION_MODEL_REGISTRY,
 )
@@ -187,6 +193,39 @@ def test_init_model_from_checkpoint__legacy_dinov2_ltdetr_reroutes_to_generic() 
 
     assert isinstance(model, LTDETRObjectDetection)
     assert model.init_args["model_name"] == "dinov3/vitt16-notpretrained-ltdetr"
-    assert model.init_args["decoder_name"] == "rtdetrv2"
+    assert model.init_args["decoder_name"] is None
+    assert isinstance(model.decoder, RTDETRTransformerv2)
+    for name, param in model.state_dict().items():
+        assert torch.equal(param, reference_model.state_dict()[name])
+
+
+def test_init_model_from_checkpoint__missing_decoder_uses_dfine_architecture() -> None:
+    reference_model = LTDETRObjectDetection(
+        model_name="ltdetrv2-s",
+        classes={0: "class_0", 1: "class_1"},
+        image_size=(256, 256),
+        load_weights=False,
+    )
+    train_state_dict = {
+        f"model.{name}": param for name, param in reference_model.state_dict().items()
+    }
+
+    model = task_model_helpers.init_model_from_checkpoint(
+        {
+            "model_class_path": (
+                "lightly_train._task_models.ltdetr_object_detection.task_model"
+                ".LTDETRObjectDetection"
+            ),
+            "model_init_args": {
+                "model_name": "ltdetrv2-s",
+                "classes": {0: "class_0", 1: "class_1"},
+                "image_size": (256, 256),
+            },
+            "train_model": train_state_dict,
+        },
+        device="cpu",
+    )
+
+    assert isinstance(model.decoder, DFINETransformer)
     for name, param in model.state_dict().items():
         assert torch.equal(param, reference_model.state_dict()[name])


### PR DESCRIPTION
## What has changed and why?
- our ckpt loading was broken for downloadable models and for LT-DETRv1 models

## How has it been tested?
- unit tests
- tested fine-tuning with `dinov3/vitt16-ltdetr-coco`, `dinov3/vits16-ltdetr-coco`, `dinov2/vits14-noreg-ltdetr-coco` and `ltdetrv2-s-coco` and all gave expected val mAP values after only a single step of fine-tuning

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
