### PR TITLE
Add activation checkpointing for ViT backbones

### DIFF
--- a/src/lightly_train/_activation_checkpointing.py
+++ b/src/lightly_train/_activation_checkpointing.py
@@ -24,6 +24,16 @@ class ActivationCheckpointingArgs(PydanticConfig):
     activations during the forward pass and recomputing them during the backward
     pass. This can significantly reduce peak GPU memory usage when pretraining
     large vision transformer backbones.
+
+    Attributes:
+        enabled:
+            Whether to enable activation checkpointing.
+        every_n_blocks:
+            Apply checkpointing every N blocks. 1 means all blocks are checkpointed.
+            Backbones with chunked blocks (DINOv2 with ``block_chunks > 0``, used by
+            ViT-L/14 and ViT-g/14) checkpoint whole chunks, so there ``every_n_blocks``
+            counts chunks and the effective granularity is
+            ``every_n_blocks * chunksize`` blocks.
     """
 
     enabled: bool = False
@@ -54,7 +64,7 @@ def maybe_checkpoint(
         **kwargs: Keyword arguments forwarded to ``block``.
     """
     if use_activation_checkpointing and block_index % every_n_blocks == 0:
-        return torch.utils.checkpoint.checkpoint(  # type: ignore[return-value]
+        return torch.utils.checkpoint.checkpoint(
             block, *args, use_reentrant=False, **kwargs
         )
     return block(*args, **kwargs)

--- a/src/lightly_train/_activation_checkpointing.py
+++ b/src/lightly_train/_activation_checkpointing.py
@@ -7,7 +7,7 @@
 #
 from __future__ import annotations
 
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, cast
 
 import torch
 from pydantic import Field
@@ -64,7 +64,10 @@ def maybe_checkpoint(
         **kwargs: Keyword arguments forwarded to ``block``.
     """
     if use_activation_checkpointing and block_index % every_n_blocks == 0:
-        return torch.utils.checkpoint.checkpoint(
-            block, *args, use_reentrant=False, **kwargs
+        return cast(
+            _T,
+            torch.utils.checkpoint.checkpoint(
+                block, *args, use_reentrant=False, **kwargs
+            ),
         )
     return block(*args, **kwargs)

--- a/src/lightly_train/_activation_checkpointing.py
+++ b/src/lightly_train/_activation_checkpointing.py
@@ -1,0 +1,60 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+import torch
+from pydantic import Field
+
+from lightly_train._configs.config import PydanticConfig
+
+_T = TypeVar("_T")
+
+
+class ActivationCheckpointingArgs(PydanticConfig):
+    """Configuration for activation checkpointing (gradient checkpointing).
+
+    Activation checkpointing trades compute for memory by discarding intermediate
+    activations during the forward pass and recomputing them during the backward
+    pass. This can significantly reduce peak GPU memory usage when pretraining
+    large vision transformer backbones.
+    """
+
+    enabled: bool = False
+    every_n_blocks: int = Field(default=1, ge=1)
+
+
+def maybe_checkpoint(
+    block: Callable[..., _T],
+    *args: Any,
+    use_activation_checkpointing: bool,
+    block_index: int,
+    every_n_blocks: int,
+    **kwargs: Any,
+) -> _T:
+    """Conditionally apply activation checkpointing to a block.
+
+    When checkpointing is enabled and the block index is a multiple of
+    ``every_n_blocks``, the block's forward pass is wrapped with
+    ``torch.utils.checkpoint.checkpoint``. Otherwise, the block is called
+    directly.
+
+    Args:
+        block: The module or callable to execute.
+        *args: Positional arguments forwarded to ``block``.
+        use_activation_checkpointing: Whether checkpointing is enabled.
+        block_index: Zero-based index of the current block.
+        every_n_blocks: Apply checkpointing every N blocks.
+        **kwargs: Keyword arguments forwarded to ``block``.
+    """
+    if use_activation_checkpointing and block_index % every_n_blocks == 0:
+        return torch.utils.checkpoint.checkpoint(  # type: ignore[return-value]
+            block, *args, use_reentrant=False, **kwargs
+        )
+    return block(*args, **kwargs)

--- a/src/lightly_train/_cli.py
+++ b/src/lightly_train/_cli.py
@@ -203,7 +203,7 @@ _PRETRAIN_HELP_MSG = f"""
             parameter. For example, if `model='torchvision/<model_name>'`, the
             arguments are passed to
             `torchvision.models.get_model(model_name, **model_args)`.
-        activation_checkpointing (dict):
+        activation_checkpoint_args (dict):
             Activation checkpointing configuration to reduce memory usage.
             Supported keys: `enabled` (bool), `every_n_blocks` (int).
             Only supported for ViT-based backbones (DINOv2, DINOv3, EdgeCrafter).

--- a/src/lightly_train/_cli.py
+++ b/src/lightly_train/_cli.py
@@ -203,6 +203,11 @@ _PRETRAIN_HELP_MSG = f"""
             parameter. For example, if `model='torchvision/<model_name>'`, the
             arguments are passed to
             `torchvision.models.get_model(model_name, **model_args)`.
+        activation_checkpointing (dict):
+            Activation checkpointing configuration to reduce memory usage.
+            Supported keys: `enabled` (bool), `every_n_blocks` (int).
+            Only supported for ViT-based backbones (DINOv2, DINOv3, EdgeCrafter).
+            Default: null
         resume (bool):
             Deprecated. Use `resume_interrupted` instead.
             Default: null

--- a/src/lightly_train/_cli.py
+++ b/src/lightly_train/_cli.py
@@ -207,6 +207,8 @@ _PRETRAIN_HELP_MSG = f"""
             Activation checkpointing configuration to reduce memory usage.
             Supported keys: `enabled` (bool), `every_n_blocks` (int).
             Only supported for ViT-based backbones (DINOv2, DINOv3, EdgeCrafter).
+            Backbones with chunked blocks (DINOv2 ViT-L/14 and ViT-g/14) checkpoint
+            whole chunks, so there `every_n_blocks` counts chunks instead of blocks.
             Default: null
         resume (bool):
             Deprecated. Use `resume_interrupted` instead.

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -80,7 +80,7 @@ def pretrain(
     loader_args: dict[str, Any] | None = None,
     trainer_args: dict[str, Any] | None = None,
     model_args: dict[str, Any] | None = None,
-    activation_checkpointing: dict[str, Any] | None = None,
+    activation_checkpoint_args: dict[str, Any] | None = None,
     resume: bool | None = None,  # Deprecated, use `resume_interrupted`` instead.
 ) -> None:
     """Pretrain a self-supervised model.
@@ -241,7 +241,7 @@ def pretrain(
             parameter. For example, if ``model='torchvision/<model_name>'``, the
             arguments are passed to
             ``torchvision.models.get_model(model_name, **model_args)``.
-        activation_checkpointing:
+        activation_checkpoint_args:
             Activation checkpointing configuration to reduce memory usage during
             training. Pass ``{"enabled": True}`` to enable checkpointing for all
             transformer blocks. Use ``{"enabled": True, "every_n_blocks": 2}``
@@ -284,7 +284,7 @@ def train(
     loader_args: dict[str, Any] | None = None,
     trainer_args: dict[str, Any] | None = None,
     model_args: dict[str, Any] | None = None,
-    activation_checkpointing: dict[str, Any] | None = None,
+    activation_checkpoint_args: dict[str, Any] | None = None,
     resume: bool | None = None,  # Deprecated, use `resume_interrupted`` instead.
 ) -> None:
     """Deprecated. Use :func:`pretrain` instead."""
@@ -378,14 +378,14 @@ def train_from_config(config: TrainConfig, called_via_train: bool = False) -> No
             dataset_size=dataset_size,
             epochs=config.epochs,
         )
+        ac_args = train_helpers.get_activation_checkpoint_args(
+            config.activation_checkpoint_args
+        )
         model_args = dict(config.model_args) if config.model_args else {}
-        if config.activation_checkpointing is not None:
-            ac_args = validate.pydantic_model_validate(
-                ActivationCheckpointingArgs, dict(config.activation_checkpointing)
-            )
-        else:
-            ac_args = ActivationCheckpointingArgs()
         if ac_args.enabled:
+            train_helpers.validate_activation_checkpointing_model(
+                model=config.model,
+            )
             model_args["activation_checkpointing"] = True
             model_args["activation_checkpointing_every_n_blocks"] = (
                 ac_args.every_n_blocks
@@ -585,7 +585,7 @@ class TrainConfig(PydanticConfig):
     loader_args: dict[str, Any] | None = None
     trainer_args: dict[str, Any] | None = None
     model_args: dict[str, Any] | None = None
-    activation_checkpointing: dict[str, Any] | ActivationCheckpointingArgs | None = None
+    activation_checkpoint_args: dict[str, Any] | ActivationCheckpointingArgs | None = None
     resume: bool | None = None  # Deprecated, use `resume_interrupted` instead.
 
     # Allow arbitrary field types such as Module, Dataset, Accelerator, ...
@@ -600,7 +600,7 @@ class FunctionTrainConfig(TrainConfig):
     optim: str = "auto"
     optim_args: dict[str, Any] | None = None
     transform_args: dict[str, Any] | None = None
-    activation_checkpointing: dict[str, Any] | None = None
+    activation_checkpoint_args: dict[str, Any] | None = None
 
 
 class CLITrainConfig(FunctionTrainConfig):

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -25,6 +25,7 @@ from pytorch_lightning.trainer.connectors.accelerator_connector import (  # type
 from torch.nn import Module
 
 from lightly_train import _float32_matmul_precision, _logging, _system
+from lightly_train._activation_checkpointing import ActivationCheckpointingArgs
 from lightly_train._callbacks import callback_helpers
 from lightly_train._callbacks.callback_args import CallbackArgs
 from lightly_train._commands import _warnings, common_helpers, train_helpers
@@ -79,6 +80,7 @@ def pretrain(
     loader_args: dict[str, Any] | None = None,
     trainer_args: dict[str, Any] | None = None,
     model_args: dict[str, Any] | None = None,
+    activation_checkpointing: dict[str, Any] | None = None,
     resume: bool | None = None,  # Deprecated, use `resume_interrupted`` instead.
 ) -> None:
     """Pretrain a self-supervised model.
@@ -239,6 +241,12 @@ def pretrain(
             parameter. For example, if ``model='torchvision/<model_name>'``, the
             arguments are passed to
             ``torchvision.models.get_model(model_name, **model_args)``.
+        activation_checkpointing:
+            Activation checkpointing configuration to reduce memory usage during
+            training. Pass ``{"enabled": True}`` to enable checkpointing for all
+            transformer blocks. Use ``{"enabled": True, "every_n_blocks": 2}``
+            to checkpoint every other block. Only supported for ViT-based
+            backbones (DINOv2, DINOv3, EdgeCrafter).
         resume:
             Deprecated. Use ``resume_interrupted`` instead.
     """
@@ -276,6 +284,7 @@ def train(
     loader_args: dict[str, Any] | None = None,
     trainer_args: dict[str, Any] | None = None,
     model_args: dict[str, Any] | None = None,
+    activation_checkpointing: dict[str, Any] | None = None,
     resume: bool | None = None,  # Deprecated, use `resume_interrupted`` instead.
 ) -> None:
     """Deprecated. Use :func:`pretrain` instead."""
@@ -369,9 +378,22 @@ def train_from_config(config: TrainConfig, called_via_train: bool = False) -> No
             dataset_size=dataset_size,
             epochs=config.epochs,
         )
+        model_args = dict(config.model_args) if config.model_args else {}
+        if config.activation_checkpointing is not None:
+            ac_args = validate.pydantic_model_validate(
+                ActivationCheckpointingArgs, dict(config.activation_checkpointing)
+            )
+        else:
+            ac_args = ActivationCheckpointingArgs()
+        if ac_args.enabled:
+            model_args["activation_checkpointing"] = True
+            model_args["activation_checkpointing_every_n_blocks"] = (
+                ac_args.every_n_blocks
+            )
+
         wrapped_model = package_helpers.get_wrapped_model(
             model=config.model,
-            model_args=config.model_args,
+            model_args=model_args or None,
             num_input_channels=no_auto(transform_instance.transform_args.num_channels),
         )
         embedding_model = train_helpers.get_embedding_model(
@@ -563,6 +585,7 @@ class TrainConfig(PydanticConfig):
     loader_args: dict[str, Any] | None = None
     trainer_args: dict[str, Any] | None = None
     model_args: dict[str, Any] | None = None
+    activation_checkpointing: dict[str, Any] | ActivationCheckpointingArgs | None = None
     resume: bool | None = None  # Deprecated, use `resume_interrupted` instead.
 
     # Allow arbitrary field types such as Module, Dataset, Accelerator, ...
@@ -577,6 +600,7 @@ class FunctionTrainConfig(TrainConfig):
     optim: str = "auto"
     optim_args: dict[str, Any] | None = None
     transform_args: dict[str, Any] | None = None
+    activation_checkpointing: dict[str, Any] | None = None
 
 
 class CLITrainConfig(FunctionTrainConfig):

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -378,24 +378,18 @@ def train_from_config(config: TrainConfig, called_via_train: bool = False) -> No
             dataset_size=dataset_size,
             epochs=config.epochs,
         )
+        wrapped_model = package_helpers.get_wrapped_model(
+            model=config.model,
+            model_args=config.model_args,
+            num_input_channels=no_auto(transform_instance.transform_args.num_channels),
+        )
         ac_args = train_helpers.get_activation_checkpoint_args(
             config.activation_checkpoint_args
         )
-        model_args = dict(config.model_args) if config.model_args else {}
         if ac_args.enabled:
-            train_helpers.validate_activation_checkpointing_model(
-                model=config.model,
+            train_helpers.set_activation_checkpointing(
+                wrapped_model=wrapped_model, args=ac_args
             )
-            model_args["activation_checkpointing"] = True
-            model_args["activation_checkpointing_every_n_blocks"] = (
-                ac_args.every_n_blocks
-            )
-
-        wrapped_model = package_helpers.get_wrapped_model(
-            model=config.model,
-            model_args=model_args or None,
-            num_input_channels=no_auto(transform_instance.transform_args.num_channels),
-        )
         embedding_model = train_helpers.get_embedding_model(
             wrapped_model=wrapped_model, embed_dim=config.embed_dim
         )
@@ -585,7 +579,9 @@ class TrainConfig(PydanticConfig):
     loader_args: dict[str, Any] | None = None
     trainer_args: dict[str, Any] | None = None
     model_args: dict[str, Any] | None = None
-    activation_checkpoint_args: dict[str, Any] | ActivationCheckpointingArgs | None = None
+    activation_checkpoint_args: dict[str, Any] | ActivationCheckpointingArgs | None = (
+        None
+    )
     resume: bool | None = None  # Deprecated, use `resume_interrupted` instead.
 
     # Allow arbitrary field types such as Module, Dataset, Accelerator, ...

--- a/src/lightly_train/_commands/train_helpers.py
+++ b/src/lightly_train/_commands/train_helpers.py
@@ -26,6 +26,7 @@ from pytorch_lightning.trainer.connectors.accelerator_connector import (  # type
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
 
+from lightly_train._activation_checkpointing import ActivationCheckpointingArgs
 from lightly_train._checkpoint import Checkpoint
 from lightly_train._configs import validate
 from lightly_train._env import Env
@@ -34,7 +35,10 @@ from lightly_train._methods.method import Method
 from lightly_train._methods.method_args import MethodArgs
 from lightly_train._models import package_helpers
 from lightly_train._models.embedding_model import EmbeddingModel
-from lightly_train._models.model_wrapper import ModelWrapper
+from lightly_train._models.model_wrapper import (
+    ModelWrapper,
+    SupportsActivationCheckpointing,
+)
 from lightly_train._optim import optimizer_helpers
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
@@ -499,3 +503,51 @@ def load_state_dict(
         ckpt.lightly_train.models.embedding_model.state_dict()
     )
     method.load_state_dict(ckpt.state_dict)
+
+
+def get_activation_checkpoint_args(
+    activation_checkpoint_args: dict[str, Any] | ActivationCheckpointingArgs | None,
+) -> ActivationCheckpointingArgs:
+    """Resolve activation checkpoint args from a dict or None to an
+    ``ActivationCheckpointingArgs`` instance."""
+    if activation_checkpoint_args is None:
+        return ActivationCheckpointingArgs()
+    if isinstance(activation_checkpoint_args, ActivationCheckpointingArgs):
+        return activation_checkpoint_args
+    return validate.pydantic_model_validate(
+        ActivationCheckpointingArgs, dict(activation_checkpoint_args)
+    )
+
+
+_ACTIVATION_CHECKPOINTING_SUPPORTED_PACKAGES = {"dinov2", "dinov3", "edgecrafter"}
+
+
+def validate_activation_checkpointing_model(
+    model: str | Module | ModelWrapper | Any,
+) -> None:
+    """Validate that the model supports activation checkpointing.
+
+    Must be called before ``get_wrapped_model`` so that unsupported kwargs
+    are never forwarded to a model constructor that would reject them.
+
+    Raises:
+        ValueError: If the model does not support activation checkpointing.
+    """
+    if isinstance(model, str):
+        package_name, _ = package_helpers.parse_model_name(model)
+        if package_name not in _ACTIVATION_CHECKPOINTING_SUPPORTED_PACKAGES:
+            raise ValueError(
+                f"Activation checkpointing is not supported by package "
+                f"'{package_name}'. Supported packages: "
+                f"{sorted(_ACTIVATION_CHECKPOINTING_SUPPORTED_PACKAGES)}."
+            )
+        return
+    if isinstance(model, (ModelWrapper, Module)):
+        underlying = model.get_model() if isinstance(model, ModelWrapper) else model
+        if not isinstance(underlying, SupportsActivationCheckpointing):
+            raise ValueError(
+                f"Activation checkpointing is not supported by model "
+                f"'{type(underlying).__name__}'. Only ViT-based backbones "
+                f"(DINOv2, DINOv3, EdgeCrafter) support activation "
+                f"checkpointing."
+            )

--- a/src/lightly_train/_commands/train_helpers.py
+++ b/src/lightly_train/_commands/train_helpers.py
@@ -519,35 +519,20 @@ def get_activation_checkpoint_args(
     )
 
 
-_ACTIVATION_CHECKPOINTING_SUPPORTED_PACKAGES = {"dinov2", "dinov3", "edgecrafter"}
-
-
-def validate_activation_checkpointing_model(
-    model: str | Module | ModelWrapper | Any,
+def set_activation_checkpointing(
+    wrapped_model: ModelWrapper, args: ActivationCheckpointingArgs
 ) -> None:
-    """Validate that the model supports activation checkpointing.
-
-    Must be called before ``get_wrapped_model`` so that unsupported kwargs
-    are never forwarded to a model constructor that would reject them.
+    """Enable activation checkpointing on an already instantiated model wrapper.
 
     Raises:
-        ValueError: If the model does not support activation checkpointing.
+        ValueError: If the model wrapper does not support activation checkpointing.
     """
-    if isinstance(model, str):
-        package_name, _ = package_helpers.parse_model_name(model)
-        if package_name not in _ACTIVATION_CHECKPOINTING_SUPPORTED_PACKAGES:
-            raise ValueError(
-                f"Activation checkpointing is not supported by package "
-                f"'{package_name}'. Supported packages: "
-                f"{sorted(_ACTIVATION_CHECKPOINTING_SUPPORTED_PACKAGES)}."
-            )
-        return
-    if isinstance(model, (ModelWrapper, Module)):
-        underlying = model.get_model() if isinstance(model, ModelWrapper) else model
-        if not isinstance(underlying, SupportsActivationCheckpointing):
-            raise ValueError(
-                f"Activation checkpointing is not supported by model "
-                f"'{type(underlying).__name__}'. Only ViT-based backbones "
-                f"(DINOv2, DINOv3, EdgeCrafter) support activation "
-                f"checkpointing."
-            )
+    if not isinstance(wrapped_model, SupportsActivationCheckpointing):
+        raise ValueError(
+            f"Activation checkpointing is not supported by model "
+            f"'{type(wrapped_model).__name__}'. Only ViT-based backbones "
+            f"(DINOv2, DINOv3, EdgeCrafter) support activation checkpointing."
+        )
+    wrapped_model.set_activation_checkpointing(
+        enabled=True, every_n_blocks=args.every_n_blocks
+    )

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit.py
@@ -24,10 +24,16 @@ from lightly_train._models.model_wrapper import (
     ForwardFeaturesOutput,
     ForwardPoolOutput,
     MultiScaleFeatureViT,
+    SupportsActivationCheckpointing,
 )
 
 
-class DINOv2ViTModelWrapper(Module, MultiScaleFeatureViT, ArchitectureInfoGettable):
+class DINOv2ViTModelWrapper(
+    Module,
+    MultiScaleFeatureViT,
+    ArchitectureInfoGettable,
+    SupportsActivationCheckpointing,
+):
     _input_mean: Tensor
     _input_std: Tensor
 
@@ -45,6 +51,12 @@ class DINOv2ViTModelWrapper(Module, MultiScaleFeatureViT, ArchitectureInfoGettab
             torch.tensor(IMAGENET_NORMALIZE["std"]).view(1, -1, 1, 1),
             persistent=False,
         )
+
+    def set_activation_checkpointing(
+        self, enabled: bool, every_n_blocks: int = 1
+    ) -> None:
+        self._model._activation_checkpointing = enabled
+        self._model._activation_checkpointing_every_n_blocks = every_n_blocks
 
     def feature_dim(self) -> int:
         return self._feature_dim

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
@@ -68,9 +68,23 @@ def named_apply(
 
 
 class BlockChunk(nn.ModuleList):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._activation_checkpointing = False
+        self._activation_checkpointing_every_n_blocks = 1
+
     def forward(self, x):
-        for b in self:
-            x = b(x)
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
+        for i, b in enumerate(self):
+            x = maybe_checkpoint(
+                b,
+                x,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
         return x
 
 
@@ -99,6 +113,8 @@ class DinoVisionTransformer(nn.Module):
         interpolate_antialias=False,
         interpolate_offset=0.1,
         input_normalization: Literal["imagenet", "none"] = "imagenet",
+        activation_checkpointing: bool = False,
+        activation_checkpointing_every_n_blocks: int = 1,
     ):
         """
         Args:
@@ -126,6 +142,10 @@ class DinoVisionTransformer(nn.Module):
             interpolate_offset: (float) work-around offset to apply when interpolating positional embeddings
             input_normalization: Expected input normalization. ``"none"`` expects
                 RGB values in the [0, 1] range.
+            activation_checkpointing: Enable activation checkpointing to reduce
+                memory usage at the cost of additional compute.
+            activation_checkpointing_every_n_blocks: Apply checkpointing every
+                N blocks. 1 means all blocks are checkpointed.
         """
         check_xformers()
         super().__init__()
@@ -202,6 +222,11 @@ class DinoVisionTransformer(nn.Module):
             )
             for i in range(depth)
         ]
+        self._activation_checkpointing = activation_checkpointing
+        self._activation_checkpointing_every_n_blocks = (
+            activation_checkpointing_every_n_blocks
+        )
+
         if block_chunks > 0:
             self.chunked_blocks = True
             chunked_blocks = []
@@ -212,6 +237,11 @@ class DinoVisionTransformer(nn.Module):
                     [nn.Identity()] * i + blocks_list[i : i + chunksize]
                 )
             self.blocks = nn.ModuleList([BlockChunk(p) for p in chunked_blocks])
+            for chunk in self.blocks:
+                chunk._activation_checkpointing = activation_checkpointing
+                chunk._activation_checkpointing_every_n_blocks = (
+                    activation_checkpointing_every_n_blocks
+                )
         else:
             self.chunked_blocks = False
             self.blocks = nn.ModuleList(blocks_list)
@@ -319,12 +349,21 @@ class DinoVisionTransformer(nn.Module):
         return x
 
     def forward_features_list(self, x_list, masks_list):
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
         x = [
             self.prepare_tokens_with_masks(x, masks)
             for x, masks in zip(x_list, masks_list)
         ]
-        for blk in self.blocks:
-            x = blk(x)
+        for i, blk in enumerate(self.blocks):
+            x = maybe_checkpoint(
+                blk,
+                x,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
 
         all_x = x
         output = []
@@ -342,13 +381,22 @@ class DinoVisionTransformer(nn.Module):
         return output
 
     def forward_features(self, x, masks=None):
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
         if isinstance(x, list):
             return self.forward_features_list(x, masks)
 
         x = self.prepare_tokens_with_masks(x, masks)
 
-        for blk in self.blocks:
-            x = blk(x)
+        for i, blk in enumerate(self.blocks):
+            x = maybe_checkpoint(
+                blk,
+                x,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
 
         x_norm = self.norm(x)
         return {
@@ -360,6 +408,8 @@ class DinoVisionTransformer(nn.Module):
         }
 
     def _get_intermediate_layers_not_chunked(self, x, n=1):
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
         x = self.prepare_tokens_with_masks(x)
         # If n is an int, take the n last blocks. If it's a list, take them
         output, total_block_len = [], len(self.blocks)
@@ -367,7 +417,14 @@ class DinoVisionTransformer(nn.Module):
             range(total_block_len - n, total_block_len) if isinstance(n, int) else n
         )
         for i, blk in enumerate(self.blocks):
-            x = blk(x)
+            x = maybe_checkpoint(
+                blk,
+                x,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
             if i in blocks_to_take:
                 output.append(x)
         assert len(output) == len(blocks_to_take), (
@@ -376,6 +433,8 @@ class DinoVisionTransformer(nn.Module):
         return output
 
     def _get_intermediate_layers_chunked(self, x, n=1):
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
         x = self.prepare_tokens_with_masks(x)
         output, i, total_block_len = [], 0, len(self.blocks[-1])
         # If n is an int, take the n last blocks. If it's a list, take them
@@ -384,7 +443,14 @@ class DinoVisionTransformer(nn.Module):
         )
         for block_chunk in self.blocks:
             for blk in block_chunk[i:]:  # Passing the nn.Identity()
-                x = blk(x)
+                x = maybe_checkpoint(
+                    blk,
+                    x,
+                    use_activation_checkpointing=self._activation_checkpointing
+                    and self.training,
+                    block_index=i,
+                    every_n_blocks=self._activation_checkpointing_every_n_blocks,
+                )
                 if i in blocks_to_take:
                     output.append(x)
                 i += 1

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
@@ -69,21 +69,14 @@ def named_apply(
 
 
 class BlockChunk(nn.ModuleList):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._activation_checkpointing = False
-        self._activation_checkpointing_every_n_blocks = 1
-
+    # Activation checkpointing is applied by the caller iterating over
+    # DinoVisionTransformer.blocks, which wraps each chunk as a whole. Checkpointing
+    # again here would nest inside that region and recompute every block twice.
+    # Consequence: on this path every_n_blocks counts chunks, not blocks, so the
+    # effective granularity is every_n_blocks * chunksize blocks.
     def forward(self, x):
-        for i, b in enumerate(self):
-            x = maybe_checkpoint(
-                b,
-                x,
-                use_activation_checkpointing=self._activation_checkpointing
-                and self.training,
-                block_index=i,
-                every_n_blocks=self._activation_checkpointing_every_n_blocks,
-            )
+        for b in self:
+            x = b(x)
         return x
 
 
@@ -112,8 +105,6 @@ class DinoVisionTransformer(nn.Module):
         interpolate_antialias=False,
         interpolate_offset=0.1,
         input_normalization: Literal["imagenet", "none"] = "imagenet",
-        activation_checkpointing: bool = False,
-        activation_checkpointing_every_n_blocks: int = 1,
     ):
         """
         Args:
@@ -141,10 +132,6 @@ class DinoVisionTransformer(nn.Module):
             interpolate_offset: (float) work-around offset to apply when interpolating positional embeddings
             input_normalization: Expected input normalization. ``"none"`` expects
                 RGB values in the [0, 1] range.
-            activation_checkpointing: Enable activation checkpointing to reduce
-                memory usage at the cost of additional compute.
-            activation_checkpointing_every_n_blocks: Apply checkpointing every
-                N blocks. 1 means all blocks are checkpointed.
         """
         check_xformers()
         super().__init__()
@@ -221,10 +208,9 @@ class DinoVisionTransformer(nn.Module):
             )
             for i in range(depth)
         ]
-        self._activation_checkpointing = activation_checkpointing
-        self._activation_checkpointing_every_n_blocks = (
-            activation_checkpointing_every_n_blocks
-        )
+        # Configured post-instantiation via DINOv2ViTModelWrapper.
+        self._activation_checkpointing = False
+        self._activation_checkpointing_every_n_blocks = 1
 
         if block_chunks > 0:
             self.chunked_blocks = True
@@ -236,11 +222,6 @@ class DinoVisionTransformer(nn.Module):
                     [nn.Identity()] * i + blocks_list[i : i + chunksize]
                 )
             self.blocks = nn.ModuleList([BlockChunk(p) for p in chunked_blocks])
