### PR TITLE
Add LTDETRv2 segmentation COCO checkpoints and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add TIPSv2 vision backbones: `dinov2/vitb14-tipsv2`, `dinov2/vitl14-tipsv2`,
   `dinov2/vitso400m14-tipsv2`, and `dinov2/vitg14-tipsv2`.
+- Add **LTDETRv2 instance segmentation**, extending the compact LTDETRv2 architecture
+  to predict per-instance masks alongside boxes. Use the `ltdetrv2-seg-s/m/l/x` models,
+  which are built on [EdgeCrafter](https://arxiv.org/abs/2603.18739) ECViT backbones and
+  share the efficiency profile of their object detection counterparts. COCO-pretrained
+  checkpoints are hosted for download as `ltdetrv2-seg-s-coco`, `ltdetrv2-seg-m-coco`,
+  `ltdetrv2-seg-l-coco`, and `ltdetrv2-seg-x-coco` (also available under the
+  `edgecrafter/…-ltdetr-seg-coco` names), so you can fine-tune from strong weights or
+  run inference out of the box.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.16.3] - 2026-07-22
+
+### Added
+
 - Add support for [LingBot Vision](https://github.com/Robbyant/lingbot-vision) backbones
   `dinov3/vits16-lingbot`, `dinov3/vitb16-lingbot`, and `dinov3/vitl16-lingbot`.
 - Add LingBot Vision backbones to the DINOv3 EoMT semantic, panoptic, and instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add TIPSv2 vision backbones: `dinov2/vitb14-tipsv2`, `dinov2/vitl14-tipsv2`,
   `dinov2/vitso400m14-tipsv2`, and `dinov2/vitg14-tipsv2`.
-- Add **LTDETRv2 instance segmentation**, extending the compact LTDETRv2 architecture
-  to predict per-instance masks alongside boxes. Use the `ltdetrv2-seg-s/m/l/x` models,
+- Add **LTDETRv2 instance segmentation**, extending the compact LTDETRv2 architecture to
+  predict per-instance masks alongside boxes. Use the `ltdetrv2-seg-s/m/l/x` models,
   which are built on [EdgeCrafter](https://arxiv.org/abs/2603.18739) ECViT backbones and
   share the efficiency profile of their object detection counterparts. COCO-pretrained
   checkpoints are hosted for download as `ltdetrv2-seg-s-coco`, `ltdetrv2-seg-m-coco`,

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
@@ -12,9 +12,33 @@ from typing import Any, Literal
 from pydantic import Field
 
 from lightly_train._configs.config import ConfigsNamespace, PydanticConfig
-from lightly_train._configs.model_registry import ModelRegistry
+from lightly_train._configs.model_registry import (
+    DownloadableCheckpoint,
+    ModelAlias,
+    ModelRegistry,
+)
 
 LTDETR_SEG_MODEL_REGISTRY: ModelRegistry[SegmentorConfig] = ModelRegistry()
+
+# COCO-pretrained ECViT LT-DETR instance-segmentation weights. The URLs are paths
+# relative to DOWNLOADABLE_MODEL_BASE_URL (they live in the ecvit_ltdetrv2_seg_coco/
+# subfolder of the S3 bucket).
+_LTDETRV2_SEG_S_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-s-coco.pt"
+_LTDETRV2_SEG_S_COCO_SHA256 = (
+    "5c7e00895e10a5b8a14cb9ad1c164232a16af302719fd7a2f7de241264155c15"
+)
+_LTDETRV2_SEG_M_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-m-coco.pt"
+_LTDETRV2_SEG_M_COCO_SHA256 = (
+    "4527278b7e1d819fecbf72fb90554f665a506f178ef30b32f22c227107970384"
+)
+_LTDETRV2_SEG_L_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-l-coco.pt"
+_LTDETRV2_SEG_L_COCO_SHA256 = (
+    "601b9d8b51d73105ad11feae0dfc4d8d085a12d0afac3f991e7d83f9f493d58b"
+)
+_LTDETRV2_SEG_X_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-x-coco.pt"
+_LTDETRV2_SEG_X_COCO_SHA256 = (
+    "d55b16f48f05f18e6dd03e3c5c2a3894d0bdeaf468dc80280a727edf5086edcd"
+)
 
 
 class HybridEncoderConfig(PydanticConfig):
@@ -158,7 +182,22 @@ class LTDETRBaseConfig(ConfigsNamespace):
 
 class LTDETRv2ConfigRegistry(ConfigsNamespace):
     @LTDETR_SEG_MODEL_REGISTRY.register(
-        "edgecrafter/ecvitt-ltdetr-seg", "ltdetrv2-seg-s"
+        "edgecrafter/ecvitt-ltdetr-seg",
+        ModelAlias(
+            name="edgecrafter/ecvitt-ltdetr-seg-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_S_COCO_URL,
+                sha256=_LTDETRV2_SEG_S_COCO_SHA256,
+            ),
+        ),
+        "ltdetrv2-seg-s",
+        ModelAlias(
+            name="ltdetrv2-seg-s-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_S_COCO_URL,
+                sha256=_LTDETRV2_SEG_S_COCO_SHA256,
+            ),
+        ),
     )
     class EdgeCrafterECViTTiny(LTDETRBaseConfig.ViTTiny):
         backbone_name: str = "edgecrafter/ecvitt"
