### PR TITLE
Fix TensorRT GridSample inference for LT-DETR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix incorrect TensorRT inference for LTDETR object detection. The exported ONNX
+  opset 20+ `GridSample` mode was interpreted as nearest-neighbor by TensorRT instead
+  of bilinear, producing wrong detections; TensorRT export now passes parser-compatible
+  mode names for opset 20+.
 - Fix `export_onnx(verify=True)` crashing with an `onnx.checker` `ShapeInferenceError`
   for LTDETR object detection by repairing stale intermediate shape annotations left by
   the ONNX exporter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix incorrect TensorRT inference for LTDETR object detection. The exported ONNX
-  opset 20+ `GridSample` mode was interpreted as nearest-neighbor by TensorRT instead
-  of bilinear, producing wrong detections; TensorRT export now passes parser-compatible
-  mode names for opset 20+.
+- Fix incorrect TensorRT inference for LT-DETR object detection and instance
+  segmentation. TensorRT's optimizer/fusion pass around the `GridSample` ops used by
+  deformable attention silently produced wrong activations, corrupting detections and
+  masks, even with parser-compatible mode names. Deployment/export now replaces
+  `grid_sample` with a gather-based bilinear equivalent that contains no `GridSample`
+  op, so neither the parser mode-name issue nor the optimizer bug can apply; training
+  keeps the faster fused `grid_sample`.
 - Fix `export_onnx(verify=True)` crashing with an `onnx.checker` `ShapeInferenceError`
   for LTDETR object detection by repairing stale intermediate shape annotations left by
   the ONNX exporter.