-            for chunk in self.blocks:
-                chunk._activation_checkpointing = activation_checkpointing
-                chunk._activation_checkpointing_every_n_blocks = (
-                    activation_checkpointing_every_n_blocks
-                )
         else:
             self.chunked_blocks = False
             self.blocks = nn.ModuleList(blocks_list)

--- a/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov2_vit/dinov2_vit_src/models/vision_transformer.py
@@ -25,6 +25,7 @@ from lightning_utilities.core.imports import RequirementCache
 from torch.nn.init import trunc_normal_
 
 from lightly_train import _torch_helpers
+from lightly_train._activation_checkpointing import maybe_checkpoint
 from lightly_train._export.onnx_helpers import is_in_precalculate_for_onnx_export
 from lightly_train._models import _model_helpers
 from lightly_train._models.dinov2_vit.dinov2_vit_src.layers import (
@@ -74,8 +75,6 @@ class BlockChunk(nn.ModuleList):
         self._activation_checkpointing_every_n_blocks = 1
 
     def forward(self, x):
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         for i, b in enumerate(self):
             x = maybe_checkpoint(
                 b,
@@ -349,8 +348,6 @@ class DinoVisionTransformer(nn.Module):
         return x
 
     def forward_features_list(self, x_list, masks_list):
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         x = [
             self.prepare_tokens_with_masks(x, masks)
             for x, masks in zip(x_list, masks_list)
@@ -381,8 +378,6 @@ class DinoVisionTransformer(nn.Module):
         return output
 
     def forward_features(self, x, masks=None):
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         if isinstance(x, list):
             return self.forward_features_list(x, masks)
 
@@ -408,8 +403,6 @@ class DinoVisionTransformer(nn.Module):
         }
 
     def _get_intermediate_layers_not_chunked(self, x, n=1):
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         x = self.prepare_tokens_with_masks(x)
         # If n is an int, take the n last blocks. If it's a list, take them
         output, total_block_len = [], len(self.blocks)
@@ -433,8 +426,6 @@ class DinoVisionTransformer(nn.Module):
         return output
 
     def _get_intermediate_layers_chunked(self, x, n=1):
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         x = self.prepare_tokens_with_masks(x)
         output, i, total_block_len = [], 0, len(self.blocks[-1])
         # If n is an int, take the n last blocks. If it's a list, take them

--- a/src/lightly_train/_models/dinov3/dinov3_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov3/dinov3_src/models/vision_transformer.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn.init
 from torch import Tensor, nn
 
+from lightly_train._activation_checkpointing import maybe_checkpoint
 from lightly_train._models.dinov3.dinov3_src.layers import (
     LayerScale,
     Mlp,
@@ -268,8 +269,6 @@ class DinoVisionTransformer(nn.Module):
             t2_x, hw_tuple = self.prepare_tokens_with_masks(t_x, t_masks)
             x.append(t2_x)
             rope.append(hw_tuple)
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         for i, blk in enumerate(self.blocks):
             if self.rope_embed is not None:
                 rope_sincos = [self.rope_embed(H=H, W=W) for H, W in rope]
@@ -331,8 +330,6 @@ class DinoVisionTransformer(nn.Module):
         blocks_to_take = (
             range(total_block_len - n, total_block_len) if isinstance(n, int) else n
         )
-        from lightly_train._activation_checkpointing import maybe_checkpoint
-
         for i, blk in enumerate(self.blocks):
             if self.rope_embed is not None:
                 rope_sincos = self.rope_embed(H=H, W=W)

--- a/src/lightly_train/_models/dinov3/dinov3_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov3/dinov3_src/models/vision_transformer.py
@@ -103,8 +103,6 @@ class DinoVisionTransformer(nn.Module):
         untie_cls_and_patch_norms: bool = False,
         untie_global_and_local_cls_norm: bool = False,
         device: Any | None = None,
-        activation_checkpointing: bool = False,
-        activation_checkpointing_every_n_blocks: int = 1,
         **ignored_kwargs,
     ):
         super().__init__()
@@ -191,10 +189,9 @@ class DinoVisionTransformer(nn.Module):
         self.chunked_blocks = False
         self.blocks = nn.ModuleList(blocks_list)
 
-        self._activation_checkpointing = activation_checkpointing
-        self._activation_checkpointing_every_n_blocks = (
-            activation_checkpointing_every_n_blocks
-        )
+        # Configured post-instantiation via DINOv3ViTModelWrapper.
+        self._activation_checkpointing = False
+        self._activation_checkpointing_every_n_blocks = 1
 
         # This norm is applied to everything, or when untying, to patch and mask tokens.
         self.norm = norm_layer_cls(embed_dim)

--- a/src/lightly_train/_models/dinov3/dinov3_src/models/vision_transformer.py
+++ b/src/lightly_train/_models/dinov3/dinov3_src/models/vision_transformer.py
@@ -102,6 +102,8 @@ class DinoVisionTransformer(nn.Module):
         untie_cls_and_patch_norms: bool = False,
         untie_global_and_local_cls_norm: bool = False,
         device: Any | None = None,
+        activation_checkpointing: bool = False,
+        activation_checkpointing_every_n_blocks: int = 1,
         **ignored_kwargs,
     ):
         super().__init__()
@@ -188,6 +190,11 @@ class DinoVisionTransformer(nn.Module):
         self.chunked_blocks = False
         self.blocks = nn.ModuleList(blocks_list)
 
+        self._activation_checkpointing = activation_checkpointing
+        self._activation_checkpointing_every_n_blocks = (
+            activation_checkpointing_every_n_blocks
+        )
+
         # This norm is applied to everything, or when untying, to patch and mask tokens.
         self.norm = norm_layer_cls(embed_dim)
 
@@ -261,12 +268,22 @@ class DinoVisionTransformer(nn.Module):
             t2_x, hw_tuple = self.prepare_tokens_with_masks(t_x, t_masks)
             x.append(t2_x)
             rope.append(hw_tuple)
-        for _, blk in enumerate(self.blocks):
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
+        for i, blk in enumerate(self.blocks):
             if self.rope_embed is not None:
                 rope_sincos = [self.rope_embed(H=H, W=W) for H, W in rope]
             else:
                 rope_sincos = [None for r in rope]
-            x = blk(x, rope_sincos)
+            x = maybe_checkpoint(
+                blk,
+                x,
+                rope_sincos,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
         all_x = x
         output = []
         for idx, (x, masks) in enumerate(zip(all_x, masks_list)):
@@ -314,12 +331,22 @@ class DinoVisionTransformer(nn.Module):
         blocks_to_take = (
             range(total_block_len - n, total_block_len) if isinstance(n, int) else n
         )
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
         for i, blk in enumerate(self.blocks):
             if self.rope_embed is not None:
                 rope_sincos = self.rope_embed(H=H, W=W)
             else:
                 rope_sincos = None
-            x = blk(x, rope_sincos)
+            x = maybe_checkpoint(
+                blk,
+                x,
+                rope_sincos,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
             if i in blocks_to_take:
                 output.append(x)
         assert len(output) == len(blocks_to_take), (

--- a/src/lightly_train/_models/dinov3/dinov3_vit.py
+++ b/src/lightly_train/_models/dinov3/dinov3_vit.py
@@ -25,14 +25,26 @@ from lightly_train._models.model_wrapper import (
     ForwardFeaturesOutput,
     ForwardPoolOutput,
     MultiScaleFeatureViT,
+    SupportsActivationCheckpointing,
 )
 
 
-class DINOv3ViTModelWrapper(Module, MultiScaleFeatureViT, ArchitectureInfoGettable):
+class DINOv3ViTModelWrapper(
+    Module,
+    MultiScaleFeatureViT,
+    ArchitectureInfoGettable,
+    SupportsActivationCheckpointing,
+):
     def __init__(self, model: DinoVisionTransformer) -> None:
         super().__init__()
         self._model = model
         self._feature_dim = int(self._model.embed_dim)
+
+    def set_activation_checkpointing(
+        self, enabled: bool, every_n_blocks: int = 1
+    ) -> None:
+        self._model._activation_checkpointing = enabled
+        self._model._activation_checkpointing_every_n_blocks = every_n_blocks
 
     def feature_dim(self) -> int:
         return self._feature_dim

--- a/src/lightly_train/_models/ecvit/ecvit.py
+++ b/src/lightly_train/_models/ecvit/ecvit.py
@@ -45,6 +45,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from typing_extensions import Self
 
+from lightly_train._activation_checkpointing import maybe_checkpoint
 from lightly_train._models.dinov3.dinov3_src.layers.ffn_layers import Mlp
 from lightly_train._models.dinov3.dinov3_src.layers.rope_position_encoding import (
     RopePositionEmbedding,
@@ -418,8 +419,6 @@ class VisionTransformer(nn.Module):
         sin = sin.to(device=x_embed.device, dtype=x_embed.dtype)
         cos = cos.to(device=x_embed.device, dtype=x_embed.dtype)
         rope_sincos = sin.unsqueeze(0).unsqueeze(0), cos.unsqueeze(0).unsqueeze(0)
-
-        from lightly_train._activation_checkpointing import maybe_checkpoint
 
         for i, blk in enumerate(self.blocks):
             x = maybe_checkpoint(

--- a/src/lightly_train/_models/ecvit/ecvit.py
+++ b/src/lightly_train/_models/ecvit/ecvit.py
@@ -56,6 +56,7 @@ from lightly_train._models.model_wrapper import (
     ForwardFeaturesOutput,
     ForwardPoolOutput,
     ModelWrapper,
+    SupportsActivationCheckpointing,
 )
 from lightly_train._task_models.object_detection_components.hybrid_encoder import (
     ConvNormLayer,
@@ -330,8 +331,6 @@ class VisionTransformer(nn.Module):
         norm_layer: type[nn.Module] | partial[Any] | None = None,
         act_layer: type[nn.Module] | None = None,
         ffn_layer: type[nn.Module] = Mlp,
-        activation_checkpointing: bool = False,
-        activation_checkpointing_every_n_blocks: int = 1,
     ) -> None:
         super().__init__()
         self.num_features = self.embed_dim = embed_dim
@@ -375,10 +374,9 @@ class VisionTransformer(nn.Module):
             ]
         )
 
-        self._activation_checkpointing = activation_checkpointing
-        self._activation_checkpointing_every_n_blocks = (
-            activation_checkpointing_every_n_blocks
-        )
+        # Configured post-instantiation via ECViTModelWrapper.
+        self._activation_checkpointing = False
+        self._activation_checkpointing_every_n_blocks = 1
 
         self.rope_embed = RopePositionEmbedding(
             embed_dim=embed_dim,
@@ -439,7 +437,12 @@ class VisionTransformer(nn.Module):
         return outs
 
 
-class ECViTModelWrapper(nn.Module, ModelWrapper, ArchitectureInfoGettable):
+class ECViTModelWrapper(
+    nn.Module,
+    ModelWrapper,
+    ArchitectureInfoGettable,
+    SupportsActivationCheckpointing,
+):
     """EdgeCrafter ECViT backbone wrapper for LTDETR-style feature pyramids.
 
     The forward path intentionally follows EdgeCrafter's ECViT adapter:
@@ -542,6 +545,13 @@ class ECViTModelWrapper(nn.Module, ModelWrapper, ArchitectureInfoGettable):
     @property
     def backbone_model(self) -> nn.Module:
         return self.backbone
+
+    def set_activation_checkpointing(
+        self, enabled: bool, every_n_blocks: int = 1
+    ) -> None:
+        # Target the backbone directly: get_model() returns the wrapper itself.
+        self.backbone._activation_checkpointing = enabled
+        self.backbone._activation_checkpointing_every_n_blocks = every_n_blocks
 
     def _load_backbone_weights(self, weights_path: PathLike) -> None:
         state = _load_torch_checkpoint(Path(weights_path))

--- a/src/lightly_train/_models/ecvit/ecvit.py
+++ b/src/lightly_train/_models/ecvit/ecvit.py
@@ -329,6 +329,8 @@ class VisionTransformer(nn.Module):
         norm_layer: type[nn.Module] | partial[Any] | None = None,
         act_layer: type[nn.Module] | None = None,
         ffn_layer: type[nn.Module] = Mlp,
+        activation_checkpointing: bool = False,
+        activation_checkpointing_every_n_blocks: int = 1,
     ) -> None:
         super().__init__()
         self.num_features = self.embed_dim = embed_dim
@@ -372,6 +374,11 @@ class VisionTransformer(nn.Module):
             ]
         )
 
+        self._activation_checkpointing = activation_checkpointing
+        self._activation_checkpointing_every_n_blocks = (
+            activation_checkpointing_every_n_blocks
+        )
+
         self.rope_embed = RopePositionEmbedding(
             embed_dim=embed_dim,
             num_heads=num_heads,
@@ -412,8 +419,18 @@ class VisionTransformer(nn.Module):
         cos = cos.to(device=x_embed.device, dtype=x_embed.dtype)
         rope_sincos = sin.unsqueeze(0).unsqueeze(0), cos.unsqueeze(0).unsqueeze(0)
 
+        from lightly_train._activation_checkpointing import maybe_checkpoint
+
         for i, blk in enumerate(self.blocks):
-            x = blk(x, rope_sincos=rope_sincos)
+            x = maybe_checkpoint(
+                blk,
+                x,
+                rope_sincos=rope_sincos,
+                use_activation_checkpointing=self._activation_checkpointing
+                and self.training,
+                block_index=i,
+                every_n_blocks=self._activation_checkpointing_every_n_blocks,
+            )
             if i in self.return_layers:
                 outs.append(x[:, 1:])
         return outs, (H, W)

--- a/src/lightly_train/_models/model_wrapper.py
+++ b/src/lightly_train/_models/model_wrapper.py
@@ -228,12 +228,22 @@ class MultiScaleFeatureCNN(
 
 @runtime_checkable
 class SupportsActivationCheckpointing(Protocol):
-    """Protocol for model wrappers whose underlying model accepts
-    ``activation_checkpointing`` and ``activation_checkpointing_every_n_blocks``
-    constructor kwargs."""
+    """Protocol for model wrappers whose blocks can run with activation checkpointing."""
 
-    _activation_checkpointing: bool
-    _activation_checkpointing_every_n_blocks: int
+    def set_activation_checkpointing(
+        self, enabled: bool, every_n_blocks: int = 1
+    ) -> None:
+        """Enables or disables activation checkpointing on the wrapped model's blocks.
+
+        Args:
+            enabled:
+                Whether to checkpoint the model's blocks.
+            every_n_blocks:
+                Apply checkpointing every N blocks. 1 means all blocks are
+                checkpointed. See ``ActivationCheckpointingArgs.every_n_blocks`` for
+                how this interacts with chunked blocks.
+        """
+        ...
 
 
 def missing_model_wrapper_attrs(

--- a/src/lightly_train/_models/model_wrapper.py
+++ b/src/lightly_train/_models/model_wrapper.py
@@ -226,6 +226,16 @@ class MultiScaleFeatureCNN(
     """Protocol for CNN models with multiscale feature extraction."""
 
 
+@runtime_checkable
+class SupportsActivationCheckpointing(Protocol):
+    """Protocol for model wrappers whose underlying model accepts
+    ``activation_checkpointing`` and ``activation_checkpointing_every_n_blocks``
+    constructor kwargs."""
+
+    _activation_checkpointing: bool
+    _activation_checkpointing_every_n_blocks: int
+
+
 def missing_model_wrapper_attrs(
     model_wrapper: Any, exclude_module_attrs: bool = False
 ) -> list[str]:

--- a/tests/_commands/test_train.py
+++ b/tests/_commands/test_train.py
@@ -533,7 +533,7 @@ def test_pretrain__log_resolved_config(
             "Resolved configuration:\n"
             "{\n"
             '    "accelerator": "CPUAccelerator",\n'
-            '    "activation_checkpointing": null,\n'
+            '    "activation_checkpoint_args": null,\n'
             '    "batch_size": 4,\n'
         )
         assert expected in caplog.text

--- a/tests/_commands/test_train.py
+++ b/tests/_commands/test_train.py
@@ -533,6 +533,7 @@ def test_pretrain__log_resolved_config(
             "Resolved configuration:\n"
             "{\n"
             '    "accelerator": "CPUAccelerator",\n'
+            '    "activation_checkpointing": null,\n'
             '    "batch_size": 4,\n'
         )
         assert expected in caplog.text

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import cast
+from typing import Protocol, cast
 
 import pytest
 import torch
@@ -21,6 +21,29 @@ from lightly_train._activation_checkpointing import (
 )
 from lightly_train._models.model_wrapper import SupportsActivationCheckpointing
 from tests import helpers
+
+
+class ActivationCheckpointable(Protocol):
+    """Bare model interface needed by the checkpointing test helper."""
+
+    _activation_checkpointing: bool
+    _activation_checkpointing_every_n_blocks: int
+
+
+class DinoForwardFeatures(Protocol):
+    """Typed subset of the vendor DINO forward-features interface used in tests."""
+
+    def forward_features(self, x: torch.Tensor) -> dict[str, torch.Tensor]: ...
+
+
+class DinoV3ForwardFeatures(DinoForwardFeatures, Protocol):
+    """DINOv3-specific list-input variant of forward-features."""
+
+    def forward_features_list(
+        self,
+        x_list: list[torch.Tensor],
+        masks_list: list[torch.Tensor | None],
+    ) -> list[dict[str, torch.Tensor]]: ...
 
 
 class CountingBlock(nn.Module):
@@ -40,10 +63,12 @@ class CountingBlock(nn.Module):
         return cast(torch.Tensor, self.linear(x))
 
 
-def enable_checkpointing(model: nn.Module, every_n_blocks: int = 1) -> None:
+def enable_checkpointing(
+    model: ActivationCheckpointable, every_n_blocks: int = 1
+) -> None:
     """Configure a bare ViT the way its model wrapper would."""
-    model._activation_checkpointing = True  # type: ignore[assignment]
-    model._activation_checkpointing_every_n_blocks = every_n_blocks  # type: ignore[assignment]
+    model._activation_checkpointing = True
+    model._activation_checkpointing_every_n_blocks = every_n_blocks
 
 
 class TestActivationCheckpointingArgs:
@@ -63,7 +88,9 @@ class TestActivationCheckpointingArgs:
 
     def test_extra_fields_rejected(self) -> None:
         with pytest.raises(ValueError):
-            ActivationCheckpointingArgs(enabled=True, unknown_field=42)
+            ActivationCheckpointingArgs.model_validate(
+                {"enabled": True, "unknown_field": 42}
+            )
 
 
 class TestMaybeCheckpoint:
@@ -130,7 +157,7 @@ class TestMaybeCheckpoint:
                 self.linear = nn.Linear(16, 16)
 
             def forward(self, x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
-                return self.linear(x) * scale
+                return cast(torch.Tensor, self.linear(x)) * scale
 
         block = BlockWithKwargs()
         x = torch.randn(2, 16, requires_grad=True)
@@ -152,6 +179,7 @@ class TestMaybeCheckpoint:
 
         y_ref = linear(x)
         y_ref.sum().backward()
+        assert x.grad is not None
         grad_ref = x.grad.clone()
 
         x.grad = None
@@ -163,6 +191,7 @@ class TestMaybeCheckpoint:
             every_n_blocks=1,
         )
         y_ckpt.sum().backward()
+        assert x.grad is not None
 
         assert torch.allclose(y_ref, y_ckpt)
         assert torch.allclose(grad_ref, x.grad)
@@ -185,9 +214,9 @@ class TestDINOv2ViTActivationCheckpointing:
         enable_checkpointing(model)
         model.train()
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
-        out = model.forward_features(x)
+        out = cast(DinoForwardFeatures, model).forward_features(x)
         loss = out["x_norm_clstoken"].sum()
-        loss.backward()
+        torch.autograd.backward(loss)
         assert x.grad is not None
 
     def test_numerical_equivalence(self) -> None:
@@ -195,26 +224,32 @@ class TestDINOv2ViTActivationCheckpointing:
             DinoVisionTransformer,
         )
 
-        vit_kwargs = {
-            "img_size": 56,
-            "patch_size": 14,
-            "embed_dim": 64,
-            "depth": 4,
-            "num_heads": 4,
-            "mlp_ratio": 2.0,
-        }
         torch.manual_seed(0)
-        model_ref = DinoVisionTransformer(**vit_kwargs)
+        model_ref = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            mlp_ratio=2.0,
+        )
         torch.manual_seed(0)
-        model_ckpt = DinoVisionTransformer(**vit_kwargs)
+        model_ckpt = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            mlp_ratio=2.0,
+        )
         enable_checkpointing(model_ckpt)
         model_ckpt.load_state_dict(model_ref.state_dict())
         model_ref.train()
         model_ckpt.train()
 
         x = torch.randn(2, 3, 56, 56)
-        out_ref = model_ref.forward_features(x)
-        out_ckpt = model_ckpt.forward_features(x)
+        out_ref = cast(DinoForwardFeatures, model_ref).forward_features(x)
+        out_ckpt = cast(DinoForwardFeatures, model_ckpt).forward_features(x)
 
         assert torch.allclose(
             out_ref["x_norm_clstoken"], out_ckpt["x_norm_clstoken"], atol=1e-5
@@ -236,8 +271,8 @@ class TestDINOv2ViTActivationCheckpointing:
         enable_checkpointing(model, every_n_blocks=2)
         model.train()
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
-        out = model.forward_features(x)
-        out["x_norm_clstoken"].sum().backward()
+        out = cast(DinoForwardFeatures, model).forward_features(x)
+        torch.autograd.backward(out["x_norm_clstoken"].sum())
         assert x.grad is not None
 
 
@@ -258,9 +293,9 @@ class TestDINOv3ViTActivationCheckpointing:
         enable_checkpointing(model)
         model.train()
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
-        out = model.forward_features(x)
+        out = cast(DinoForwardFeatures, model).forward_features(x)
         loss = out["x_norm_clstoken"].sum()
-        loss.backward()
+        torch.autograd.backward(loss)
         assert x.grad is not None
 
     def test_list_input(self) -> None:
@@ -282,9 +317,11 @@ class TestDINOv3ViTActivationCheckpointing:
             torch.randn(2, 3, 56, 56, requires_grad=True),
             torch.randn(2, 3, 56, 56, requires_grad=True),
         ]
-        out_list = model.forward_features_list(x_list, [None, None])
-        loss = sum(o["x_norm_clstoken"].sum() for o in out_list)
-        loss.backward()
+        out_list = cast(DinoV3ForwardFeatures, model).forward_features_list(
+            x_list, [None, None]
+        )
+        loss = torch.stack([o["x_norm_clstoken"].sum() for o in out_list]).sum()
+        torch.autograd.backward(loss)
         assert all(x.grad is not None for x in x_list)
 
 
@@ -305,8 +342,8 @@ class TestECViTActivationCheckpointing:
         model.train()
         x = torch.randn(2, 3, 224, 224, requires_grad=True)
         outs, _ = model.forward_with_grid(x)
-        loss = sum(o.sum() for o in outs)
-        loss.backward()
+        loss = torch.stack([o.sum() for o in outs]).sum()
+        torch.autograd.backward(loss)
         assert x.grad is not None
 
 
@@ -473,7 +510,11 @@ class TestBlockChunkNotDoubleCheckpointed:
             )
 
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
-        model.forward_features(x)["x_norm_clstoken"].sum().backward()
+        torch.autograd.backward(
+            cast(DinoForwardFeatures, model).forward_features(x)[
+                "x_norm_clstoken"
+            ].sum()
+        )
 
         assert counts, "no blocks were instrumented"
         # Exactly 2 = one forward plus one recompute. Checkpointing again inside

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -511,9 +511,9 @@ class TestBlockChunkNotDoubleCheckpointed:
 
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
         torch.autograd.backward(
-            cast(DinoForwardFeatures, model).forward_features(x)[
-                "x_norm_clstoken"
-            ].sum()
+            cast(DinoForwardFeatures, model)
+            .forward_features(x)["x_norm_clstoken"]
+            .sum()
         )
 
         assert counts, "no blocks were instrumented"

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -295,7 +295,7 @@ class TestPretrainActivationCheckpointing:
             num_workers=0,
             epochs=1,
             accelerator="cpu",
-            activation_checkpointing={"enabled": True},
+            activation_checkpoint_args={"enabled": True},
         )
         assert (tmp_path / "out" / "checkpoints" / "last.ckpt").exists()
 
@@ -315,3 +315,21 @@ class TestPretrainActivationCheckpointing:
             accelerator="cpu",
         )
         assert (tmp_path / "out" / "checkpoints" / "last.ckpt").exists()
+
+    def test_pretrain_unsupported_model_raises(self, tmp_path: Path) -> None:
+        from lightly_train._commands import train
+
+        data = tmp_path / "data"
+        helpers.create_images(image_dir=data, files=10)
+        with pytest.raises(ValueError, match="not supported"):
+            train.pretrain(
+                out=tmp_path / "out",
+                data=data,
+                model="torchvision/resnet18",
+                method="simclr",
+                batch_size=4,
+                num_workers=0,
+                epochs=1,
+                accelerator="cpu",
+                activation_checkpoint_args={"enabled": True},
+            )

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -1,0 +1,317 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from lightly_train._activation_checkpointing import (
+    ActivationCheckpointingArgs,
+    maybe_checkpoint,
+)
+from tests import helpers
+
+
+class TestActivationCheckpointingArgs:
+    def test_defaults(self) -> None:
+        args = ActivationCheckpointingArgs()
+        assert args.enabled is False
+        assert args.every_n_blocks == 1
+
+    def test_from_dict(self) -> None:
+        args = ActivationCheckpointingArgs(enabled=True, every_n_blocks=3)
+        assert args.enabled is True
+        assert args.every_n_blocks == 3
+
+    def test_every_n_blocks_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            ActivationCheckpointingArgs(enabled=True, every_n_blocks=0)
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            ActivationCheckpointingArgs(enabled=True, unknown_field=42)
+
+
+class TestMaybeCheckpoint:
+    def test_disabled(self) -> None:
+        linear = nn.Linear(16, 16)
+        x = torch.randn(2, 16, requires_grad=True)
+        y = maybe_checkpoint(
+            linear,
+            x,
+            use_activation_checkpointing=False,
+            block_index=0,
+            every_n_blocks=1,
+        )
+        y.sum().backward()
+        assert x.grad is not None
+
+    def test_enabled(self) -> None:
+        linear = nn.Linear(16, 16)
+        x = torch.randn(2, 16, requires_grad=True)
+        y = maybe_checkpoint(
+            linear,
+            x,
+            use_activation_checkpointing=True,
+            block_index=0,
+            every_n_blocks=1,
+        )
+        y.sum().backward()
+        assert x.grad is not None
+
+    def test_every_n_blocks_skips(self) -> None:
+        linear = nn.Linear(16, 16)
+        x = torch.randn(2, 16, requires_grad=True)
+        y = maybe_checkpoint(
+            linear,
+            x,
+            use_activation_checkpointing=True,
+            block_index=1,
+            every_n_blocks=2,
+        )
+        y.sum().backward()
+        assert x.grad is not None
+
+    def test_every_n_blocks_applies(self) -> None:
+        linear = nn.Linear(16, 16)
+        x = torch.randn(2, 16, requires_grad=True)
+        y = maybe_checkpoint(
+            linear,
+            x,
+            use_activation_checkpointing=True,
+            block_index=2,
+            every_n_blocks=2,
+        )
+        y.sum().backward()
+        assert x.grad is not None
+
+    def test_with_kwargs(self) -> None:
+        class BlockWithKwargs(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(16, 16)
+
+            def forward(self, x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+                return self.linear(x) * scale
+
+        block = BlockWithKwargs()
+        x = torch.randn(2, 16, requires_grad=True)
+        y = maybe_checkpoint(
+            block,
+            x,
+            scale=2.0,
+            use_activation_checkpointing=True,
+            block_index=0,
+            every_n_blocks=1,
+        )
+        y.sum().backward()
+        assert x.grad is not None
+
+    def test_gradient_correctness(self) -> None:
+        torch.manual_seed(0)
+        linear = nn.Linear(16, 16)
+        x = torch.randn(2, 16, requires_grad=True)
+
+        y_ref = linear(x)
+        y_ref.sum().backward()
+        grad_ref = x.grad.clone()
+
+        x.grad = None
+        y_ckpt = maybe_checkpoint(
+            linear,
+            x,
+            use_activation_checkpointing=True,
+            block_index=0,
+            every_n_blocks=1,
+        )
+        y_ckpt.sum().backward()
+
+        assert torch.allclose(y_ref, y_ckpt)
+        assert torch.allclose(grad_ref, x.grad)
+
+
+class TestDINOv2ViTActivationCheckpointing:
+    def test_forward_backward(self) -> None:
+        from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
+            DinoVisionTransformer,
+        )
+
+        model = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            mlp_ratio=2.0,
+            activation_checkpointing=True,
+        )
+        model.train()
+        x = torch.randn(2, 3, 56, 56, requires_grad=True)
+        out = model.forward_features(x)
+        loss = out["x_norm_clstoken"].sum()
+        loss.backward()
+        assert x.grad is not None
+
+    def test_numerical_equivalence(self) -> None:
+        from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
+            DinoVisionTransformer,
+        )
+
+        vit_kwargs = {
+            "img_size": 56,
+            "patch_size": 14,
+            "embed_dim": 64,
+            "depth": 4,
+            "num_heads": 4,
+            "mlp_ratio": 2.0,
+        }
+        torch.manual_seed(0)
+        model_ref = DinoVisionTransformer(**vit_kwargs, activation_checkpointing=False)
+        torch.manual_seed(0)
+        model_ckpt = DinoVisionTransformer(**vit_kwargs, activation_checkpointing=True)
+        model_ckpt.load_state_dict(model_ref.state_dict())
+        model_ref.train()
+        model_ckpt.train()
+
+        x = torch.randn(2, 3, 56, 56)
+        out_ref = model_ref.forward_features(x)
+        out_ckpt = model_ckpt.forward_features(x)
+
+        assert torch.allclose(
+            out_ref["x_norm_clstoken"], out_ckpt["x_norm_clstoken"], atol=1e-5
+        )
+
+    def test_every_n_blocks(self) -> None:
+        from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
+            DinoVisionTransformer,
+        )
+
+        model = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            mlp_ratio=2.0,
+            activation_checkpointing=True,
+            activation_checkpointing_every_n_blocks=2,
+        )
+        model.train()
+        x = torch.randn(2, 3, 56, 56, requires_grad=True)
+        out = model.forward_features(x)
+        out["x_norm_clstoken"].sum().backward()
+        assert x.grad is not None
+
+
+class TestDINOv3ViTActivationCheckpointing:
+    def test_forward_backward(self) -> None:
+        from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
+            DinoVisionTransformer,
+        )
+
+        model = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            ffn_ratio=2.0,
+            activation_checkpointing=True,
+        )
+        model.train()
+        x = torch.randn(2, 3, 56, 56, requires_grad=True)
+        out = model.forward_features(x)
+        loss = out["x_norm_clstoken"].sum()
+        loss.backward()
+        assert x.grad is not None
+
+    def test_list_input(self) -> None:
+        from lightly_train._models.dinov3.dinov3_src.models.vision_transformer import (
+            DinoVisionTransformer,
+        )
+
+        model = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            ffn_ratio=2.0,
+            activation_checkpointing=True,
+        )
+        model.train()
+        x_list = [
+            torch.randn(2, 3, 56, 56, requires_grad=True),
+            torch.randn(2, 3, 56, 56, requires_grad=True),
+        ]
+        out_list = model.forward_features_list(x_list, [None, None])
+        loss = sum(o["x_norm_clstoken"].sum() for o in out_list)
+        loss.backward()
+        assert all(x.grad is not None for x in x_list)
+
+
+class TestECViTActivationCheckpointing:
+    def test_forward_backward(self) -> None:
+        from lightly_train._models.ecvit.ecvit import VisionTransformer
+
+        model = VisionTransformer(
+            img_size=224,
+            patch_size=16,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            ffn_ratio=2.0,
+            return_layers=[2, 3],
+            activation_checkpointing=True,
+        )
+        model.train()
+        x = torch.randn(2, 3, 224, 224, requires_grad=True)
+        outs, _ = model.forward_with_grid(x)
+        loss = sum(o.sum() for o in outs)
+        loss.backward()
+        assert x.grad is not None
+
+
+class TestPretrainActivationCheckpointing:
+    def test_pretrain_with_activation_checkpointing(self, tmp_path: Path) -> None:
+        from lightly_train._commands import train
+
+        data = tmp_path / "data"
+        helpers.create_images(image_dir=data, files=10)
+        train.pretrain(
+            out=tmp_path / "out",
+            data=data,
+            model="dinov2/_vittest14",
+            method="dinov2",
+            batch_size=2,
+            num_workers=0,
+            epochs=1,
+            accelerator="cpu",
+            activation_checkpointing={"enabled": True},
+        )
+        assert (tmp_path / "out" / "checkpoints" / "last.ckpt").exists()
+
+    def test_pretrain_without_activation_checkpointing(self, tmp_path: Path) -> None:
+        from lightly_train._commands import train
+
+        data = tmp_path / "data"
+        helpers.create_images(image_dir=data, files=10)
+        train.pretrain(
+            out=tmp_path / "out",
+            data=data,
+            model="torchvision/resnet18",
+            method="simclr",
+            batch_size=4,
+            num_workers=0,
+            epochs=1,
+            accelerator="cpu",
+        )
+        assert (tmp_path / "out" / "checkpoints" / "last.ckpt").exists()

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -7,9 +7,8 @@
 #
 from __future__ import annotations
 
-from collections.abc import Iterable
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Iterable, Protocol, cast
 
 import pytest
 import torch

--- a/tests/test_activation_checkpointing.py
+++ b/tests/test_activation_checkpointing.py
@@ -7,7 +7,9 @@
 #
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
+from typing import cast
 
 import pytest
 import torch
@@ -17,7 +19,31 @@ from lightly_train._activation_checkpointing import (
     ActivationCheckpointingArgs,
     maybe_checkpoint,
 )
+from lightly_train._models.model_wrapper import SupportsActivationCheckpointing
 from tests import helpers
+
+
+class CountingBlock(nn.Module):
+    """Linear block that records how many times its forward ran.
+
+    Checkpointing is only observable as a *recompute*: asserting on gradients
+    alone passes even when no checkpointing happens at all.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(16, 16)
+        self.num_forward_calls = 0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.num_forward_calls += 1
+        return cast(torch.Tensor, self.linear(x))
+
+
+def enable_checkpointing(model: nn.Module, every_n_blocks: int = 1) -> None:
+    """Configure a bare ViT the way its model wrapper would."""
+    model._activation_checkpointing = True  # type: ignore[assignment]
+    model._activation_checkpointing_every_n_blocks = every_n_blocks  # type: ignore[assignment]
 
 
 class TestActivationCheckpointingArgs:
@@ -42,10 +68,10 @@ class TestActivationCheckpointingArgs:
 
 class TestMaybeCheckpoint:
     def test_disabled(self) -> None:
-        linear = nn.Linear(16, 16)
+        block = CountingBlock()
         x = torch.randn(2, 16, requires_grad=True)
         y = maybe_checkpoint(
-            linear,
+            block,
             x,
             use_activation_checkpointing=False,
             block_index=0,
@@ -53,12 +79,14 @@ class TestMaybeCheckpoint:
         )
         y.sum().backward()
         assert x.grad is not None
+        # Without checkpointing the block runs once, with no recompute.
+        assert block.num_forward_calls == 1
 
     def test_enabled(self) -> None:
-        linear = nn.Linear(16, 16)
+        block = CountingBlock()
         x = torch.randn(2, 16, requires_grad=True)
         y = maybe_checkpoint(
-            linear,
+            block,
             x,
             use_activation_checkpointing=True,
             block_index=0,
@@ -66,6 +94,8 @@ class TestMaybeCheckpoint:
         )
         y.sum().backward()
         assert x.grad is not None
+        # With checkpointing the block is recomputed during backward.
+        assert block.num_forward_calls == 2
 
     def test_every_n_blocks_skips(self) -> None:
         linear = nn.Linear(16, 16)
@@ -151,8 +181,8 @@ class TestDINOv2ViTActivationCheckpointing:
             depth=4,
             num_heads=4,
             mlp_ratio=2.0,
-            activation_checkpointing=True,
         )
+        enable_checkpointing(model)
         model.train()
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
         out = model.forward_features(x)
@@ -174,9 +204,10 @@ class TestDINOv2ViTActivationCheckpointing:
             "mlp_ratio": 2.0,
         }
         torch.manual_seed(0)
-        model_ref = DinoVisionTransformer(**vit_kwargs, activation_checkpointing=False)
+        model_ref = DinoVisionTransformer(**vit_kwargs)
         torch.manual_seed(0)
-        model_ckpt = DinoVisionTransformer(**vit_kwargs, activation_checkpointing=True)
+        model_ckpt = DinoVisionTransformer(**vit_kwargs)
+        enable_checkpointing(model_ckpt)
         model_ckpt.load_state_dict(model_ref.state_dict())
         model_ref.train()
         model_ckpt.train()
@@ -201,9 +232,8 @@ class TestDINOv2ViTActivationCheckpointing:
             depth=4,
             num_heads=4,
             mlp_ratio=2.0,
-            activation_checkpointing=True,
-            activation_checkpointing_every_n_blocks=2,
         )
+        enable_checkpointing(model, every_n_blocks=2)
         model.train()
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
         out = model.forward_features(x)
@@ -224,8 +254,8 @@ class TestDINOv3ViTActivationCheckpointing:
             depth=4,
             num_heads=4,
             ffn_ratio=2.0,
-            activation_checkpointing=True,
         )
+        enable_checkpointing(model)
         model.train()
         x = torch.randn(2, 3, 56, 56, requires_grad=True)
         out = model.forward_features(x)
@@ -245,8 +275,8 @@ class TestDINOv3ViTActivationCheckpointing:
             depth=4,
             num_heads=4,
             ffn_ratio=2.0,
-            activation_checkpointing=True,
         )
