### PR TITLE
Add documentation on normalization for distillation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add TIPSv2 vision backbones: `dinov2/vitb14-tipsv2`, `dinov2/vitl14-tipsv2`,
   `dinov2/vitso400m14-tipsv2`, and `dinov2/vitg14-tipsv2`.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.16.3] - 2026-07-22
+
+### Added
+
 - Add support for [LingBot Vision](https://github.com/Robbyant/lingbot-vision) backbones
   `dinov3/vits16-lingbot`, `dinov3/vitb16-lingbot`, and `dinov3/vitl16-lingbot`.
 - Add LingBot Vision backbones to the DINOv3 EoMT semantic, panoptic, and instance

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -83,19 +83,14 @@ lightly-train pretrain out=out/my_experiment data=my_data_dir model="torchvision
 Distillation passes the same transformed image to the student and teacher. LightlyTrain
 uses ImageNet normalization by default, with mean `(0.485, 0.456, 0.406)` and standard
 deviation `(0.229, 0.224, 0.225)`. Keep this default when using LightlyTrain's
-`dinov2/*`, `dinov3/*`, or `radio/*` models as either the student or teacher. This also
-applies to TIPSv2, EUPE, and LingBot variants in those packages.
-
-Some upstream models, including RADIO and TIPSv2, natively consume images in the
-`[0, 1]` range. Their LightlyTrain wrappers convert the ImageNet-normalized input back
-to the model's native range internally, so do not change `transform_args.normalize` for
-these models.
+`dinov2/*`, `dinov3/*`, or `radio/*` models as the teacher, or else the features might
+degrade. This also applies to TIPSv2, EUPE, and LingBot variants in those packages.
 
 Custom teachers can have a different input contract. In that case, set
-`transform_args.normalize` to the statistics expected by the custom teacher. The same
-normalization is also applied to the student, so its wrapper must accept that input or
-convert it internally. See {ref}`pretrain-transform-normalize` for configuration
-details.
+`transform_args.normalize` to the statistics expected by the custom teacher. If your
+downstream student requires a different normalization from the teacher, you can either
+denormalize in the students forward pass or just adjust the normalization during the
+downstream fine-tuning stage – the normalization will adapt very quickly!
 
 (methods-distillation-dinov3)=
 

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -89,7 +89,7 @@ degrade. This also applies to TIPSv2, EUPE, and LingBot variants in those packag
 Custom teachers can have a different input contract. In that case, set
 `transform_args.normalize` to the statistics expected by the custom teacher. If your
 downstream student requires a different normalization from the teacher, you can either
-denormalize in the students forward pass or just adjust the normalization during the
+denormalize in the student's forward pass or just adjust the normalization during the
 downstream fine-tuning stage – the normalization will adapt very quickly!
 
 (methods-distillation-dinov3)=

--- a/docs/source/pretrain_distill/methods/distillation.md
+++ b/docs/source/pretrain_distill/methods/distillation.md
@@ -76,6 +76,27 @@ lightly-train pretrain out=out/my_experiment data=my_data_dir model="torchvision
 ```
 ````
 
+(methods-distillation-input-normalization)=
+
+### Input Normalization
+
+Distillation passes the same transformed image to the student and teacher. LightlyTrain
+uses ImageNet normalization by default, with mean `(0.485, 0.456, 0.406)` and standard
+deviation `(0.229, 0.224, 0.225)`. Keep this default when using LightlyTrain's
+`dinov2/*`, `dinov3/*`, or `radio/*` models as either the student or teacher. This also
+applies to TIPSv2, EUPE, and LingBot variants in those packages.
+
+Some upstream models, including RADIO and TIPSv2, natively consume images in the
+`[0, 1]` range. Their LightlyTrain wrappers convert the ImageNet-normalized input back
+to the model's native range internally, so do not change `transform_args.normalize` for
+these models.
+
+Custom teachers can have a different input contract. In that case, set
+`transform_args.normalize` to the statistics expected by the custom teacher. The same
+normalization is also applied to the student, so its wrapper must accept that input or
+convert it internally. See {ref}`pretrain-transform-normalize` for configuration
+details.
+
 (methods-distillation-dinov3)=
 
 (methods-distillation-custom-models)=

--- a/docs/source/settings/pretrain_settings.md
+++ b/docs/source/settings/pretrain_settings.md
@@ -571,11 +571,23 @@ lightly_train.pretrain(
 )
 ```
 
+(pretrain-transform-normalize)=
+
 #### `normalize`
 
 Dictionary specifying the mean and standard deviation used for input normalization.
-ImageNet statistics are used by default. Change these values when working with datasets
-that have different color distributions.
+ImageNet statistics are used by default. For non-distillation methods, you can change
+these values if your model or training setup expects different input statistics.
+
+```{important}
+During distillation, the same normalized image is passed to the student and teacher.
+Keep the ImageNet defaults when using LightlyTrain's `dinov2/*`, `dinov3/*`, or
+`radio/*` teachers, including TIPSv2, EUPE, and LingBot variants. LightlyTrain handles
+any conversion to a model's native input range inside its wrapper. Override
+`normalize` only when using a custom teacher that expects different normalization, and
+ensure that the student accepts the same input contract. See
+{ref}`methods-distillation-input-normalization` for details.
+```
 
 ```python
 import lightly_train

--- a/docs/source/settings/pretrain_settings.md
+++ b/docs/source/settings/pretrain_settings.md
@@ -579,7 +579,7 @@ Dictionary specifying the mean and standard deviation used for input normalizati
 ImageNet statistics are used by default. For non-distillation methods, you can change
 these values if your model or training setup expects different input statistics.
 
-```{important}
+```{warning}
 During distillation, the same normalized image is passed to the student and teacher.
 Keep the ImageNet defaults when using LightlyTrain's `dinov2/*`, `dinov3/*`, or
 `radio/*` teachers, including TIPSv2, EUPE, and LingBot variants. For teachers from 

--- a/docs/source/settings/pretrain_settings.md
+++ b/docs/source/settings/pretrain_settings.md
@@ -582,11 +582,9 @@ these values if your model or training setup expects different input statistics.
 ```{important}
 During distillation, the same normalized image is passed to the student and teacher.
 Keep the ImageNet defaults when using LightlyTrain's `dinov2/*`, `dinov3/*`, or
-`radio/*` teachers, including TIPSv2, EUPE, and LingBot variants. LightlyTrain handles
-any conversion to a model's native input range inside its wrapper. Override
-`normalize` only when using a custom teacher that expects different normalization, and
-ensure that the student accepts the same input contract. See
-{ref}`methods-distillation-input-normalization` for details.
+`radio/*` teachers, including TIPSv2, EUPE, and LingBot variants. For teachers from 
+other packages or for custom teachers make sure to set this to the expected statistics
+of the teacher. See {ref}`methods-distillation-input-normalization` for details.
 ```
 
 ```python

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -461,6 +461,11 @@ def train_from_config(config: TrainConfig, called_via_train: bool = False) -> No
             optimizer_args=config.optim_args,
             wrapped_model=wrapped_model,
         )
+        train_helpers.warn_if_distillation_normalization_mismatch(
+            method=config.method,
+            method_args=config.method_args,
+            normalize_args=transform_instance.transform_args.normalize,
+        )
         method_instance = train_helpers.get_method(
             method_cls=method_cls,
             method_args=config.method_args,

--- a/src/lightly_train/_commands/train_helpers.py
+++ b/src/lightly_train/_commands/train_helpers.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Literal, Sized
 
 import torch
+from lightly.transforms.utils import IMAGENET_NORMALIZE
 from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.accelerators.accelerator import Accelerator
 from pytorch_lightning.accelerators.cpu import CPUAccelerator
@@ -47,14 +48,6 @@ from lightly_train.errors import UnknownModelError
 from lightly_train.types import DatasetItem, PathLike
 
 logger = logging.getLogger(__name__)
-
-_DISTILLATION_METHODS = {
-    "distillation",
-    "distillationv1",
-    "distillationv2",
-    "distillationv3",
-}
-_IMAGENET_NORMALIZED_TEACHER_PACKAGES = {"dinov2", "dinov3", "radio"}
 
 
 def get_transform_args(
@@ -99,7 +92,12 @@ def warn_if_distillation_normalization_mismatch(
     normalize_args: NormalizeArgs,
 ) -> None:
     """Warn if a built-in teacher receives unexpected input normalization."""
-    if method not in _DISTILLATION_METHODS or normalize_args == NormalizeArgs():
+    distillation_methods = [
+        available_method
+        for available_method in method_helpers.list_methods()
+        if available_method.startswith("distillation")
+    ]
+    if method not in distillation_methods:
         return
 
     teacher = getattr(method_args, "teacher", None)
@@ -122,15 +120,19 @@ def warn_if_distillation_normalization_mismatch(
     else:
         return
 
-    if package_name not in _IMAGENET_NORMALIZED_TEACHER_PACKAGES:
+    if package_name not in package_helpers.IMAGENET_NORMALIZED_PACKAGE_NAMES:
         return
 
-    expected = NormalizeArgs()
+    imagenet_mean = tuple(IMAGENET_NORMALIZE["mean"])
+    imagenet_std = tuple(IMAGENET_NORMALIZE["std"])
+    if normalize_args.mean == imagenet_mean and normalize_args.std == imagenet_std:
+        return
+
     logger.warning(
         f"The distillation teacher '{teacher_name}' expects LightlyTrain's ImageNet "
         "normalization, but `transform_args.normalize` was changed. This can produce "
         "invalid teacher features. Remove the normalization override or use "
-        f"mean={expected.mean} and std={expected.std}. Current values are "
+        f"mean={imagenet_mean} and std={imagenet_std}. Current values are "
         f"mean={normalize_args.mean} and std={normalize_args.std}."
     )
 

--- a/src/lightly_train/_commands/train_helpers.py
+++ b/src/lightly_train/_commands/train_helpers.py
@@ -31,6 +31,7 @@ from lightly_train._env import Env
 from lightly_train._methods import method_helpers
 from lightly_train._methods.method import Method
 from lightly_train._methods.method_args import MethodArgs
+from lightly_train._models import package_helpers
 from lightly_train._models.embedding_model import EmbeddingModel
 from lightly_train._models.model_wrapper import ModelWrapper
 from lightly_train._optim import optimizer_helpers
@@ -40,10 +41,20 @@ from lightly_train._scaling import IMAGENET_SIZE, ScalingInfo
 from lightly_train._transforms.transform import (
     MethodTransform,
     MethodTransformArgs,
+    NormalizeArgs,
 )
+from lightly_train.errors import UnknownModelError
 from lightly_train.types import DatasetItem, PathLike
 
 logger = logging.getLogger(__name__)
+
+_DISTILLATION_METHODS = {
+    "distillation",
+    "distillationv1",
+    "distillationv2",
+    "distillationv3",
+}
+_IMAGENET_NORMALIZED_TEACHER_PACKAGES = {"dinov2", "dinov3", "radio"}
 
 
 def get_transform_args(
@@ -80,6 +91,48 @@ def get_transform(
     transform_cls = method_cls.transform_cls()
     transform = transform_cls(transform_args=transform_args_resolved)
     return transform
+
+
+def warn_if_distillation_normalization_mismatch(
+    method: str,
+    method_args: MethodArgs,
+    normalize_args: NormalizeArgs,
+) -> None:
+    """Warn if a built-in teacher receives unexpected input normalization."""
+    if method not in _DISTILLATION_METHODS or normalize_args == NormalizeArgs():
+        return
+
+    teacher = getattr(method_args, "teacher", None)
+    package_name: str | None = None
+    teacher_name: str
+    if isinstance(teacher, str):
+        package_name, _ = package_helpers.parse_model_name(teacher)
+        teacher_name = teacher
+    elif isinstance(teacher, (Module, ModelWrapper)):
+        teacher_name = teacher.__class__.__name__
+        try:
+            package = package_helpers.get_package_from_model(
+                model=teacher,
+                include_custom=False,
+                fallback_custom=False,
+            )
+        except UnknownModelError:
+            return
+        package_name = package.name
+    else:
+        return
+
+    if package_name not in _IMAGENET_NORMALIZED_TEACHER_PACKAGES:
+        return
+
+    expected = NormalizeArgs()
+    logger.warning(
+        f"The distillation teacher '{teacher_name}' expects LightlyTrain's ImageNet "
+        "normalization, but `transform_args.normalize` was changed. This can produce "
+        "invalid teacher features. Remove the normalization override or use "
+        f"mean={expected.mean} and std={expected.std}. Current values are "
+        f"mean={normalize_args.mean} and std={normalize_args.std}."
+    )
 
 
 def get_total_num_devices(

--- a/src/lightly_train/_models/package_helpers.py
+++ b/src/lightly_train/_models/package_helpers.py
@@ -28,6 +28,8 @@ from lightly_train._models.torchvision.torchvision_package import TORCHVISION_PA
 from lightly_train._models.ultralytics.ultralytics_package import ULTRALYTICS_PACKAGE
 from lightly_train.errors import UnknownModelError
 
+IMAGENET_NORMALIZED_PACKAGE_NAMES = {"dinov2", "dinov3", "radio"}
+
 
 def list_base_packages() -> list[BasePackage]:
     """Lists all supported packages."""

--- a/tests/_commands/test_train_helpers.py
+++ b/tests/_commands/test_train_helpers.py
@@ -7,6 +7,7 @@
 #
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Literal
 
@@ -21,6 +22,7 @@ from torchvision.datasets import FakeData
 
 from lightly_train._commands import train_helpers
 from lightly_train._loggers.jsonl import JSONLLogger
+from lightly_train._methods.distillationv3.distillationv3 import DistillationV3Args
 from lightly_train._methods.simclr.simclr import (
     SimCLR,
     SimCLRArgs,
@@ -465,6 +467,87 @@ def test_get_transform_args__failure() -> None:
             method="simclr",
             transform_args={"nonexisting_arg": 1},
         )
+
+
+@pytest.mark.parametrize(
+    "teacher",
+    [
+        "dinov2/vitb14",
+        "dinov2/vitb14-tipsv2",
+        "dinov3/vitb16",
+        "dinov3/vitb16-eupe",
+        "dinov3/vitb16-lingbot",
+        "radio/c-radio_v4-h",
+    ],
+)
+def test_warn_if_distillation_normalization_mismatch__warns(
+    teacher: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    normalize_args = NormalizeArgs(mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0))
+
+    with caplog.at_level(logging.WARNING):
+        train_helpers.warn_if_distillation_normalization_mismatch(
+            method="distillation",
+            method_args=DistillationV3Args(teacher=teacher),
+            normalize_args=normalize_args,
+        )
+
+    assert caplog.text.count("expects LightlyTrain's ImageNet normalization") == 1
+    assert teacher in caplog.text
+    assert f"mean={normalize_args.mean}" in caplog.text
+    assert f"std={normalize_args.std}" in caplog.text
+
+
+def test_warn_if_distillation_normalization_mismatch__model_instance(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    teacher = helpers.dummy_dinov2_vit_model()
+
+    with caplog.at_level(logging.WARNING):
+        train_helpers.warn_if_distillation_normalization_mismatch(
+            method="distillationv3",
+            method_args=DistillationV3Args(teacher=teacher),
+            normalize_args=NormalizeArgs(mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)),
+        )
+
+    assert caplog.text.count("expects LightlyTrain's ImageNet normalization") == 1
+
+
+@pytest.mark.parametrize(
+    "method, teacher, normalize_args",
+    [
+        ("distillation", "dinov3/vitb16", NormalizeArgs()),
+        (
+            "distillation",
+            "timm/vit_base_patch16_224",
+            NormalizeArgs(mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)),
+        ),
+        (
+            "distillation",
+            DummyCustomModel(),
+            NormalizeArgs(mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)),
+        ),
+        (
+            "simclr",
+            "dinov3/vitb16",
+            NormalizeArgs(mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0)),
+        ),
+    ],
+)
+def test_warn_if_distillation_normalization_mismatch__does_not_warn(
+    method: str,
+    teacher: str | ModelWrapper,
+    normalize_args: NormalizeArgs,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        train_helpers.warn_if_distillation_normalization_mismatch(
+            method=method,
+            method_args=DistillationV3Args(teacher=teacher),
+            normalize_args=normalize_args,
+        )
+
+    assert "expects LightlyTrain's ImageNet normalization" not in caplog.text
 
 
 def test_load_checkpoint(tmp_path: Path, mocker: MockerFixture) -> None:

--- a/tests/_commands/test_train_helpers.py
+++ b/tests/_commands/test_train_helpers.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 
 import pytest
 import torch
+from lightly.transforms.utils import IMAGENET_NORMALIZE
 from pytest_mock import MockerFixture
 from pytorch_lightning.strategies.ddp import DDPStrategy
 from torch import Tensor
@@ -22,6 +23,7 @@ from torchvision.datasets import FakeData
 
 from lightly_train._commands import train_helpers
 from lightly_train._loggers.jsonl import JSONLLogger
+from lightly_train._methods import method_helpers
 from lightly_train._methods.distillationv3.distillationv3 import DistillationV3Args
 from lightly_train._methods.simclr.simclr import (
     SimCLR,
@@ -480,20 +482,30 @@ def test_get_transform_args__failure() -> None:
         "radio/c-radio_v4-h",
     ],
 )
+@pytest.mark.parametrize(
+    "method",
+    [
+        method
+        for method in method_helpers.list_methods()
+        if method.startswith("distillation")
+    ],
+)
 def test_warn_if_distillation_normalization_mismatch__warns(
-    teacher: str, caplog: pytest.LogCaptureFixture
+    method: str, teacher: str, caplog: pytest.LogCaptureFixture
 ) -> None:
     normalize_args = NormalizeArgs(mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0))
 
     with caplog.at_level(logging.WARNING):
         train_helpers.warn_if_distillation_normalization_mismatch(
-            method="distillation",
+            method=method,
             method_args=DistillationV3Args(teacher=teacher),
             normalize_args=normalize_args,
         )
 
     assert caplog.text.count("expects LightlyTrain's ImageNet normalization") == 1
     assert teacher in caplog.text
+    assert f"mean={tuple(IMAGENET_NORMALIZE['mean'])}" in caplog.text
+    assert f"std={tuple(IMAGENET_NORMALIZE['std'])}" in caplog.text
     assert f"mean={normalize_args.mean}" in caplog.text
     assert f"std={normalize_args.std}" in caplog.text
 
@@ -516,7 +528,14 @@ def test_warn_if_distillation_normalization_mismatch__model_instance(
 @pytest.mark.parametrize(
     "method, teacher, normalize_args",
     [
-        ("distillation", "dinov3/vitb16", NormalizeArgs()),
+        (
+            "distillation",
+            "dinov3/vitb16",
+            NormalizeArgs(
+                mean=tuple(IMAGENET_NORMALIZE["mean"]),
+                std=tuple(IMAGENET_NORMALIZE["std"]),
+            ),
+        ),
         (
             "distillation",
             "timm/vit_base_patch16_224",


### PR DESCRIPTION
## What has changed and why?
- "default" teachers require imagenet normalization, however this was not properly documented
- this could cause issues for people using distillation, but changing the normalization, since it changes it for both, student & teacher, which share the augmentation pipeline
- this PR adds documentation for the usual DINOv2/DINOv3 and RADIO-based backbones and issues a warning is someone alters normalization params for these backbones
- also fixes an issue in the CHANGELOG introduced by #701 

## How has it been tested?
- unit tests

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (internal change without effects for user)