--- a/src/lightly_train/_export/export_onnx.py
+++ b/src/lightly_train/_export/export_onnx.py
@@ -24,6 +24,7 @@ from lightly_train._commands import _warnings
 from lightly_train._export.export import ExportMixin
 from lightly_train._export.onnx_helpers import (
     fix_topological_order,
+    prepare_for_onnx_export,
     remove_duplicate_cast_nodes,
     remove_redundant_casts,
     repair_value_info,
@@ -111,6 +112,7 @@ class ONNXExportMixin(ExportMixin):
         # safely after export. The shared pipeline deliberately preserves that behavior.
         module.to(torch.float32)
         module.deploy()
+        prepare_for_onnx_export(module)
 
         program = self.export(
             batch_size=batch_size,

--- a/src/lightly_train/_export/onnx_helpers.py
+++ b/src/lightly_train/_export/onnx_helpers.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Iterator
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import torch
 from lightning_utilities.core.imports import RequirementCache
@@ -29,6 +29,11 @@ _TORCH_DYNAMO_AVAILABLE = RequirementCache(f"torch>={_TORCH_DYNAMO_MIN_VERSION}"
 
 _TORCH_DIM_HINTS_MIN_VERSION = "2.6.0"
 _TORCH_DIM_HINTS_AVAILABLE = RequirementCache(f"torch>={_TORCH_DIM_HINTS_MIN_VERSION}")
+
+
+@runtime_checkable
+class ONNXExportConvertible(Protocol):
+    def convert_to_onnx_export(self) -> None: ...
 
 
 def check_onnx_dynamo_requirements() -> None:
@@ -117,8 +122,8 @@ def repair_value_info(out: str | Path) -> None:
 def prepare_for_onnx_export(module: Module) -> None:
     """Apply module-specific graph conversions required for ONNX export."""
     for child in module.modules():
-        if hasattr(child, "convert_to_onnx_export"):
-            child.convert_to_onnx_export()  # type: ignore[operator]
+        if isinstance(child, ONNXExportConvertible):
+            child.convert_to_onnx_export()
 
 
 def remove_duplicate_cast_nodes(model: onnx.ModelProto) -> None:

--- a/src/lightly_train/_export/onnx_helpers.py
+++ b/src/lightly_train/_export/onnx_helpers.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 from lightning_utilities.core.imports import RequirementCache
+from torch.nn import Module
 
 if TYPE_CHECKING:
     import onnx
@@ -111,6 +112,13 @@ def repair_value_info(out: str | Path) -> None:
     del model.graph.value_info[:]
     model = onnx.shape_inference.infer_shapes(model, strict_mode=False, data_prop=True)
     onnx.save(model, str(out))
+
+
+def prepare_for_onnx_export(module: Module) -> None:
+    """Apply module-specific graph conversions required for ONNX export."""
+    for child in module.modules():
+        if hasattr(child, "convert_to_onnx_export"):
+            child.convert_to_onnx_export()  # type: ignore[operator]
 
 
 def remove_duplicate_cast_nodes(model: onnx.ModelProto) -> None:

--- a/src/lightly_train/_export/tensorrt_helpers.py
+++ b/src/lightly_train/_export/tensorrt_helpers.py
@@ -154,7 +154,8 @@ def export_tensorrt(
         _debug_mark_all_layers_as_outputs(onnx_out)
 
     logger.info(f"Loading ONNX file from {onnx_out}")
-    onnx_bytes = _fix_grid_sample_modes_for_tensorrt(onnx_out=onnx_out)
+    with open(onnx_out, "rb") as f:
+        onnx_bytes = f.read()
     if not parser.parse(onnx_bytes):
         for error in range(parser.num_errors):
             logger.error(parser.get_error(error))
@@ -261,37 +262,6 @@ def export_tensorrt(
     with open(out, "wb") as f:
         f.write(engine)
     logger.info("Engine export complete.")
-
-
-def _fix_grid_sample_modes_for_tensorrt(*, onnx_out: PathLike) -> bytes:
-    """Use the legacy GridSample mode names expected by TensorRT's ONNX parser."""
-    import onnx
-
-    onnx_bytes = Path(onnx_out).read_bytes()
-    model = onnx.load_from_string(onnx_bytes)
-    opset_version = next(
-        (
-            opset.version
-            for opset in model.opset_import
-            if opset.domain in ("", "ai.onnx")
-        ),
-        0,
-    )
-    if opset_version < 20:
-        return onnx_bytes
-
-    # NOTE: This works around a known onnx-tensorrt issue where the opset 20+
-    # "linear"/"cubic" names silently fall back to nearest:
-    # https://github.com/onnx/onnx-tensorrt/pull/1060
-    mode_names = {b"linear": b"bilinear", b"cubic": b"bicubic"}
-    for node in model.graph.node:
-        if node.domain in ("", "ai.onnx") and node.op_type == "GridSample":
-            for attr in node.attribute:
-                if attr.name == "mode" and attr.s in mode_names:
-                    attr.s = mode_names[attr.s]
-
-    serialized: bytes = model.SerializeToString()
-    return serialized
 
 
 def _force_fp32_for_attention_scores(net: trt.INetworkDefinition) -> None:

--- a/src/lightly_train/_export/tensorrt_helpers.py
+++ b/src/lightly_train/_export/tensorrt_helpers.py
@@ -154,11 +154,11 @@ def export_tensorrt(
         _debug_mark_all_layers_as_outputs(onnx_out)
 
     logger.info(f"Loading ONNX file from {onnx_out}")
-    with open(onnx_out, "rb") as f:
-        if not parser.parse(f.read()):
-            for error in range(parser.num_errors):
-                logger.error(parser.get_error(error))
-            raise RuntimeError("Failed to parse ONNX file")
+    onnx_bytes = _fix_grid_sample_modes_for_tensorrt(onnx_out=onnx_out)
+    if not parser.parse(onnx_bytes):
+        for error in range(parser.num_errors):
+            logger.error(parser.get_error(error))
+        raise RuntimeError("Failed to parse ONNX file")
 
     if fp32_attention_scores:
         _force_fp32_for_attention_scores(network)
@@ -261,6 +261,37 @@ def export_tensorrt(
     with open(out, "wb") as f:
         f.write(engine)
     logger.info("Engine export complete.")
+
+
+def _fix_grid_sample_modes_for_tensorrt(*, onnx_out: PathLike) -> bytes:
+    """Use the legacy GridSample mode names expected by TensorRT's ONNX parser."""
+    import onnx
+
+    onnx_bytes = Path(onnx_out).read_bytes()
+    model = onnx.load_from_string(onnx_bytes)
+    opset_version = next(
+        (
+            opset.version
+            for opset in model.opset_import
+            if opset.domain in ("", "ai.onnx")
+        ),
+        0,
+    )
+    if opset_version < 20:
+        return onnx_bytes
+
+    # NOTE: This works around a known onnx-tensorrt issue where the opset 20+
+    # "linear"/"cubic" names silently fall back to nearest:
+    # https://github.com/onnx/onnx-tensorrt/pull/1060
+    mode_names = {b"linear": b"bilinear", b"cubic": b"bicubic"}
+    for node in model.graph.node:
+        if node.domain in ("", "ai.onnx") and node.op_type == "GridSample":
+            for attr in node.attribute:
+                if attr.name == "mode" and attr.s in mode_names:
+                    attr.s = mode_names[attr.s]
+
+    serialized: bytes = model.SerializeToString()
+    return serialized
 
 
 def _force_fp32_for_attention_scores(net: trt.INetworkDefinition) -> None:

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/task_model.py
@@ -26,6 +26,7 @@ from lightly_train._data import file_helpers
 from lightly_train._export import tensorrt_helpers
 from lightly_train._export.onnx_helpers import (
     fix_topological_order,
+    prepare_for_onnx_export,
     remove_redundant_casts,
 )
 from lightly_train._models import package_helpers
@@ -374,6 +375,7 @@ class LTDETRInstanceSegmentation(TaskModel):
         # post-export via onnxruntime.transformers.
         self.to(torch.float32)
         self.deploy()
+        prepare_for_onnx_export(self)
         model_device = next(self.parameters()).device
 
         # Infer num_channels if not provided. The model always consumes

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -29,6 +29,7 @@ from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer i
     DinoVisionTransformer as DINOv2VisionTransformer,
 )
 from lightly_train._models.dinov3.dinov3_convnext import DINOv3VConvNeXtModelWrapper
+from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.models.convnext import ConvNeXt
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer as DINOv3VisionTransformer,
@@ -765,10 +766,21 @@ class LTDETRObjectDetection(TaskModel, ONNXExportMixin):
         onnx_args = dict(onnx_args) if onnx_args is not None else {}
         onnx_args.setdefault("precision", precision)
 
-        logger.info(
-            "Using a weakly-typed TensorRT network so TensorRT can optimize "
-            "layer precision."
+        strongly_typed = (
+            precision == "fp16"
+            and self._backbone_package_name == DINOV3_PACKAGE.name
+            and self._backbone_name == "vits16"
         )
+        if strongly_typed:
+            logger.info(
+                "Using a strongly-typed TensorRT network for DINOv3 ViT-S to "
+                "preserve FP32 attention scores and prevent FP16 overflow."
+            )
+        else:
+            logger.info(
+                "Using a weakly-typed TensorRT network so TensorRT can optimize "
+                "layer precision."
+            )
 
         tensorrt_helpers.export_tensorrt(
             export_onnx_fn=self.export_onnx,
@@ -780,7 +792,7 @@ class LTDETRObjectDetection(TaskModel, ONNXExportMixin):
             opt_batchsize=opt_batchsize,
             min_batchsize=min_batchsize,
             fp32_attention_scores=False,
-            strongly_typed=False,
+            strongly_typed=strongly_typed,
             verbose=verbose,
         )
 

--- a/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/task_model.py
@@ -29,7 +29,6 @@ from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer i
     DinoVisionTransformer as DINOv2VisionTransformer,
 )
 from lightly_train._models.dinov3.dinov3_convnext import DINOv3VConvNeXtModelWrapper
-from lightly_train._models.dinov3.dinov3_package import DINOV3_PACKAGE
 from lightly_train._models.dinov3.dinov3_src.models.convnext import ConvNeXt
 from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
     DinoVisionTransformer as DINOv3VisionTransformer,
@@ -766,21 +765,10 @@ class LTDETRObjectDetection(TaskModel, ONNXExportMixin):
         onnx_args = dict(onnx_args) if onnx_args is not None else {}
         onnx_args.setdefault("precision", precision)
 
-        strongly_typed = (
-            precision == "fp16"
-            and self._backbone_package_name == DINOV3_PACKAGE.name
-            and self._backbone_name == "vits16"
+        logger.info(
+            "Using a weakly-typed TensorRT network so TensorRT can optimize "
+            "layer precision."
         )
-        if strongly_typed:
-            logger.info(
-                "Using a strongly-typed TensorRT network for DINOv3 ViT-S to "
-                "preserve FP32 attention scores and prevent FP16 overflow."
-            )
-        else:
-            logger.info(
-                "Using a weakly-typed TensorRT network so TensorRT can optimize "
-                "layer precision."
-            )
 
         tensorrt_helpers.export_tensorrt(
             export_onnx_fn=self.export_onnx,
@@ -792,7 +780,7 @@ class LTDETRObjectDetection(TaskModel, ONNXExportMixin):
             opt_batchsize=opt_batchsize,
             min_batchsize=min_batchsize,
             fp32_attention_scores=False,
-            strongly_typed=strongly_typed,
+            strongly_typed=False,
             verbose=verbose,
         )
 

--- a/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/dfine_decoder.py
@@ -158,6 +158,18 @@ class MSDeformableAttention(nn.Module):
         init.constant_(self.attention_weights.weight, 0)
         init.constant_(self.attention_weights.bias, 0)
 
+    def convert_to_onnx_export(self) -> None:
+        # Switch the default (grid_sample) sampler to a gather-based bilinear
+        # equivalent that exports to a TensorRT-compatible graph. TensorRT
+        # converts ONNX GridSample incorrectly for this deformable attention, so
+        # the fused grid_sample is kept only for training. Discrete sampling is
+        # left unchanged.
+        if self.method == "default":
+            self.method = "bilinear_gather"
+            self.ms_deformable_attn_core = functools.partial(
+                deformable_attention_core_func_v2, method=self.method
+            )
+
     def forward(
         self,
         query,

--- a/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
+++ b/src/lightly_train/_task_models/object_detection_components/rtdetrv2_decoder.py
@@ -143,6 +143,18 @@ class MSDeformableAttention(nn.Module):
         init.xavier_uniform_(self.output_proj.weight)
         init.constant_(self.output_proj.bias, 0)
 
+    def convert_to_onnx_export(self) -> None:
+        # Switch the default (grid_sample) sampler to a gather-based bilinear
+        # equivalent that exports to a TensorRT-compatible graph. TensorRT
+        # converts ONNX GridSample incorrectly for this deformable attention, so
+        # the fused grid_sample is kept only for training. Discrete sampling is
+        # left unchanged.
+        if self.method == "default":
+            self.method = "bilinear_gather"
+            self.ms_deformable_attn_core = functools.partial(
+                deformable_attention_core_func_v2, method=self.method
+            )
+
     def forward(
         self,
         query: torch.Tensor,

--- a/src/lightly_train/_task_models/object_detection_components/utils.py
+++ b/src/lightly_train/_task_models/object_detection_components/utils.py
@@ -37,6 +37,80 @@ def bias_init_with_prob(prior_prob=0.01):
     return bias_init
 
 
+def bilinear_grid_sample(
+    im: Tensor, grid: Tensor, align_corners: bool = False
+) -> Tensor:
+    """Pure gather-based equivalent of ``F.grid_sample`` (bilinear, zero padding).
+
+    ``torch.nn.functional.grid_sample`` exports to an ONNX ``GridSample`` op that
+    TensorRT converts incorrectly for the deformable-attention sampling used by
+    LT-DETR (the engine produces wrong outputs even though the inputs are exact).
+    This decomposition into ``Pad`` + ``Gather`` + arithmetic matches
+    ``F.grid_sample(mode="bilinear", padding_mode="zeros", align_corners=...)`` to
+    within floating-point tolerance and builds a correct TensorRT engine.
+
+    Args:
+        im:
+            Input feature map of shape ``(N, C, H, W)``.
+        grid:
+            Sampling grid of shape ``(N, H_out, W_out, 2)`` with coordinates
+            normalized to ``[-1, 1]``.
+        align_corners:
+            Matches the ``align_corners`` argument of ``F.grid_sample``.
+
+    Returns:
+        Sampled tensor of shape ``(N, C, H_out, W_out)``.
+    """
+    n, c, h, w = im.shape
+    _, gh, gw, _ = grid.shape
+
+    x = grid[..., 0]
+    y = grid[..., 1]
+    if align_corners:
+        x = ((x + 1) / 2) * (w - 1)
+        y = ((y + 1) / 2) * (h - 1)
+    else:
+        x = ((x + 1) * w - 1) / 2
+        y = ((y + 1) * h - 1) / 2
+
+    x = x.reshape(n, -1)
+    y = y.reshape(n, -1)
+    x0 = torch.floor(x)
+    y0 = torch.floor(y)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    # Bilinear interpolation weights (computed before clamping so out-of-bounds
+    # samples keep their correct weights and only fetch zeros).
+    wa = ((x1 - x) * (y1 - y)).unsqueeze(1)
+    wb = ((x1 - x) * (y - y0)).unsqueeze(1)
+    wc = ((x - x0) * (y1 - y)).unsqueeze(1)
+    wd = ((x - x0) * (y - y0)).unsqueeze(1)
+
+    # Zero-pad by one pixel on each side so that out-of-bounds coordinates land on
+    # the zero border, reproducing ``padding_mode="zeros"``.
+    im = F.pad(im, [1, 1, 1, 1])
+    padded_h = h + 2
+    padded_w = w + 2
+    x0 = (x0 + 1).long().clamp(0, padded_w - 1)
+    x1 = (x1 + 1).long().clamp(0, padded_w - 1)
+    y0 = (y0 + 1).long().clamp(0, padded_h - 1)
+    y1 = (y1 + 1).long().clamp(0, padded_h - 1)
+
+    im = im.reshape(n, c, padded_h * padded_w)
+
+    def _gather(xx: Tensor, yy: Tensor) -> Tensor:
+        idx = (xx + yy * padded_w).unsqueeze(1).expand(-1, c, -1)
+        return torch.gather(im, 2, idx)
+
+    ia = _gather(x0, y0)
+    ib = _gather(x0, y1)
+    ic = _gather(x1, y0)
+    id_ = _gather(x1, y1)
+
+    return (ia * wa + ib * wb + ic * wc + id_ * wd).reshape(n, c, gh, gw)
+
+
 def deformable_attention_core_func(
     value, value_spatial_shapes, sampling_locations, attention_weights
 ):
@@ -115,7 +189,7 @@ def deformable_attention_core_func_v2(
     value_list = value.permute(0, 2, 3, 1).flatten(0, 1).split(split_shape, dim=-1)
 
     # sampling_offsets [8, 480, 8, 12, 2]
-    if method == "default":
+    if method in ("default", "bilinear_gather"):
         sampling_grids = 2 * sampling_locations - 1
 
     elif method == "discrete":
@@ -136,6 +210,14 @@ def deformable_attention_core_func_v2(
                 mode="bilinear",
                 padding_mode="zeros",
                 align_corners=False,
+            )
+
+        elif method == "bilinear_gather":
+            # Gather-based equivalent of the "default" grid_sample that exports to
+            # a TensorRT-compatible graph (see ``bilinear_grid_sample``). Used for
+            # deployment/export; training keeps the faster fused grid_sample.
+            sampling_value_l = bilinear_grid_sample(
+                value_l, sampling_grid_l, align_corners=False
             )
 
         elif method == "discrete":

--- a/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
+++ b/tests/_task_models/ltdetr_instance_segmentation/test_task_model.py
@@ -300,6 +300,12 @@ def test_export_onnx__dynamic_batch_size(
     input_batch_dim = onnx_model.graph.input[0].type.tensor_type.shape.dim[0]
     assert input_batch_dim.dim_param == "N"
 
+    # The graph must not contain a GridSample op: TensorRT converts it incorrectly
+    # for the deformable-attention sampling shared with object detection, so
+    # deployment swaps it for a gather-based bilinear equivalent.
+    op_types = {node.op_type for node in onnx_model.graph.node}
+    assert "GridSample" not in op_types
+
     # Use a batch size (3) different from the one used during tracing (2).
     inputs = np.random.randn(3, 3, 256, 256).astype(np.float32)
     orig_target_size = np.array([[256, 256]] * 3, dtype=np.int64)

--- a/tests/_task_models/ltdetr_object_detection/test_task_model.py
+++ b/tests/_task_models/ltdetr_object_detection/test_task_model.py
@@ -842,7 +842,9 @@ def test_export_onnx__dynamic_batch_size(tmp_path: Path) -> None:
 )
 def test_export_onnx__checks(tmp_path: Path) -> None:
     # The graph must pass the full ONNX checker, which requires the dynamo
-    # shape-annotation repair.
+    # shape-annotation repair. It must also not contain a GridSample op: TensorRT
+    # converts it incorrectly for the deformable-attention sampling, so deployment
+    # swaps it for a gather-based bilinear equivalent.
     import onnx
 
     model = LTDETRObjectDetection(
@@ -857,6 +859,10 @@ def test_export_onnx__checks(tmp_path: Path) -> None:
     model.export_onnx(out=out, simplify=True, verify=True)
 
     onnx.checker.check_model(str(out), full_check=True)
+
+    onnx_model = onnx.load(out)
+    op_types = {node.op_type for node in onnx_model.graph.node}
+    assert "GridSample" not in op_types
 
 
 @pytest.mark.skipif(not RequirementCache("onnx"), reason="onnx not installed")

--- a/tests/_task_models/object_detection_components/test_utils.py
+++ b/tests/_task_models/object_detection_components/test_utils.py
@@ -7,9 +7,15 @@
 #
 from __future__ import annotations
 
+import pytest
 import torch
+import torch.nn.functional as F
 
-from lightly_train._task_models.object_detection_components.utils import _yolo_to_xyxy
+from lightly_train._task_models.object_detection_components.utils import (
+    _yolo_to_xyxy,
+    bilinear_grid_sample,
+    deformable_attention_core_func_v2,
+)
 
 
 def test_yolo_to_xyxy_accepts_1d_box() -> None:
@@ -52,3 +58,59 @@ def test_yolo_to_xyxy_accepts_two_boxes() -> None:
         dtype=torch.float32,
     )
     torch.testing.assert_close(converted[0], expected)
+
+
+@pytest.mark.parametrize(
+    ("h", "w", "hg", "wg"),
+    [(80, 80, 300, 3), (40, 40, 300, 6), (20, 20, 300, 3), (13, 17, 50, 4)],
+)
+def test_bilinear_grid_sample__matches_grid_sample(
+    h: int, w: int, hg: int, wg: int
+) -> None:
+    # The gather-based implementation must match F.grid_sample (bilinear, zero
+    # padding, align_corners=False), including for out-of-bounds coordinates which
+    # deformable attention produces.
+    torch.manual_seed(0)
+    im = torch.randn(4, 12, h, w)
+    grid = torch.rand(4, hg, wg, 2) * 2.6 - 1.3  # spans outside [-1, 1]
+
+    expected = F.grid_sample(
+        im, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+    )
+    got = bilinear_grid_sample(im, grid, align_corners=False)
+
+    torch.testing.assert_close(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_deformable_attention_core__bilinear_gather_matches_default() -> None:
+    # The "bilinear_gather" method (used for TensorRT-safe export) must reproduce
+    # the default grid_sample-based sampling numerically.
+    torch.manual_seed(0)
+    bs, n_head, c = 2, 8, 16
+    value_spatial_shapes = [(20, 20), (10, 10)]
+    num_points_list = [4, 4]
+    len_q = 30
+    value_len = sum(h * w for h, w in value_spatial_shapes)
+
+    value = torch.randn(bs, value_len, n_head, c)
+    sampling_locations = torch.rand(bs, len_q, n_head, sum(num_points_list), 2)
+    attention_weights = torch.rand(bs, len_q, n_head, sum(num_points_list))
+
+    default = deformable_attention_core_func_v2(
+        method="default",
+        value=value,
+        value_spatial_shapes=value_spatial_shapes,
+        sampling_locations=sampling_locations,
+        attention_weights=attention_weights,
+        num_points_list=num_points_list,
+    )
+    gather = deformable_attention_core_func_v2(
+        method="bilinear_gather",
+        value=value,
+        value_spatial_shapes=value_spatial_shapes,
+        sampling_locations=sampling_locations,
+        attention_weights=attention_weights,
+        num_points_list=num_points_list,
+    )
+
+    torch.testing.assert_close(gather, default, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
## What has changed and why?

This is PR 2 of a three-PR stack and is based on
`yutong-trn-2329-fix-onnx-verification`.

LT-DETR TensorRT engines could build and run successfully while silently producing
incorrect detections or segmentations because TensorRT compiled the deformable-attention
`GridSample` path incorrectly.

For ONNX export, the affected DFINE and RT-DETRv2 attention modules now replace native
`grid_sample` with equivalent gather-based bilinear interpolation built from simpler
operations such as `Pad`, `Gather`, multiplication, and addition. The resulting ONNX
graphs contain no `GridSample` nodes, so no opset-specific TensorRT parser workaround is
needed. Training and ordinary deployment retain the faster native `grid_sample` path.

The ONNX-only conversion is applied through an explicit runtime-checkable export
protocol. DINOv3 ViT-S/16 FP16 TensorRT export remains strongly typed independently of
the `GridSample` fix, preserving the graph's FP32 attention operations and preventing
FP16 overflow. Other model and precision combinations retain the existing weakly typed
path.

## How has it been tested?

Raw ONNX Runtime versus TensorRT results on the T4 with TensorRT 10.13.3.9:

- Object detection:
  - logits max/mean difference: `7.97e-4` / `1.46e-5`
  - boxes max/mean difference: `5.21e-5` / `3.58e-7`
- Instance segmentation:
  - labels: exact match
  - boxes max/mean difference: `1.05e-2` / `1.48e-4`
  - masks max/mean difference: `1.16e-3` / `2.95e-5`
  - scores max/mean difference: `6.87e-6` / `4.29e-7`

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [ ] Yes
- [x] Not needed (the exported model interface is unchanged)