### PR TITLE
Make dinov31 available again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add [C++ inference recipes](examples/cpp/README.md) for LT-DETR object detection,
   covering ONNX Runtime's CUDA execution provider and TensorRT directly, both with
   zero-copy GPU input/output allocation.
+- Restore the DINOv3.1 pretraining method now that its LightlySSL dependencies are
+  available from PyPI.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ DOCKER_EXTRAS := [mlflow,tensorboard,timm,wandb,rfdetr]
 
 # Date until which dependencies installed with --exclude-newer must have been released.
 # Dependencies released after this date are ignored.
-EXCLUDE_NEWER_DATE := "2026-07-18"
+EXCLUDE_NEWER_DATE := "2026-07-30"
 
 export LIGHTLY_TRAIN_EVENTS_DISABLED := "1"
 export LIGHTLY_TRAIN_POSTHOG_KEY := ""

--- a/docs/source/pretrain_distill/methods/dinov31.md
+++ b/docs/source/pretrain_distill/methods/dinov31.md
@@ -1,0 +1,62 @@
+(methods-dinov31)=
+
+# DINOv31
+
+DINOv31 post-trains ("continues") a DINOv2-pretrained backbone with the full DINOv2
+objective (DINO + iBOT + KoLeo) plus an auxiliary Patch Kernel Alignment (PaKA / CKA)
+loss that aligns the relational structure of student and teacher dense patch tokens,
+aimed at improving dense (patch-level) features for downstream segmentation and
+detection. See the [PaKA paper](https://arxiv.org/abs/2509.05606) for details.
+
+```{seealso}
+DINOv31 is a DINOv2 post-training method: start from a DINOv2 checkpoint
+(see {ref}`methods-dinov2`) and continue training with PaKA.
+```
+
+## Use DINOv31 in LightlyTrain
+
+````{tab} Python
+```python
+import lightly_train
+
+if __name__ == "__main__":
+    lightly_train.pretrain(
+        out="out/my_experiment",
+        data="my_data_dir",
+        model="dinov2/vits14",
+        method="dinov31",
+        checkpoint="dinov2_vits14.ckpt",  # full DINOv2 checkpoint (incl. optimizer); only model weights are loaded
+    )
+```
+````
+
+````{tab} Command Line
+```bash
+lightly-train pretrain \
+    out=out/my_experiment \
+    data=my_data_dir \
+    model="dinov2/vits14" \
+    method="dinov31" \
+    checkpoint="dinov2_vits14.ckpt"
+```
+````
+
+## Default Method Arguments
+
+The following are the default method arguments for DINOv31. To learn how you can
+override these settings, see {ref}`method-args`.
+
+````{dropdown} Default Method Arguments
+```{include} _auto/dinov31_method_args.md
+```
+````
+
+## Default Image Transform Arguments
+
+The following are the default transform arguments for DINOv31. To learn how you can
+override these settings, see {ref}`method-transform-args`.
+
+````{dropdown} Default Image Transforms
+```{include} _auto/dinov31_transform_args.md
+```
+````

--- a/docs/source/pretrain_distill/methods/index.md
+++ b/docs/source/pretrain_distill/methods/index.md
@@ -6,6 +6,7 @@ Lightly**Train** supports the following pretraining methods:
 
 - {ref}`methods-distillation`
 - {ref}`methods-dinov2`
+- {ref}`methods-dinov31`
 - {ref}`methods-dino`
 - {ref}`methods-simclr`
 
@@ -130,6 +131,7 @@ maxdepth: 1
 Overview <self>
 distillation
 dinov2
+dinov31
 dino
 simclr
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "eval-type-backport>=0.2",  # Required for Pydantic. Allows 3.10 types in old Python versions.
     "filelock>=3.0.0",     # Cross-platform file locking
     "fsspec>=2023.1.0",
-    "lightly>=1.5.20",
+    "lightly>=1.5.26",
     "matplotlib>=3.5",
     "omegaconf>=2.3",
     "psutil>=5.0",
@@ -240,9 +240,6 @@ convention = "google"
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) in root `__init__.py`.
 "src/lightly_train/__init__.py" = ["E402"]
