### PR TITLE
Reorganize task sections across the README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pip install lightly-train
 ![Tasks](docs/source/_static/images/tasks/tasks.png)
 
 <details open>
-<summary><strong>Object Detection</strong></summary>
+<summary><h3>Object Detection</h3></summary>
 
 Train LTDETR detection models with DINOv2, DINOv3, or EdgeCrafter ECViT backbones.
 
@@ -149,68 +149,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><strong>Panoptic Segmentation</strong></summary>
-
-Train state-of-the-art panoptic segmentation models with DINOv3 backbones using the EoMT
-method from CVPR 2025.
-
-#### COCO Results
-
-| Implementation                       | Model                                 | Val PQ   | Avg. Latency (ms) | Params (M) | Input Size |
-| ------------------------------------ | ------------------------------------- | -------- | ----------------- | ---------- | ---------- |
-| LightlyTrain                         | dinov3/vitt16-eomt-panoptic-coco      | 38.0     | 13.5              | 6.0        | 640×640    |
-| LightlyTrain                         | dinov3/vittplus16-eomt-panoptic-coco  | 41.4     | 14.1              | 7.7        | 640×640    |
-| LightlyTrain                         | dinov3/vits16-eomt-panoptic-coco      | 46.8     | 21.2              | 23.4       | 640×640    |
-| LightlyTrain                         | dinov3/vitb16-eomt-panoptic-coco      | 53.2     | 39.4              | 92.5       | 640×640    |
-| LightlyTrain                         | dinov3/vitl16-eomt-panoptic-coco      | 57.0     | 80.1              | 315.1      | 640×640    |
-| LightlyTrain                         | dinov3/vitl16-eomt-panoptic-coco-1280 | **59.0** | 500.1             | 315.1      | 1280×1280  |
-| EoMT (CVPR 2025 paper, current SOTA) | dinov3/vitl16-eomt-panoptic-coco-1280 | 58.9     | -                 | 315.1      | 1280×1280  |
-
-Tiny models are trained for 48 epochs, small and base models for 24 epochs and large
-models for 12 epochs on the COCO 2017 dataset and evaluated on the validation set with
-single-scale testing. Avg. Latency is measured on a single NVIDIA T4 GPU with batch size
-1\. All models are optimized using `torch.compile`.
-
-#### Usage
-
-[![Documentation](https://img.shields.io/badge/Documentation-blue)](https://docs.lightly.ai/train/stable/panoptic_segmentation.html)
-[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_panoptic_segmentation.ipynb)
-
-```python
-import lightly_train
-
-if __name__ == "__main__":
-    # Train an panoptic segmentation model with a DINOv3 backbone
-    lightly_train.train_panoptic_segmentation(
-        out="out/my_experiment",
-        model="dinov3/vitb16-eomt-panoptic-coco",
-        data={
-            "train": {
-                "images": "images/train",
-                "masks": "annotations/train",
-                "annotations": "annotations/train.json",
-            },
-            "val": {
-                "images": "images/val",
-                "masks": "annotations/val",
-                "annotations": "annotations/val.json",
-            },
-        },
-    )
-
-    model = lightly_train.load_model("out/my_experiment/exported_models/exported_best.pt")
-    results = model.predict("image.jpg")
-    results["masks"]    # Masks with (class_label, segment_id) for each pixel, tensor of
-                        # shape (height, width, 2). Height and width correspond to the
-                        # original image size.
-    results["segment_ids"]    # Segment ids, tensor of shape (num_segments,).
-    results["scores"]   # Confidence scores, tensor of shape (num_segments,)
-```
-
-</details>
-
-<details>
-<summary><strong>Instance Segmentation</strong></summary>
+<summary><h3>Instance Segmentation</h3></summary>
 
 Train state-of-the-art instance segmentation models with DINOv3 backbones using the EoMT
 method from CVPR 2025.
@@ -268,7 +207,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><strong>Semantic Segmentation</strong></summary>
+<summary><h3>Semantic Segmentation</h3></summary>
 
 Train state-of-the-art semantic segmentation models with DINOv2 or DINOv3 backbones
 using the EoMT method from CVPR 2025.
@@ -347,45 +286,68 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><strong>Image Classification</strong></summary>
+<summary><h3>Panoptic Segmentation</h3></summary>
 
-Train multiclass or multilabel image classification models with any backbone.
+Train state-of-the-art panoptic segmentation models with DINOv3 backbones using the EoMT
+method from CVPR 2025.
+
+#### COCO Results
+
+| Implementation                       | Model                                 | Val PQ   | Avg. Latency (ms) | Params (M) | Input Size |
+| ------------------------------------ | ------------------------------------- | -------- | ----------------- | ---------- | ---------- |
+| LightlyTrain                         | dinov3/vitt16-eomt-panoptic-coco      | 38.0     | 13.5              | 6.0        | 640×640    |
+| LightlyTrain                         | dinov3/vittplus16-eomt-panoptic-coco  | 41.4     | 14.1              | 7.7        | 640×640    |
+| LightlyTrain                         | dinov3/vits16-eomt-panoptic-coco      | 46.8     | 21.2              | 23.4       | 640×640    |
+| LightlyTrain                         | dinov3/vitb16-eomt-panoptic-coco      | 53.2     | 39.4              | 92.5       | 640×640    |
+| LightlyTrain                         | dinov3/vitl16-eomt-panoptic-coco      | 57.0     | 80.1              | 315.1      | 640×640    |
+| LightlyTrain                         | dinov3/vitl16-eomt-panoptic-coco-1280 | **59.0** | 500.1             | 315.1      | 1280×1280  |
+| EoMT (CVPR 2025 paper, current SOTA) | dinov3/vitl16-eomt-panoptic-coco-1280 | 58.9     | -                 | 315.1      | 1280×1280  |
+
+Tiny models are trained for 48 epochs, small and base models for 24 epochs and large
+models for 12 epochs on the COCO 2017 dataset and evaluated on the validation set with
+single-scale testing. Avg. Latency is measured on a single NVIDIA T4 GPU with batch size
+1\. All models are optimized using `torch.compile`.
 
 #### Usage
 
-[![Documentation](https://img.shields.io/badge/Documentation-blue)](https://docs.lightly.ai/train/stable/image_classification.html)
-[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/image_classification.ipynb)
+[![Documentation](https://img.shields.io/badge/Documentation-blue)](https://docs.lightly.ai/train/stable/panoptic_segmentation.html)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/eomt_panoptic_segmentation.ipynb)
 
 ```python
 import lightly_train
 
 if __name__ == "__main__":
-    # Train an image classification model with a DINOv3 backbone
-    lightly_train.train_image_classification(
+    # Train an panoptic segmentation model with a DINOv3 backbone
+    lightly_train.train_panoptic_segmentation(
         out="out/my_experiment",
-        model="dinov3/vitt16",
+        model="dinov3/vitb16-eomt-panoptic-coco",
         data={
-            "train": "my_data_dir/train/",
-            "val": "my_data_dir/val/",
-            "classes": {
-                0: "cat",
-                1: "car",
-                2: "dog",
-                # ...
+            "train": {
+                "images": "images/train",
+                "masks": "annotations/train",
+                "annotations": "annotations/train.json",
+            },
+            "val": {
+                "images": "images/val",
+                "masks": "annotations/val",
+                "annotations": "annotations/val.json",
             },
         },
     )
 
     model = lightly_train.load_model("out/my_experiment/exported_models/exported_best.pt")
-    results = model.predict("image.jpg", topk=1, threshold=0.5)
-    results["labels"]   # Class labels, tensor of shape (topk,)
-    results["scores"]   # Confidence scores, tensor of shape (topk,)
+    results = model.predict("image.jpg")
+    results["masks"]    # Masks with (class_label, segment_id) for each pixel, tensor of
+                        # shape (height, width, 2). Height and width correspond to the
+                        # original image size.
+    results["segment_ids"]    # Segment ids, tensor of shape (num_segments,).
+    results["scores"]   # Confidence scores, tensor of shape (num_segments,)
 ```
 
 </details>
 
 <details>
-<summary><strong>Depth Estimation</strong></summary>
+<summary><h3>Depth Estimation</h3></summary>
 
 Run monocular depth inference with Depth Anything V2 and V3 models.
 
@@ -438,7 +400,45 @@ Metric depth (in meters) and the full list of available models are covered in th
 </details>
 
 <details>
-<summary><strong>Distillation (DINOv2/v3)</strong></summary>
+<summary><h3>Image Classification</h3></summary>
+
+Train multiclass or multilabel image classification models with any backbone.
+
+#### Usage
+
+[![Documentation](https://img.shields.io/badge/Documentation-blue)](https://docs.lightly.ai/train/stable/image_classification.html)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/image_classification.ipynb)
+
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    # Train an image classification model with a DINOv3 backbone
+    lightly_train.train_image_classification(
+        out="out/my_experiment",
+        model="dinov3/vitt16",
+        data={
+            "train": "my_data_dir/train/",
+            "val": "my_data_dir/val/",
+            "classes": {
+                0: "cat",
+                1: "car",
+                2: "dog",
+                # ...
+            },
+        },
+    )
+
+    model = lightly_train.load_model("out/my_experiment/exported_models/exported_best.pt")
+    results = model.predict("image.jpg", topk=1, threshold=0.5)
+    results["labels"]   # Class labels, tensor of shape (topk,)
+    results["scores"]   # Confidence scores, tensor of shape (topk,)
+```
+
+</details>
+
+<details>
+<summary><h3>Distillation (DINOv2/v3)</h3></summary>
 
 Pretrain any model architecture with unlabeled data by distilling the knowledge from
 DINOv2 or DINOv3 foundation models into your model. On the COCO dataset, YOLOv8-s models
@@ -477,7 +477,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><strong>Pretraining (DINOv2 Foundation Models)</strong></summary>
+<summary><h3>Pretraining (DINOv2 Foundation Models)</h3></summary>
 
 With LightlyTrain you can train your very own foundation model like DINOv2 on your data.
 
@@ -511,7 +511,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><strong>Autolabeling</strong></summary>
+<summary><h3>Autolabeling</h3></summary>
 
 LightlyTrain provides simple commands to autolabel your unlabeled data using DINOv2 or
 DINOv3 pretrained models. This allows you to efficiently boost performance of your

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pip install lightly-train
 ![Tasks](docs/source/_static/images/tasks/tasks.png)
 
 <details open>
-<summary><h3>Object Detection</h3></summary>
+<summary><strong>Object Detection</strong></summary>
 
 Train LTDETR detection models with DINOv2, DINOv3, or EdgeCrafter ECViT backbones.
 
@@ -149,7 +149,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Instance Segmentation</h3></summary>
+<summary><strong>Instance Segmentation</strong></summary>
 
 Train state-of-the-art instance segmentation models with DINOv3 backbones using the EoMT
 method from CVPR 2025.
@@ -207,7 +207,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Semantic Segmentation</h3></summary>
+<summary><strong>Semantic Segmentation</strong></summary>
 
 Train state-of-the-art semantic segmentation models with DINOv2 or DINOv3 backbones
 using the EoMT method from CVPR 2025.
@@ -286,7 +286,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Panoptic Segmentation</h3></summary>
+<summary><strong>Panoptic Segmentation</strong></summary>
 
 Train state-of-the-art panoptic segmentation models with DINOv3 backbones using the EoMT
 method from CVPR 2025.
@@ -347,7 +347,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Depth Estimation</h3></summary>
+<summary><strong>Depth Estimation</strong></summary>
 
 Run monocular depth inference with Depth Anything V2 and V3 models.
 
@@ -400,7 +400,7 @@ Metric depth (in meters) and the full list of available models are covered in th
 </details>
 
 <details>
-<summary><h3>Image Classification</h3></summary>
+<summary><strong>Image Classification</strong></summary>
 
 Train multiclass or multilabel image classification models with any backbone.
 
@@ -438,7 +438,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Distillation (DINOv2/v3)</h3></summary>
+<summary><strong>Distillation (DINOv2/v3)</strong></summary>
 
 Pretrain any model architecture with unlabeled data by distilling the knowledge from
 DINOv2 or DINOv3 foundation models into your model. On the COCO dataset, YOLOv8-s models
@@ -477,7 +477,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Pretraining (DINOv2 Foundation Models)</h3></summary>
+<summary><strong>Pretraining (DINOv2 Foundation Models)</strong></summary>
 
 With LightlyTrain you can train your very own foundation model like DINOv2 on your data.
 
@@ -511,7 +511,7 @@ if __name__ == "__main__":
 </details>
 
 <details>
-<summary><h3>Autolabeling</h3></summary>
+<summary><strong>Autolabeling</strong></summary>
 
 LightlyTrain provides simple commands to autolabel your unlabeled data using DINOv2 or
 DINOv3 pretrained models. This allows you to efficiently boost performance of your

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -95,28 +95,28 @@ Train LTDETR detection models with DINOv2, DINOv3, or EdgeCrafter ECViT backbone
 Train EoMT segmentation models with DINOv3 backbones.<br>
 ```
 
-```{grid-item-card} Panoptic Segmentation
-:link: panoptic_segmentation.html
-<img src="_static/images/tasks/panoptic_segmentation.png" height="64"><br>
-Train EoMT segmentation models with DINOv2 or DINOv3 backbones.<br>
-```
-
 ```{grid-item-card} Semantic Segmentation
 :link: semantic_segmentation.html
 <img src="_static/images/tasks/semantic_segmentation.png" height="64"><br>
 Train EoMT segmentation models with DINOv2 or DINOv3 backbones.<br>
 ```
 
-```{grid-item-card} Image Classification
-:link: image_classification.html
-<img src="_static/images/tasks/image_classification.jpg" height="64"><br>
-Train image classification models with any backbone.<br>
+```{grid-item-card} Panoptic Segmentation
+:link: panoptic_segmentation.html
+<img src="_static/images/tasks/panoptic_segmentation.png" height="64"><br>
+Train EoMT segmentation models with DINOv2 or DINOv3 backbones.<br>
 ```
 
 ```{grid-item-card} Depth Estimation
 :link: depth_estimation.html
 <img src="_static/images/tasks/depth_estimation.png" height="64"><br>
 Run Depth Anything V2 and V3 monocular depth inference.<br>
+```
+
+```{grid-item-card} Image Classification
+:link: image_classification.html
+<img src="_static/images/tasks/image_classification.jpg" height="64"><br>
+Train image classification models with any backbone.<br>
 ```
 
 ```{grid-item-card} Distillation

--- a/docs/source/panoptic_segmentation.md
+++ b/docs/source/panoptic_segmentation.md
@@ -245,28 +245,30 @@ for an example dataset and how to set up the data for training.
 The [`model`](settings/train_settings.md#model) argument defines the model used for
 panoptic segmentation training. The following models are available:
 
-Unless noted otherwise, all
+Unless noted otherwise, all `dinov2/`-prefixed and `dinov3/`-prefixed model backbones
+are initialized from weights pretrained by Meta through
 [DINOv2](https://github.com/facebookresearch/dinov2?tab=readme-ov-file#pretrained-models)
 and
-[DINOv3](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models)
-backbones are initialized from weights pretrained by Meta. The non-EUPE DINOv3 models
-with `vitt16` and `vitt16plus` backbones use Lightly-pretrained DINOv3 backbone weights
-instead.
+[DINOv3](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models),
+respectively. Non-EUPE DINOv3 models with `vitt16` and `vitt16plus` backbones use
+Lightly-pretrained weights, while `eupe`-postfixed and `lingbot`-postfixed variants use
+[EUPE weights](https://github.com/facebookresearch/EUPE) and
+[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), respectively.
 
 DINOv3 models are under the
-[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file).
-Models marked as EUPE use [EUPE weights](https://github.com/facebookresearch/EUPE) and
-are under the
+[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file). EUPE
+variants are under the
 [FAIR Noncommercial Research License](https://github.com/facebookresearch/EUPE?tab=License-1-ov-file).
-Models marked as LingBot use
-[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), which are released
-under the
+LingBot Vision weights are released under the
 [Apache 2.0 license](https://github.com/Robbyant/lingbot-vision?tab=Apache-2.0-1-ov-file);
 as they are built on DINOv3, the terms of the
 [DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file) also
 apply to these models.
 
 ```{dropdown} DINOv3 ViT backbones
+---
+open:
+---
 - `dinov3/vitt16-eomt-panoptic-coco` (fine-tuned on COCO)
 - `dinov3/vitt16plus-eomt-panoptic-coco` (fine-tuned on COCO)
 - `dinov3/vits16-eomt-panoptic-coco` (fine-tuned on COCO)

--- a/docs/source/panoptic_segmentation.md
+++ b/docs/source/panoptic_segmentation.md
@@ -245,8 +245,28 @@ for an example dataset and how to set up the data for training.
 The [`model`](settings/train_settings.md#model) argument defines the model used for
 panoptic segmentation training. The following models are available:
 
-### DINOv3 Models
+Unless noted otherwise, all
+[DINOv2](https://github.com/facebookresearch/dinov2?tab=readme-ov-file#pretrained-models)
+and
+[DINOv3](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models)
+backbones are initialized from weights pretrained by Meta. The non-EUPE DINOv3 models
+with `vitt16` and `vitt16plus` backbones use Lightly-pretrained DINOv3 backbone weights
+instead.
 
+DINOv3 models are under the
+[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file).
+Models marked as EUPE use [EUPE weights](https://github.com/facebookresearch/EUPE) and
+are under the
+[FAIR Noncommercial Research License](https://github.com/facebookresearch/EUPE?tab=License-1-ov-file).
+Models marked as LingBot use
+[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), which are released
+under the
+[Apache 2.0 license](https://github.com/Robbyant/lingbot-vision?tab=Apache-2.0-1-ov-file);
+as they are built on DINOv3, the terms of the
+[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file) also
+apply to these models.
+
+```{dropdown} DINOv3 ViT backbones
 - `dinov3/vitt16-eomt-panoptic-coco` (fine-tuned on COCO)
 - `dinov3/vitt16plus-eomt-panoptic-coco` (fine-tuned on COCO)
 - `dinov3/vits16-eomt-panoptic-coco` (fine-tuned on COCO)
@@ -254,49 +274,34 @@ panoptic segmentation training. The following models are available:
 - `dinov3/vitl16-eomt-panoptic-coco` (fine-tuned on COCO)
 - `dinov3/vitl16-eomt-panoptic-coco-1280` (fine-tuned on COCO with 1280x1280 input size)
 - `dinov3/vitt16-eomt`
-- `dinov3/vitt16-eupe-eomt` - [EUPE weights](https://github.com/facebookresearch/EUPE)
 - `dinov3/vitt16plus-eomt`
 - `dinov3/vits16-eomt`
-- `dinov3/vits16-eupe-eomt` - [EUPE weights](https://github.com/facebookresearch/EUPE)
-- `dinov3/vits16-lingbot-eomt` -
-  [LingBot Vision weights](https://github.com/Robbyant/lingbot-vision)
 - `dinov3/vits16plus-eomt`
 - `dinov3/vitb16-eomt`
-- `dinov3/vitb16-eupe-eomt` - [EUPE weights](https://github.com/facebookresearch/EUPE)
-- `dinov3/vitb16-lingbot-eomt` -
-  [LingBot Vision weights](https://github.com/Robbyant/lingbot-vision)
 - `dinov3/vitl16-eomt`
-- `dinov3/vitl16-lingbot-eomt` -
-  [LingBot Vision weights](https://github.com/Robbyant/lingbot-vision)
 - `dinov3/vitl16plus-eomt`
 - `dinov3/vith16plus-eomt`
 - `dinov3/vit7b16-eomt`
+```
 
-Unless noted otherwise, all DINOv3 backbones are initialized from weights
-[pretrained by Meta](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models).
-The non-EUPE models with `vitt16` and `vitt16plus` backbones use Lightly-pretrained
-DINOv3 backbone weights instead. Models marked as EUPE use
-[EUPE weights](https://github.com/facebookresearch/EUPE). DINOv3 models are under the
-[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file). EUPE
-models are under the
-[FAIR Noncommercial Research License](https://github.com/facebookresearch/EUPE?tab=License-1-ov-file).
-Models marked as LingBot use
-[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), which are released
-under the
-[Apache 2.0 license](https://github.com/Robbyant/lingbot-vision?tab=Apache-2.0-1-ov-file).
-As they are built on DINOv3, the terms of the
-[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file) also
-apply to these models.
+```{dropdown} DINOv3 ViT backbones with EUPE weights
+- `dinov3/vitt16-eupe-eomt`
+- `dinov3/vits16-eupe-eomt`
+- `dinov3/vitb16-eupe-eomt`
+```
 
-### DINOv2 Models
+```{dropdown} DINOv3 ViT backbones with LingBot Vision weights
+- `dinov3/vits16-lingbot-eomt`
+- `dinov3/vitb16-lingbot-eomt`
+- `dinov3/vitl16-lingbot-eomt`
+```
 
+```{dropdown} DINOv2 ViT backbones
 - `dinov2/vits14-eomt`
 - `dinov2/vitb14-eomt`
 - `dinov2/vitl14-eomt`
 - `dinov2/vitg14-eomt`
-
-All DINOv2 models are
-[pretrained by Meta](https://github.com/facebookresearch/dinov2?tab=readme-ov-file#pretrained-models).
+```
 
 ## Training Settings
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -585,8 +585,30 @@ if __name__ == "__main__":
 The [`model`](settings/train_settings.md#model) argument defines the model used for
 semantic segmentation training. The following models are available:
 
-### DINOv3 Models
+Unless noted otherwise, all
+[DINOv2](https://github.com/facebookresearch/dinov2?tab=readme-ov-file#pretrained-models)
+and
+[DINOv3](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models)
+backbones are initialized from weights pretrained by Meta. The non-EUPE DINOv3 models
+with `vitt16` and `vitt16plus` backbones use Lightly-pretrained DINOv3 backbone weights
+instead.
 
+DINOv3 models are under the
+[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file).
+Models marked as EUPE use [EUPE weights](https://github.com/facebookresearch/EUPE) and
+are under the
+[FAIR Noncommercial Research License](https://github.com/facebookresearch/EUPE?tab=License-1-ov-file).
+Models marked as LingBot use
+[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), which are released
+under the
+[Apache 2.0 license](https://github.com/Robbyant/lingbot-vision?tab=Apache-2.0-1-ov-file);
+as they are built on DINOv3, the terms of the
+[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file) also
+apply to these models.
+
+(dinov3-models)=
+
+```{dropdown} DINOv3 ViT backbones
 - `dinov3/vitt32-eomt-coco` (fine-tuned on COCO-Stuff)
 - `dinov3/vitt32plus-eomt-coco` (fine-tuned on COCO-Stuff)
 - `dinov3/vits32-eomt-coco` (fine-tuned on COCO-Stuff)
@@ -601,49 +623,34 @@ semantic segmentation training. The following models are available:
 - `dinov3/vitb16-eomt-cityscapes` (fine-tuned on Cityscapes)
 - `dinov3/vitl16-eomt-cityscapes` (fine-tuned on Cityscapes)
 - `dinov3/vitt16-eomt`
-- `dinov3/vitt16-eupe-eomt` - [EUPE weights](https://github.com/facebookresearch/EUPE)
 - `dinov3/vitt16plus-eomt`
 - `dinov3/vits16-eomt`
-- `dinov3/vits16-eupe-eomt` - [EUPE weights](https://github.com/facebookresearch/EUPE)
-- `dinov3/vits16-lingbot-eomt` -
-  [LingBot Vision weights](https://github.com/Robbyant/lingbot-vision)
 - `dinov3/vits16plus-eomt`
 - `dinov3/vitb16-eomt`
-- `dinov3/vitb16-eupe-eomt` - [EUPE weights](https://github.com/facebookresearch/EUPE)
-- `dinov3/vitb16-lingbot-eomt` -
-  [LingBot Vision weights](https://github.com/Robbyant/lingbot-vision)
 - `dinov3/vitl16-eomt`
-- `dinov3/vitl16-lingbot-eomt` -
-  [LingBot Vision weights](https://github.com/Robbyant/lingbot-vision)
 - `dinov3/vitl16plus-eomt`
 - `dinov3/vith16plus-eomt`
 - `dinov3/vit7b16-eomt`
+```
 
-Unless noted otherwise, all DINOv3 backbones are initialized from weights
-[pretrained by Meta](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models).
-The non-EUPE models with `vitt16` and `vitt16plus` backbones use Lightly-pretrained
-DINOv3 backbone weights instead. Models marked as EUPE use
-[EUPE weights](https://github.com/facebookresearch/EUPE). DINOv3 models are under the
-[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file). EUPE
-models are under the
-[FAIR Noncommercial Research License](https://github.com/facebookresearch/EUPE?tab=License-1-ov-file).
-Models marked as LingBot use
-[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), which are released
-under the
-[Apache 2.0 license](https://github.com/Robbyant/lingbot-vision?tab=Apache-2.0-1-ov-file).
-As they are built on DINOv3, the terms of the
-[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file) also
-apply to these models.
+```{dropdown} DINOv3 ViT backbones with EUPE weights
+- `dinov3/vitt16-eupe-eomt`
+- `dinov3/vits16-eupe-eomt`
+- `dinov3/vitb16-eupe-eomt`
+```
 
-### DINOv2 Models
+```{dropdown} DINOv3 ViT backbones with LingBot Vision weights
+- `dinov3/vits16-lingbot-eomt`
+- `dinov3/vitb16-lingbot-eomt`
+- `dinov3/vitl16-lingbot-eomt`
+```
 
+```{dropdown} DINOv2 ViT backbones
 - `dinov2/vits14-eomt`
 - `dinov2/vitb14-eomt`
 - `dinov2/vitl14-eomt`
 - `dinov2/vitg14-eomt`
-
-All DINOv2 models are
-[pretrained by Meta](https://github.com/facebookresearch/dinov2?tab=readme-ov-file#pretrained-models).
+```
 
 ## Training Settings
 

--- a/docs/source/semantic_segmentation.md
+++ b/docs/source/semantic_segmentation.md
@@ -585,22 +585,21 @@ if __name__ == "__main__":
 The [`model`](settings/train_settings.md#model) argument defines the model used for
 semantic segmentation training. The following models are available:
 
-Unless noted otherwise, all
+Unless noted otherwise, all `dinov2/`-prefixed and `dinov3/`-prefixed model backbones
+are initialized from weights pretrained by Meta through
 [DINOv2](https://github.com/facebookresearch/dinov2?tab=readme-ov-file#pretrained-models)
 and
-[DINOv3](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models)
-backbones are initialized from weights pretrained by Meta. The non-EUPE DINOv3 models
-with `vitt16` and `vitt16plus` backbones use Lightly-pretrained DINOv3 backbone weights
-instead.
+[DINOv3](https://github.com/facebookresearch/dinov3/tree/main?tab=readme-ov-file#pretrained-models),
+respectively. Non-EUPE DINOv3 models with `vitt16` and `vitt16plus` backbones use
+Lightly-pretrained weights, while `eupe`-postfixed and `lingbot`-postfixed variants use
+[EUPE weights](https://github.com/facebookresearch/EUPE) and
+[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), respectively.
 
 DINOv3 models are under the
-[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file).
-Models marked as EUPE use [EUPE weights](https://github.com/facebookresearch/EUPE) and
-are under the
+[DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file). EUPE
+variants are under the
 [FAIR Noncommercial Research License](https://github.com/facebookresearch/EUPE?tab=License-1-ov-file).
-Models marked as LingBot use
-[LingBot Vision weights](https://github.com/Robbyant/lingbot-vision), which are released
-under the
+LingBot Vision weights are released under the
 [Apache 2.0 license](https://github.com/Robbyant/lingbot-vision?tab=Apache-2.0-1-ov-file);
 as they are built on DINOv3, the terms of the
 [DINOv3 license](https://github.com/facebookresearch/dinov3?tab=License-1-ov-file) also
@@ -609,6 +608,9 @@ apply to these models.
 (dinov3-models)=
 
 ```{dropdown} DINOv3 ViT backbones
+---
+open:
+---
 - `dinov3/vitt32-eomt-coco` (fine-tuned on COCO-Stuff)
 - `dinov3/vitt32plus-eomt-coco` (fine-tuned on COCO-Stuff)
 - `dinov3/vits32-eomt-coco` (fine-tuned on COCO-Stuff)

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -28,12 +28,12 @@ maxdepth: 1
 caption: Core Tasks
 ---
 object_detection
-image_classification
-depth_estimation
-eomt_semantic_segmentation
 eomt_instance_segmentation
 ltdetr_instance_segmentation
+eomt_semantic_segmentation
 eomt_panoptic_segmentation
+depth_estimation
+image_classification
 ```
 
 ```{toctree}

--- a/examples/notebooks/depth_estimation_export.ipynb
+++ b/examples/notebooks/depth_estimation_export.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Depth Estimation Model Export - Depth Anything v3\n",
+    "# Depth Estimation Model Export - Depth Anything v2\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/depth_estimation_export.ipynb)\n",
     "\n",

--- a/examples/notebooks/depth_estimation_export.ipynb
+++ b/examples/notebooks/depth_estimation_export.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Depth Estimation Model Export (ONNX and TensorRT)\n",
+    "# Depth Estimation Model Export - Depth Anything v3\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/lightly-ai/lightly-train/blob/main/examples/notebooks/depth_estimation_export.ipynb)\n",
     "\n",


### PR DESCRIPTION
## What has changed and why?

- Reorder the task tutorials and workflow sections consistently across the README,
  documentation navigation, and documentation landing page.
- Clarify that the depth estimation export tutorial covers Depth Anything v2.
- Reorganize the semantic and panoptic segmentation model documentations into dropdowns for standard
  DINOv3, EUPE, LingBot Vision, and DINOv2 backbones, with the relevant pretrained
  weight and license information.

These changes make the task ordering and model documentation more consistent and
improve the discoverability of the available workflows and model variants.

## How has it been tested?

[LightlyTrain documentation.pdf](https://github.com/user-attachments/files/30315059/LightlyTrain.documentation.pdf)
[Panoptic Segmentation - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/30339605/Panoptic.Segmentation.-.LightlyTrain.documentation.pdf)
[Semantic Segmentation - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/30339607/Semantic.Segmentation.-.LightlyTrain.documentation.pdf)
[Tutorials - LightlyTrain documentation.pdf](https://github.com/user-attachments/files/30315061/Tutorials.-.LightlyTrain.documentation.pdf)


## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [ ] Yes
- [x] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