@@ -179,7 +218,22 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
         backbone_name: str = "edgecrafter/_ecvitt-notpretrained"
 
     @LTDETR_SEG_MODEL_REGISTRY.register(
-        "edgecrafter/ecvittplus-ltdetr-seg", "ltdetrv2-seg-m"
+        "edgecrafter/ecvittplus-ltdetr-seg",
+        ModelAlias(
+            name="edgecrafter/ecvittplus-ltdetr-seg-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_M_COCO_URL,
+                sha256=_LTDETRV2_SEG_M_COCO_SHA256,
+            ),
+        ),
+        "ltdetrv2-seg-m",
+        ModelAlias(
+            name="ltdetrv2-seg-m-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_M_COCO_URL,
+                sha256=_LTDETRV2_SEG_M_COCO_SHA256,
+            ),
+        ),
     )
     class EdgeCrafterECViTTinyPlus(LTDETRBaseConfig.ViTTinyPlus):
         backbone_name: str = "edgecrafter/ecvittplus"
@@ -194,7 +248,22 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
         )
 
     @LTDETR_SEG_MODEL_REGISTRY.register(
-        "edgecrafter/ecvits-ltdetr-seg", "ltdetrv2-seg-l"
+        "edgecrafter/ecvits-ltdetr-seg",
+        ModelAlias(
+            name="edgecrafter/ecvits-ltdetr-seg-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_L_COCO_URL,
+                sha256=_LTDETRV2_SEG_L_COCO_SHA256,
+            ),
+        ),
+        "ltdetrv2-seg-l",
+        ModelAlias(
+            name="ltdetrv2-seg-l-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_L_COCO_URL,
+                sha256=_LTDETRV2_SEG_L_COCO_SHA256,
+            ),
+        ),
     )
     class EdgeCrafterECViTSmall(LTDETRBaseConfig.ViTTinyPlus):
         backbone_name: str = "edgecrafter/ecvits"
@@ -209,7 +278,22 @@ class LTDETRv2ConfigRegistry(ConfigsNamespace):
         )
 
     @LTDETR_SEG_MODEL_REGISTRY.register(
-        "edgecrafter/ecvitsplus-ltdetr-seg", "ltdetrv2-seg-x"
+        "edgecrafter/ecvitsplus-ltdetr-seg",
+        ModelAlias(
+            name="edgecrafter/ecvitsplus-ltdetr-seg-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_X_COCO_URL,
+                sha256=_LTDETRV2_SEG_X_COCO_SHA256,
+            ),
+        ),
+        "ltdetrv2-seg-x",
+        ModelAlias(
+            name="ltdetrv2-seg-x-coco",
+            downloadable_checkpoint=DownloadableCheckpoint(
+                url=_LTDETRV2_SEG_X_COCO_URL,
+                sha256=_LTDETRV2_SEG_X_COCO_SHA256,
+            ),
+        ),
     )
     class EdgeCrafterECViTSmallPlus(LTDETRBaseConfig.ViTTinyPlus):
         backbone_name: str = "edgecrafter/ecvitsplus"

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
@@ -22,19 +22,27 @@ LTDETR_SEG_MODEL_REGISTRY: ModelRegistry[SegmentorConfig] = ModelRegistry()
 
 # COCO-pretrained ECViT LT-DETR instance-segmentation weights. The URLs are paths
 # relative to DOWNLOADABLE_MODEL_BASE_URL.
-_LTDETRV2_SEG_S_COCO_URL = "edgecrafter_ecvitt_ltdetr_seg_coco_260721_5c7e0089.pt"
+_LTDETRV2_SEG_S_COCO_URL = (
+    "ecvit_ltdetrv2_seg_coco/edgecrafter_ecvitt_ltdetr_seg_coco_260721_5c7e0089.pt"
+)
 _LTDETRV2_SEG_S_COCO_SHA256 = (
     "5c7e00895e10a5b8a14cb9ad1c164232a16af302719fd7a2f7de241264155c15"
 )