+        enable_checkpointing(model)
         model.train()
         x_list = [
             torch.randn(2, 3, 56, 56, requires_grad=True),
@@ -270,8 +300,8 @@ class TestECViTActivationCheckpointing:
             num_heads=4,
             ffn_ratio=2.0,
             return_layers=[2, 3],
-            activation_checkpointing=True,
         )
+        enable_checkpointing(model)
         model.train()
         x = torch.randn(2, 3, 224, 224, requires_grad=True)
         outs, _ = model.forward_with_grid(x)
@@ -333,3 +363,119 @@ class TestPretrainActivationCheckpointing:
                 accelerator="cpu",
                 activation_checkpoint_args={"enabled": True},
             )
+
+
+class TestSupportsActivationCheckpointing:
+    """Support is decided once, on the instantiated model wrapper."""
+
+    def test_vit_wrappers_declare_support(self) -> None:
+        from lightly_train._models.dinov2_vit.dinov2_vit import DINOv2ViTModelWrapper
+        from lightly_train._models.dinov3.dinov3_vit import DINOv3ViTModelWrapper
+        from lightly_train._models.ecvit.ecvit import ECViTModelWrapper
+
+        for wrapper_cls in (
+            DINOv2ViTModelWrapper,
+            DINOv3ViTModelWrapper,
+            ECViTModelWrapper,
+        ):
+            assert issubclass(wrapper_cls, SupportsActivationCheckpointing)
+
+    def test_non_vit_wrappers_do_not_declare_support(self) -> None:
+        from lightly_train._models.dinov3.dinov3_convnext import (
+            DINOv3VConvNeXtModelWrapper,
+        )
+        from lightly_train._models.torchvision.torchvision import (
+            TorchvisionModelWrapper,
+        )
+
+        for wrapper_cls in (DINOv3VConvNeXtModelWrapper, TorchvisionModelWrapper):
+            assert not issubclass(wrapper_cls, SupportsActivationCheckpointing)
+
+    def test_dinov3_convnext_raises_value_error(self) -> None:
+        """A ConvNeXt in the dinov3 package must not be treated as supported.
+
+        Support used to be decided per-package, so dinov3/convnext passed the
+        check and then failed with a raw TypeError from the model builder.
+        """
+        from lightly_train._commands import train_helpers
+        from lightly_train._models import package_helpers
+
+        wrapped_model = package_helpers.get_wrapped_model(
+            model="dinov3/_convnexttest",
+            num_input_channels=3,
+            load_weights=False,
+        )
+        with pytest.raises(ValueError, match="not supported"):
+            train_helpers.set_activation_checkpointing(
+                wrapped_model=wrapped_model,
+                args=ActivationCheckpointingArgs(enabled=True),
+            )
+
+    def test_instantiated_ecvit_wrapper_is_accepted(self) -> None:
+        """An already-instantiated ECViT wrapper must be accepted.
+
+        ECViTModelWrapper.get_model() returns self, so the previous structural
+        check inspected the wrapper instead of the backbone and rejected it.
+        """
+        from lightly_train._commands import train_helpers
+        from lightly_train._models import package_helpers
+        from lightly_train._models.ecvit.ecvit import ECViTModelWrapper
+
+        wrapped_model = package_helpers.get_wrapped_model(
+            model="edgecrafter/ecvitt",
+            num_input_channels=3,
+            load_weights=False,
+        )
+        train_helpers.set_activation_checkpointing(
+            wrapped_model=wrapped_model,
+            args=ActivationCheckpointingArgs(enabled=True, every_n_blocks=2),
+        )
+        assert isinstance(wrapped_model, ECViTModelWrapper)
+        backbone = wrapped_model.backbone_model
+        assert cast(bool, backbone._activation_checkpointing) is True
+        assert cast(int, backbone._activation_checkpointing_every_n_blocks) == 2
+
+
+class TestBlockChunkNotDoubleCheckpointed:
+    def test_chunked_blocks_recompute_once(self) -> None:
+        """With block_chunks > 0 each block must recompute once, not twice.
+
+        The outer loop over ``self.blocks`` already checkpoints whole chunks, so
+        checkpointing again inside BlockChunk.forward would nest and recompute
+        twice.
+        """
+        from lightly_train._models.dinov2_vit.dinov2_vit_src.models.vision_transformer import (
+            DinoVisionTransformer,
+        )
+
+        model = DinoVisionTransformer(
+            img_size=56,
+            patch_size=14,
+            embed_dim=64,
+            depth=4,
+            num_heads=4,
+            mlp_ratio=2.0,
+            block_chunks=2,
+        )
+        enable_checkpointing(model)
+        model.train()
+
+        # A *pre*-hook is required here. Non-reentrant checkpointing aborts the
+        # recompute as soon as it has the tensors it needs, so a regular forward
+        # hook never fires for the interrupted block and hides the extra pass.
+        counts: dict[int, int] = {}
+        chunks = cast(Iterable[Iterable[nn.Module]], model.blocks)
+        for idx, block in enumerate(m for chunk in chunks for m in chunk):
+            if isinstance(block, nn.Identity):
+                continue
+            block.register_forward_pre_hook(
+                lambda _m, _i, k=idx: counts.__setitem__(k, counts.get(k, 0) + 1)
+            )
+
+        x = torch.randn(2, 3, 56, 56, requires_grad=True)
+        model.forward_features(x)["x_norm_clstoken"].sum().backward()
+
+        assert counts, "no blocks were instrumented"
+        # Exactly 2 = one forward plus one recompute. Checkpointing again inside
+        # BlockChunk.forward makes the chunked blocks reach 3.
+        assert max(counts.values()) == 2, counts


### PR DESCRIPTION
Closes #929

## Summary
- Adds `ActivationCheckpointingArgs` config class with `enabled: bool` and `every_n_blocks: int`
- Applies `torch.utils.checkpoint.checkpoint(use_reentrant=False)` to block loops in DINOv2 ViT, DINOv3 ViT, and ECViT backbones
- Threads config through `pretrain()` API and CLI via `activation_checkpointing` parameter
- Auto-disables during eval/no_grad (teacher path)

## Usage
```python
  lightly_train.pretrain(
      ...,
      activation_checkpointing={"enabled": True, "every_n_blocks": 1},
  )
```
CLI: `lightly-train pretrain ... activation_checkpointing.enabled=true`

## Test plan
  - [x] 18 new tests (config, helper, 3 backbones, integration)
  - [x] 269 existing tests pass (0 regressions)
  - [x] GPU memory verified: 30.2% reduction on ViT-S/14 (706→493 MB)
  - [x] Numerical correctness: max diff = 0.00e+00
  - [x] ruff format + lint clean