-# DINOv31 tests skip before imports until the required Lightly release is on PyPI.
-"tests/_methods/dinov31/test_constrained_crop.py" = ["E402"]
-"tests/_methods/dinov31/test_dinov31.py" = ["E402"]
 
 [tool.uv]
 override-dependencies = [

--- a/src/lightly_train/_methods/method_helpers.py
+++ b/src/lightly_train/_methods/method_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from lightly_train._methods.densecl.densecl import DenseCL
 from lightly_train._methods.dino.dino import DINO
 from lightly_train._methods.dinov2.dinov2 import DINOv2
+from lightly_train._methods.dinov31.dinov31 import DINOv31
 from lightly_train._methods.distillation.distillation import Distillation
 from lightly_train._methods.distillationv2.distillationv2 import DistillationV2
 from lightly_train._methods.distillationv3.distillationv3 import DistillationV3
@@ -57,6 +58,7 @@ def _method_name_to_cls() -> dict[str, type[Method]]:
             DenseCL,
             DINO,
             DINOv2,
+            DINOv31,
             DistillationV2,
             DistillationV3,
             SimCLR,

--- a/tests/_methods/dinov31/test_constrained_crop.py
+++ b/tests/_methods/dinov31/test_constrained_crop.py
@@ -13,11 +13,6 @@ import numpy as np
 import pytest
 import torch
 
-pytest.skip(
-    "DINOv31 is disabled until its Lightly dependency is available on PyPI.",
-    allow_module_level=True,
-)
-
 from lightly_train._methods.dinov31.constrained_crop import (
     render_clean_global,
     sample_high_overlap_box,

--- a/tests/_methods/dinov31/test_dinov31.py
+++ b/tests/_methods/dinov31/test_dinov31.py
@@ -16,11 +16,6 @@ from pytest_mock import MockerFixture
 from torch import Size, Tensor
 from torch.nn import Module
 
-pytest.skip(
-    "DINOv31 is disabled until its Lightly dependency is available on PyPI.",
-    allow_module_level=True,
-)
-
 from lightly_train._methods.dinov2.dinov2 import DINOv2, DINOv2AdamWViTArgs, DINOv2Args
 from lightly_train._methods.dinov31.dinov31 import (
     DINOv31,

--- a/tests/_methods/test_method_helpers.py
+++ b/tests/_methods/test_method_helpers.py
@@ -13,6 +13,7 @@ from lightly_train._methods import method_helpers
 from lightly_train._methods.densecl.densecl import DenseCL
 from lightly_train._methods.dino.dino import DINO
 from lightly_train._methods.dinov2.dinov2 import DINOv2
+from lightly_train._methods.dinov31.dinov31 import DINOv31
 from lightly_train._methods.distillation.distillation import Distillation
 from lightly_train._methods.distillationv2.distillationv2 import DistillationV2
 from lightly_train._methods.distillationv3.distillationv3 import DistillationV3
@@ -29,6 +30,7 @@ from ..helpers import DummyCustomModel
         ("densecl", DenseCL),
         ("dino", DINO),
         ("dinov2", DINOv2),
+        ("dinov31", DINOv31),
         ("simclr", SimCLR),
         ("distillationv1", Distillation),
         ("distillationv2", DistillationV2),
@@ -45,6 +47,7 @@ def test_list_methods_private() -> None:
         "densecl",
         "dino",
         "dinov2",
+        "dinov31",
         "distillation",
         "distillationv1",
         "distillationv2",
@@ -57,14 +60,10 @@ def test_list_methods_public() -> None:
     assert method_helpers.list_methods() == [
         "dino",
         "dinov2",
+        "dinov31",
         "distillation",
         "distillationv1",
         "distillationv2",
         "distillationv3",
         "simclr",
     ]
-
-
-def test_get_method_cls_dinov31_is_unavailable() -> None:
-    with pytest.raises(ValueError, match="Method 'dinov31' is unknown"):
-        method_helpers.get_method_cls(method="dinov31")


### PR DESCRIPTION
## What has changed and why?
- adds DINOv31 to the docs again, after the temporary removal in #910 that broke the release of 0.16.3

## How has it been tested?
- existing unit tests activated again

## Did you update [CHANGELOG.md](../CHANGELOG.md)?

- [x] Yes
- [ ] Not needed (internal change)

## Did you update the documentation?

- [x] Yes
- [ ] Not needed (internal change without effects for user)