-_LTDETRV2_SEG_M_COCO_URL = "edgecrafter_ecvittplus_ltdetr_seg_coco_260722_4527278b.pt"
+_LTDETRV2_SEG_M_COCO_URL = (
+    "ecvit_ltdetrv2_seg_coco/edgecrafter_ecvittplus_ltdetr_seg_coco_260722_4527278b.pt"
+)
 _LTDETRV2_SEG_M_COCO_SHA256 = (
     "4527278b7e1d819fecbf72fb90554f665a506f178ef30b32f22c227107970384"
 )
-_LTDETRV2_SEG_L_COCO_URL = "edgecrafter_ecvits_ltdetr_seg_coco_260721_601b9d8b.pt"
+_LTDETRV2_SEG_L_COCO_URL = (
+    "ecvit_ltdetrv2_seg_coco/edgecrafter_ecvits_ltdetr_seg_coco_260721_601b9d8b.pt"
+)
 _LTDETRV2_SEG_L_COCO_SHA256 = (
     "601b9d8b51d73105ad11feae0dfc4d8d085a12d0afac3f991e7d83f9f493d58b"
 )
-_LTDETRV2_SEG_X_COCO_URL = "edgecrafter_ecvitsplus_ltdetr_seg_coco_260721_d55b16f4.pt"
+_LTDETRV2_SEG_X_COCO_URL = (
+    "ecvit_ltdetrv2_seg_coco/edgecrafter_ecvitsplus_ltdetr_seg_coco_260721_d55b16f4.pt"
+)
 _LTDETRV2_SEG_X_COCO_SHA256 = (
     "d55b16f48f05f18e6dd03e3c5c2a3894d0bdeaf468dc80280a727edf5086edcd"
 )

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
@@ -21,21 +21,20 @@ from lightly_train._configs.model_registry import (
 LTDETR_SEG_MODEL_REGISTRY: ModelRegistry[SegmentorConfig] = ModelRegistry()
 
 # COCO-pretrained ECViT LT-DETR instance-segmentation weights. The URLs are paths
-# relative to DOWNLOADABLE_MODEL_BASE_URL (they live in the ecvit_ltdetrv2_seg_coco/
-# subfolder of the S3 bucket).
-_LTDETRV2_SEG_S_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-s-coco.pt"
+# relative to DOWNLOADABLE_MODEL_BASE_URL.
+_LTDETRV2_SEG_S_COCO_URL = "edgecrafter_ecvitt_ltdetr_seg_coco_260721_5c7e0089.pt"
 _LTDETRV2_SEG_S_COCO_SHA256 = (
     "5c7e00895e10a5b8a14cb9ad1c164232a16af302719fd7a2f7de241264155c15"
 )
-_LTDETRV2_SEG_M_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-m-coco.pt"
+_LTDETRV2_SEG_M_COCO_URL = "edgecrafter_ecvittplus_ltdetr_seg_coco_260722_4527278b.pt"
 _LTDETRV2_SEG_M_COCO_SHA256 = (
     "4527278b7e1d819fecbf72fb90554f665a506f178ef30b32f22c227107970384"
 )
-_LTDETRV2_SEG_L_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-l-coco.pt"
+_LTDETRV2_SEG_L_COCO_URL = "edgecrafter_ecvits_ltdetr_seg_coco_260721_601b9d8b.pt"
 _LTDETRV2_SEG_L_COCO_SHA256 = (
     "601b9d8b51d73105ad11feae0dfc4d8d085a12d0afac3f991e7d83f9f493d58b"
 )
-_LTDETRV2_SEG_X_COCO_URL = "ecvit_ltdetrv2_seg_coco/ltdetrv2-seg-x-coco.pt"
+_LTDETRV2_SEG_X_COCO_URL = "edgecrafter_ecvitsplus_ltdetr_seg_coco_260721_d55b16f4.pt"
 _LTDETRV2_SEG_X_COCO_SHA256 = (
     "d55b16f48f05f18e6dd03e3c5c2a3894d0bdeaf468dc80280a727edf5086edcd"
 )

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/schedule.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/schedule.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+import math
+
+_REFERENCE_TOTAL_EPOCHS = 74
+_REFERENCE_NO_AUG_EPOCHS = 2
+
+
+def resolve_no_aug_steps(
+    *,
+    total_steps: int,
+    train_num_batches: int,
+    gradient_accumulation_steps: int,
+) -> int:
+    """Resolve the no-augmentation tail for the ECSeg schedule."""
+    steps_per_epoch = train_num_batches / gradient_accumulation_steps
+    total_epochs = total_steps / steps_per_epoch
+    no_aug_epochs = min(
+        _REFERENCE_NO_AUG_EPOCHS,
+        round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
+    )
+    return math.floor(no_aug_epochs * steps_per_epoch)

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/schedule.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/schedule.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import math
 
-_REFERENCE_TOTAL_EPOCHS = 74
+_NO_AUG_SCALE_EPOCHS = 14
 _REFERENCE_NO_AUG_EPOCHS = 2
 
 
@@ -24,6 +24,6 @@ def resolve_no_aug_steps(
     total_epochs = total_steps / steps_per_epoch
     no_aug_epochs = min(
         _REFERENCE_NO_AUG_EPOCHS,
-        round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _REFERENCE_TOTAL_EPOCHS),
+        round(total_epochs * _REFERENCE_NO_AUG_EPOCHS / _NO_AUG_SCALE_EPOCHS),
     )
     return math.floor(no_aug_epochs * steps_per_epoch)

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/train_model.py
@@ -104,9 +104,7 @@ class LTDETRInstanceSegmentationTrainArgs(TrainModelArgs):
     """
 
     default_batch_size: ClassVar[int] = 32
-    default_steps: ClassVar[int] = (
-        266_112  # 6x ECDet-S schedule (72 epochs at batch 32)
-    )
+    default_steps: ClassVar[int] = 273_504  # ECSeg schedule (74 epochs at batch 32)
 
     # ECViT (EdgeCrafter) backbones all use a fixed patch size of 16.
     patch_size: int | Literal["auto"] | None = "auto"

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/train_model.py
@@ -22,6 +22,7 @@ from torch.optim.lr_scheduler import (  # type: ignore[attr-defined]
     LinearLR,
     LRScheduler,
 )
+from typing_extensions import override
 
 from lightly_train._configs.validate import no_auto
 from lightly_train._data.instance_segmentation_dataset import (
@@ -39,6 +40,9 @@ from lightly_train._task_models.instance_segmentation_components.edgecrafter_cri
 )
 from lightly_train._task_models.instance_segmentation_components.matcher import (
     MaskAwareHungarianMatcher,
+)
+from lightly_train._task_models.ltdetr_instance_segmentation.config import (
+    LTDETR_SEG_MODEL_REGISTRY,
 )
 from lightly_train._task_models.ltdetr_instance_segmentation.schedule import (
     resolve_no_aug_steps,
@@ -214,6 +218,16 @@ class LTDETRInstanceSegmentationTrainArgs(TrainModelArgs):
                 )
 
 
+class LTDETRInstanceSegmentationLargeTrainArgs(LTDETRInstanceSegmentationTrainArgs):
+    default_steps: ClassVar[int] = 184_800  # ECSeg L/X schedule (50 epochs at batch 32)
+
+
+_LARGE_ECSEG_BACKBONES = {
+    "edgecrafter/ecvits",
+    "edgecrafter/ecvitsplus",
+}
+
+
 class LTDETRInstanceSegmentationTrain(TrainModel):
     task = "instance_segmentation"
     train_model_args_cls = LTDETRInstanceSegmentationTrainArgs
@@ -222,6 +236,16 @@ class LTDETRInstanceSegmentationTrain(TrainModel):
     train_transform_cls = LTDETRInstanceSegmentationTrainTransform
     val_transform_cls = LTDETRInstanceSegmentationValTransform
     torch_compile_args_cls = TorchCompileArgs
+
+    @override
+    @classmethod
+    def get_train_model_args_cls(
+        cls, model_name: str
+    ) -> type[LTDETRInstanceSegmentationTrainArgs]:
+        config = LTDETR_SEG_MODEL_REGISTRY.get(alias=model_name)()
+        if config.backbone_name in _LARGE_ECSEG_BACKBONES:
+            return LTDETRInstanceSegmentationLargeTrainArgs
+        return LTDETRInstanceSegmentationTrainArgs
 
     def __init__(
         self,

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/train_model.py
@@ -40,6 +40,9 @@ from lightly_train._task_models.instance_segmentation_components.edgecrafter_cri
 from lightly_train._task_models.instance_segmentation_components.matcher import (
     MaskAwareHungarianMatcher,
 )
+from lightly_train._task_models.ltdetr_instance_segmentation.schedule import (
+    resolve_no_aug_steps,
+)
 from lightly_train._task_models.ltdetr_instance_segmentation.task_model import (
     LTDETRInstanceSegmentation,
 )
@@ -204,8 +207,10 @@ class LTDETRInstanceSegmentationTrainArgs(TrainModelArgs):
             if self.scheduler_flat_steps == "auto":
                 self.scheduler_flat_steps = scheduler_step_schedule.step_flat
             if self.scheduler_no_aug_steps == "auto":
-                self.scheduler_no_aug_steps = (
-                    total_steps - scheduler_step_schedule.step_stop
+                self.scheduler_no_aug_steps = resolve_no_aug_steps(
+                    total_steps=total_steps,
+                    train_num_batches=train_num_batches,
+                    gradient_accumulation_steps=gradient_accumulation_steps,
                 )
 
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -16,6 +16,9 @@ from pydantic import Field
 from lightly_train._task_models.ltdetr_instance_segmentation.schedule import (
     resolve_no_aug_steps,
 )
+from lightly_train._task_models.object_detection_components.ltdetr_schedule import (
+    resolve_ltdetr_step_schedule,
+)
 from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
     LTDETRInstanceSegmentationTransform,
     LTDETRInstanceSegmentationTransformArgs,
@@ -256,6 +259,11 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
         train_num_batches: int,
         gradient_accumulation_steps: int,
     ) -> None:
+        step_start = resolve_ltdetr_step_schedule(
+            total_steps=total_steps,
+            train_num_batches=train_num_batches,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+        ).step_start
         strong_aug_step_stop = total_steps - resolve_no_aug_steps(
             total_steps=total_steps,
             train_num_batches=train_num_batches,
@@ -267,7 +275,9 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
             train_num_batches=train_num_batches,
             gradient_accumulation_steps=gradient_accumulation_steps,
             # Mosaic/MixUp stop halfway through the augmentation-enabled portion.
-            mosaic_mixup_step_stop=strong_aug_step_stop // 2,
+            mosaic_mixup_step_stop=(
+                step_start + (strong_aug_step_stop - step_start) // 2
+            ),
             strong_aug_step_stop=strong_aug_step_stop,
         )
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any, Literal, Sequence
 
 from albumentations import BboxParams
@@ -39,6 +40,11 @@ from lightly_train._transforms.transform import (
 from lightly_train.types import ImageSizeTuple
 
 logger = logging.getLogger(__name__)
+
+# Following the released EdgeCrafter ECSeg COCO recipes, Mosaic and MixUp are disabled
+# halfway through the augmentation-enabled schedule. Photometric distortion, zoom-out, and
+# IoU-crop are disabled for the final ``_SEG_STRONG_AUG_NO_AUG_EPOCHS`` epochs.
+_SEG_STRONG_AUG_NO_AUG_EPOCHS = 2
 
 
 class LTDETRInstanceSegmentationRandomPhotometricDistortArgs(
@@ -101,7 +107,7 @@ class LTDETRInstanceSegmentationRandomFlipArgs(RandomFlipArgs):
 
 
 class LTDETRInstanceSegmentationMosaicArgs(MosaicArgs):
-    prob: float = 0.5
+    prob: float = 0.75
 
     output_size: int = 320
     max_size: int | None = None
@@ -150,7 +156,7 @@ def _resolve_normalize_num_channels(
 
 
 class LTDETRInstanceSegmentationMixUpArgs(MixUpArgs):
-    prob: float = 0.5
+    prob: float = 0.75
     step_start: int | Literal["auto"] = "auto"
     step_stop: int | Literal["auto"] | None = "auto"
 
@@ -253,11 +259,18 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
         train_num_batches: int,
         gradient_accumulation_steps: int,
     ) -> None:
+        steps_per_epoch = train_num_batches / gradient_accumulation_steps
+        strong_aug_step_stop = total_steps - math.floor(
+            _SEG_STRONG_AUG_NO_AUG_EPOCHS * steps_per_epoch
+        )
         resolve_ltdetr_step_schedule_for_augmentation(
             args=self,
             total_steps=total_steps,
             train_num_batches=train_num_batches,
             gradient_accumulation_steps=gradient_accumulation_steps,
+            # Mosaic/MixUp stop halfway through the augmentation-enabled portion.
+            mosaic_mixup_step_stop=strong_aug_step_stop // 2,
+            strong_aug_step_stop=strong_aug_step_stop,
         )
 
 

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/transforms.py
@@ -8,12 +8,14 @@
 from __future__ import annotations
 
 import logging
-import math
 from typing import Any, Literal, Sequence
 
 from albumentations import BboxParams
 from pydantic import Field
 
+from lightly_train._task_models.ltdetr_instance_segmentation.schedule import (
+    resolve_no_aug_steps,
+)
 from lightly_train._transforms.ltdetr_transforms.instance_segmentation import (
     LTDETRInstanceSegmentationTransform,
     LTDETRInstanceSegmentationTransformArgs,
@@ -40,11 +42,6 @@ from lightly_train._transforms.transform import (
 from lightly_train.types import ImageSizeTuple
 
 logger = logging.getLogger(__name__)
-
-# Following the released EdgeCrafter ECSeg COCO recipes, Mosaic and MixUp are disabled
-# halfway through the augmentation-enabled schedule. Photometric distortion, zoom-out, and
-# IoU-crop are disabled for the final ``_SEG_STRONG_AUG_NO_AUG_EPOCHS`` epochs.
-_SEG_STRONG_AUG_NO_AUG_EPOCHS = 2
 
 
 class LTDETRInstanceSegmentationRandomPhotometricDistortArgs(
@@ -259,9 +256,10 @@ class LTDETRInstanceSegmentationTrainTransformArgs(
         train_num_batches: int,
         gradient_accumulation_steps: int,
     ) -> None:
-        steps_per_epoch = train_num_batches / gradient_accumulation_steps
-        strong_aug_step_stop = total_steps - math.floor(
-            _SEG_STRONG_AUG_NO_AUG_EPOCHS * steps_per_epoch
+        strong_aug_step_stop = total_steps - resolve_no_aug_steps(
+            total_steps=total_steps,
+            train_num_batches=train_num_batches,
+            gradient_accumulation_steps=gradient_accumulation_steps,
         )
         resolve_ltdetr_step_schedule_for_augmentation(
             args=self,

--- a/src/lightly_train/_task_models/task_model_helpers.py
+++ b/src/lightly_train/_task_models/task_model_helpers.py
@@ -29,6 +29,9 @@ from lightly_train._task_models.dinov3_eomt_panoptic_segmentation.config import 
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import (
     DINOV3_EOMT_SEMANTIC_SEGMENTATION_MODEL_REGISTRY,
 )
+from lightly_train._task_models.ltdetr_instance_segmentation.config import (
+    LTDETR_SEG_MODEL_REGISTRY,
+)
 from lightly_train._task_models.ltdetr_object_detection.config import (
     LTDETR_MODEL_REGISTRY,
 )
@@ -153,6 +156,9 @@ DOWNLOADABLE_MODEL_URL_AND_HASH.update(
 )
 DOWNLOADABLE_MODEL_URL_AND_HASH.update(
     _get_downloadable_model_url_and_hashes(LTDETR_MODEL_REGISTRY)
+)
+DOWNLOADABLE_MODEL_URL_AND_HASH.update(
+    _get_downloadable_model_url_and_hashes(LTDETR_SEG_MODEL_REGISTRY)
 )
 
 

--- a/src/lightly_train/_transforms/ltdetr_transforms/utils.py
+++ b/src/lightly_train/_transforms/ltdetr_transforms/utils.py
@@ -86,6 +86,9 @@ def resolve_ltdetr_step_schedule_for_augmentation(
     total_steps: int,
     train_num_batches: int,
     gradient_accumulation_steps: int,
+    *,
+    mosaic_mixup_step_stop: int | None = None,
+    strong_aug_step_stop: int | None = None,
 ) -> None:
     """Resolve LT-DETR augmentation step windows from ``"auto"``.
 
@@ -93,6 +96,12 @@ def resolve_ltdetr_step_schedule_for_augmentation(
       ``copyblend`` use [``step_start_resolved``, ``step_stop_resolved``)
     - ``mixup`` and ``mosaic`` use [``step_start_resolved``, ``step_flat_resolved``)
     - ``scale_jitter`` only resolves ``step_stop_resolved``
+
+    ``mosaic_mixup_step_stop`` and ``strong_aug_step_stop`` optionally override the
+    resolved ``step_stop`` for the mixup/mosaic and the photometric/zoom/crop/copyblend
+    groups respectively. When ``None`` (the default) the values derived from
+    ``resolve_ltdetr_step_schedule`` (``step_flat`` and ``step_stop``) are used, which
+    preserves the original behavior for callers that do not pass overrides.
 
     If an augmentation's final integer window is empty, it is disabled instead
     of clamped to a minimum length. In practice this means:
@@ -114,13 +123,21 @@ def resolve_ltdetr_step_schedule_for_augmentation(
             "copyblend",
         ),
         step_start_resolved=step_schedule.step_start,
-        step_stop_resolved=step_schedule.step_stop,
+        step_stop_resolved=(
+            strong_aug_step_stop
+            if strong_aug_step_stop is not None
+            else step_schedule.step_stop
+        ),
     )
     _resolve_aug_fields(
         args=args,
         field_names=("mixup", "mosaic"),
         step_start_resolved=step_schedule.step_start,
-        step_stop_resolved=step_schedule.step_flat,
+        step_stop_resolved=(
+            mosaic_mixup_step_stop
+            if mosaic_mixup_step_stop is not None
+            else step_schedule.step_flat
+        ),
     )
 
     scale_jitter = args.scale_jitter

--- a/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
@@ -15,14 +15,8 @@ from lightning_utilities.core.imports import RequirementCache
 from pytest_mock import MockerFixture
 from torch import nn
 
-from lightly_train._commands.train_task_helpers import get_steps
 from lightly_train._task_models.ltdetr_instance_segmentation.task_model import (
     LTDETRInstanceSegmentation,
-)
-from lightly_train._task_models.ltdetr_instance_segmentation.train_model import (
-    LTDETRInstanceSegmentationLargeTrainArgs,
-    LTDETRInstanceSegmentationTrain,
-    LTDETRInstanceSegmentationTrainArgs,
 )
 
 from ...helpers import assert_onnx_outputs_close
@@ -233,13 +227,6 @@ LTDETR_V2_SEG_ALIAS_TO_CANONICAL: dict[str, str] = {
     "ltdetrv2-seg-x": "edgecrafter/ecvitsplus-ltdetr-seg",
 }
 
-LTDETR_V2_SEG_DEFAULT_STEPS = {
-    "edgecrafter/ecvitt-ltdetr-seg": 273_504,
-    "edgecrafter/ecvittplus-ltdetr-seg": 273_504,
-    "edgecrafter/ecvits-ltdetr-seg": 184_800,
-    "edgecrafter/ecvitsplus-ltdetr-seg": 184_800,
-}
-
 
 @pytest.mark.parametrize("model_name", LTDETR_V2_SEG_ALIAS_MODEL_NAMES)
 def test_is_supported_model__ltdetrv2_alias(model_name: str) -> None:
@@ -266,37 +253,6 @@ def test_list_model_names__includes_ltdetrv2_aliases() -> None:
     names = LTDETRInstanceSegmentation.list_model_names()
     for alias in LTDETR_V2_SEG_ALIAS_MODEL_NAMES:
         assert alias in names, f"Expected alias {alias!r} in list_model_names()"
-
-
-@pytest.mark.parametrize(
-    "model_name",
-    [*ECVIT_LTDETR_SEG_MODEL_NAMES, *LTDETR_V2_SEG_ALIAS_MODEL_NAMES],
-)
-def test_train_args_cls__uses_model_default_schedule(model_name: str) -> None:
-    train_args_cls = LTDETRInstanceSegmentationTrain.get_train_model_args_cls(
-        model_name=model_name
-    )
-    canonical_model_name = LTDETR_V2_SEG_ALIAS_TO_CANONICAL.get(model_name, model_name)
-    expected_steps = LTDETR_V2_SEG_DEFAULT_STEPS[canonical_model_name]
-    expected_cls = (
-        LTDETRInstanceSegmentationLargeTrainArgs
-        if expected_steps == 184_800
-        else LTDETRInstanceSegmentationTrainArgs
-    )
-
-    assert train_args_cls is expected_cls
-    assert train_args_cls.default_steps == expected_steps
-
-
-def test_train_args_cls__explicit_steps_override_model_default() -> None:
-    train_args_cls = LTDETRInstanceSegmentationTrain.get_train_model_args_cls(
-        model_name="ltdetrv2-seg-l"
-    )
-
-    assert (
-        get_steps(steps="auto", default_steps=train_args_cls.default_steps) == 184_800
-    )
-    assert get_steps(steps=12_345, default_steps=train_args_cls.default_steps) == 12_345
 
 
 def test_freeze_backbone_on_init() -> None:

--- a/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
@@ -15,8 +15,14 @@ from lightning_utilities.core.imports import RequirementCache
 from pytest_mock import MockerFixture
 from torch import nn
 
+from lightly_train._commands.train_task_helpers import get_steps
 from lightly_train._task_models.ltdetr_instance_segmentation.task_model import (
     LTDETRInstanceSegmentation,
+)
+from lightly_train._task_models.ltdetr_instance_segmentation.train_model import (
+    LTDETRInstanceSegmentationLargeTrainArgs,
+    LTDETRInstanceSegmentationTrain,
+    LTDETRInstanceSegmentationTrainArgs,
 )
 
 from ...helpers import assert_onnx_outputs_close
@@ -227,6 +233,13 @@ LTDETR_V2_SEG_ALIAS_TO_CANONICAL: dict[str, str] = {
     "ltdetrv2-seg-x": "edgecrafter/ecvitsplus-ltdetr-seg",
 }
 
+LTDETR_V2_SEG_DEFAULT_STEPS = {
+    "edgecrafter/ecvitt-ltdetr-seg": 273_504,
+    "edgecrafter/ecvittplus-ltdetr-seg": 273_504,
+    "edgecrafter/ecvits-ltdetr-seg": 184_800,
+    "edgecrafter/ecvitsplus-ltdetr-seg": 184_800,
+}
+
 
 @pytest.mark.parametrize("model_name", LTDETR_V2_SEG_ALIAS_MODEL_NAMES)
 def test_is_supported_model__ltdetrv2_alias(model_name: str) -> None:
@@ -253,6 +266,37 @@ def test_list_model_names__includes_ltdetrv2_aliases() -> None:
     names = LTDETRInstanceSegmentation.list_model_names()
     for alias in LTDETR_V2_SEG_ALIAS_MODEL_NAMES:
         assert alias in names, f"Expected alias {alias!r} in list_model_names()"
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [*ECVIT_LTDETR_SEG_MODEL_NAMES, *LTDETR_V2_SEG_ALIAS_MODEL_NAMES],
+)
+def test_train_args_cls__uses_model_default_schedule(model_name: str) -> None:
+    train_args_cls = LTDETRInstanceSegmentationTrain.get_train_model_args_cls(
+        model_name=model_name
+    )
+    canonical_model_name = LTDETR_V2_SEG_ALIAS_TO_CANONICAL.get(model_name, model_name)
+    expected_steps = LTDETR_V2_SEG_DEFAULT_STEPS[canonical_model_name]
+    expected_cls = (
+        LTDETRInstanceSegmentationLargeTrainArgs
+        if expected_steps == 184_800
+        else LTDETRInstanceSegmentationTrainArgs
+    )
+
+    assert train_args_cls is expected_cls
+    assert train_args_cls.default_steps == expected_steps
+
+
+def test_train_args_cls__explicit_steps_override_model_default() -> None:
+    train_args_cls = LTDETRInstanceSegmentationTrain.get_train_model_args_cls(
+        model_name="ltdetrv2-seg-l"
+    )
+
+    assert (
+        get_steps(steps="auto", default_steps=train_args_cls.default_steps) == 184_800
+    )
+    assert get_steps(steps=12_345, default_steps=train_args_cls.default_steps) == 12_345
 
 
 def test_freeze_backbone_on_init() -> None:

