### PR TITLE
Fix LT-DETR ONNX verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix `export_onnx(verify=True)` crashing with an `onnx.checker` `ShapeInferenceError`
+  for LTDETR object detection by repairing stale intermediate shape annotations left by
+  the ONNX exporter.
+
 ### Security
 
 ## [0.16.4] - 2026-07-24

--- a/src/lightly_train/_export/export_onnx.py
+++ b/src/lightly_train/_export/export_onnx.py
@@ -26,6 +26,7 @@ from lightly_train._export.onnx_helpers import (
     fix_topological_order,
     remove_duplicate_cast_nodes,
     remove_redundant_casts,
+    repair_value_info,
     write_onnx_metadata,
 )
 from lightly_train._license import LICENSE_INFO
@@ -156,6 +157,10 @@ class ONNXExportMixin(ExportMixin):
             onnxslim.slim(
                 str(out), output_model=out, skip_optimizations=["constant_folding"]
             )
+        # Repair stale/incorrect intermediate shape annotations left by the dynamo
+        # exporter so that verify (onnx.checker full_check) and downstream consumers
+        # such as TensorRT get a consistent graph.
+        repair_value_info(out=out)
         write_onnx_metadata(out=out, metadata=self.onnx_export_metadata())
 
         if verify:

--- a/src/lightly_train/_export/export_onnx.py
+++ b/src/lightly_train/_export/export_onnx.py
@@ -71,7 +71,8 @@ class ONNXExportMixin(ExportMixin):
             metadata["image_normalize"] = json.dumps(image_normalize, sort_keys=True)
         classes = getattr(self, "classes", None)
         if classes is not None:
-            metadata["classes"] = json.dumps(classes, sort_keys=True)
+            # Task models use insertion order to assign internal class indices.
+            metadata["classes"] = json.dumps(classes)
         model_name = getattr(self, "init_args", {}).get("model_name")
         if model_name is not None:
             metadata["model_name"] = str(model_name)

--- a/src/lightly_train/_export/onnx_helpers.py
+++ b/src/lightly_train/_export/onnx_helpers.py
@@ -94,6 +94,25 @@ def write_onnx_metadata(out: str | Path, metadata: dict[str, str]) -> None:
     onnx.save(model, str(out))
 
 
+def repair_value_info(out: str | Path) -> None:
+    """Strip stale intermediate ``value_info`` and re-run shape inference in-place.
+
+    The dynamo ONNX exporter can leave incorrect intermediate shape annotations
+    on the graph (for LT-DETR, the deformable-attention weight ``MatMul`` outputs
+    are annotated rank-1 where the real tensor is rank-2). ONNX Runtime recomputes
+    shapes and is unaffected, but ``onnx.checker.check_model(full_check=True)`` (used
+    by ``verify=True``) raises a ``ShapeInferenceError`` on the inconsistency, and
+    some consumers trust the wrong annotation. Dropping the stale ``value_info`` and
+    re-inferring produces a consistent graph without changing any computation.
+    """
+    import onnx
+
+    model = onnx.load(str(out))
+    del model.graph.value_info[:]
+    model = onnx.shape_inference.infer_shapes(model, strict_mode=False, data_prop=True)
+    onnx.save(model, str(out))
+
+
 def remove_duplicate_cast_nodes(model: onnx.ModelProto) -> None:
     """Remove duplicate Cast nodes emitted by convert_float_to_float16 in-place.
 

--- a/tests/_task_models/ltdetr_object_detection/test_model_io_metadata.py
+++ b/tests/_task_models/ltdetr_object_detection/test_model_io_metadata.py
@@ -24,7 +24,7 @@ from lightly_train._task_models.ltdetr_object_detection.task_model import (
 def _model() -> LTDETRObjectDetection:
     return LTDETRObjectDetection(
         model_name="dinov3/vitt16-notpretrained-ltdetr",
-        classes={0: "car", 1: "person"},
+        classes={1: "person", 0: "car"},
         image_size=(256, 320),
         image_normalize={"mean": (0.0,), "std": (1.0,)},
         backbone_args={"in_chans": 1},
@@ -52,6 +52,9 @@ def test_onnx_export_metadata() -> None:
         "mean": [0.0],
         "std": [1.0],
     }
-    assert json.loads(metadata["classes"]) == {"0": "car", "1": "person"}
+    assert list(json.loads(metadata["classes"]).items()) == [
+        ("1", "person"),
+        ("0", "car"),
+    ]
     assert metadata["model_name"] == "dinov3/vitt16-notpretrained-ltdetr"
     assert "image_size" not in metadata

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -837,6 +837,29 @@ def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
 @pytest.mark.skipif(
     not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
 )
+def test_export_onnx__checks(tmp_path: Path) -> None:
+    # The graph must pass the full ONNX checker, which requires the dynamo
+    # shape-annotation repair.
+    import onnx
+
+    model = LTDETRObjectDetection(
+        model_name="ltdetrv2-s",
+        classes={0: "car", 1: "person"},
+        image_size=(256, 256),
+        load_weights=False,
+    )
+
+    out = tmp_path / "model.onnx"
+    # verify=True runs onnx.checker(full_check=True) and a numerical ORT comparison.
+    model.export_onnx(out=out, simplify=True, verify=True)
+
+    onnx.checker.check_model(str(out), full_check=True)
+
+
+@pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")
+@pytest.mark.skipif(
+    not RequirementCache("onnxruntime"), reason="onnxruntime not installed"
+)
 def test_export_onnx__static_batch_size(tmp_path: Path) -> None:
     model = LTDETRObjectDetection(
         model_name="dinov3/vitt16-notpretrained-ltdetr",


### PR DESCRIPTION
## What has changed and why?

This is PR 1 of a three-PR stack.

LT-DETR object-detection models exported with `verify=True` could fail strict ONNX
validation even though ONNX Runtime could execute them correctly. The Dynamo exporter
left stale intermediate shape annotations in the graph. In particular, some
deformable-attention tensors were described with the wrong rank. ONNX Runtime
recomputed those shapes, while `onnx.checker` trusted the inconsistent annotations and
raised a `ShapeInferenceError`.

This change removes the stale intermediate shape information and runs ONNX shape
inference again before verification. It does not change the model computation; it
only makes the saved graph internally consistent for strict verification and downstream
consumers.

## How has it been tested?

- `make static-checks`
- Targeted LT-DETR ONNX export and verification tests
- Object-detection ONNX export smoke test

The complete three-PR stack was also validated with object-detection and dynamic
instance-segmentation ONNX exports.

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (the behavior change is covered by the changelog)