--- a/tests/_task_models/test_task_model_helpers.py
+++ b/tests/_task_models/test_task_model_helpers.py
@@ -26,6 +26,9 @@ from lightly_train._task_models.dinov3_eomt_semantic_segmentation.config import 
 from lightly_train._task_models.dinov3_eomt_semantic_segmentation.task_model import (
     DINOv3EoMTSemanticSegmentation,
 )
+from lightly_train._task_models.ltdetr_instance_segmentation.config import (
+    LTDETR_SEG_MODEL_REGISTRY,
+)
 from lightly_train._task_models.ltdetr_object_detection.task_model import (
     LTDETRObjectDetection,
 )
@@ -123,6 +126,39 @@ def test_downloadable_model__dinov3_eomt_instance_aliases_from_registry() -> Non
             checkpoint.url,
             checkpoint.sha256,
         )
+
+
+def test_downloadable_model__ltdetr_seg_aliases_from_registry() -> None:
+    aliases = [
+        "ltdetrv2-seg-s-coco",
+        "ltdetrv2-seg-m-coco",
+        "ltdetrv2-seg-l-coco",
+        "ltdetrv2-seg-x-coco",
+        "edgecrafter/ecvitt-ltdetr-seg-coco",
+        "edgecrafter/ecvittplus-ltdetr-seg-coco",
+        "edgecrafter/ecvits-ltdetr-seg-coco",
+        "edgecrafter/ecvitsplus-ltdetr-seg-coco",
+    ]
+
+    for alias in aliases:
+        checkpoint = LTDETR_SEG_MODEL_REGISTRY.get_alias_metadata(
+            alias
+        ).downloadable_checkpoint
+        assert task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH[alias] == (
+            checkpoint.url,
+            checkpoint.sha256,
+        )
+
+
+def test_downloadable_model__ltdetr_seg_coco_short_and_full_aliases_match() -> None:
+    # The ``ltdetrv2-seg-<size>-coco`` short names and the ``edgecrafter/...-seg-coco``
+    # full names must resolve to the same hosted (file, hash) so downloads are
+    # identical regardless of which name the user passes.
+    d = task_model_helpers.DOWNLOADABLE_MODEL_URL_AND_HASH
+    assert d["ltdetrv2-seg-s-coco"] == d["edgecrafter/ecvitt-ltdetr-seg-coco"]
+    assert d["ltdetrv2-seg-m-coco"] == d["edgecrafter/ecvittplus-ltdetr-seg-coco"]
+    assert d["ltdetrv2-seg-l-coco"] == d["edgecrafter/ecvits-ltdetr-seg-coco"]
+    assert d["ltdetrv2-seg-x-coco"] == d["edgecrafter/ecvitsplus-ltdetr-seg-coco"]
 
 
 def test_downloadable_model__picodet_aliases_from_registry() -> None:


### PR DESCRIPTION
## What has changed and why?

- Register downloadable COCO-pretrained checkpoints for the `ltdetrv2-seg-s/m/l/x` aliases and their full EdgeCrafter model names.
- Include LT-DETR instance-segmentation aliases in the downloadable-model lookup.
- Align the default training length and augmentation schedule with the released EdgeCrafter ECSeg COCO recipes.
- Document LTDETRv2 instance segmentation and its pretrained checkpoints in the changelog.

This makes the hosted LTDETRv2 instance-segmentation checkpoints directly loadable and brings the default fine-tuning recipe in line with the pretrained models.

## How has it been tested?

Unit tests.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [ ] Not needed (internal change without effects for user)

No standalone documentation changes were made; the new user-facing model aliases and defaults are covered in the changelog.