### PR TITLE
Fix broken "Monitor training progress" docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ if __name__ == "__main__":
   including [multi-GPU](https://docs.lightly.ai/train/stable/performance/multi_gpu.html)
   and [multi-node](https://docs.lightly.ai/train/stable/performance/multi_node.html)
   support
-- [Monitor training progress](https://docs.lightly.ai/train/stable/pretrain_distill.html#logging)
+- [Monitor training progress](https://docs.lightly.ai/train/stable/pretrain_distill/index.html#logging)
   with MLflow, TensorBoard, Weights & Biases, and more
 - Runs fully on-premises with no API authentication
 - Export models in their native format for fine-tuning or inference

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -191,7 +191,7 @@ See the full [quick start guide](quick-start-object-detection) for more details.
   including [multi-GPU](https://docs.lightly.ai/train/stable/performance/multi_gpu.html)
   and [multi-node](https://docs.lightly.ai/train/stable/performance/multi_node.html)
   support
-- [Monitor training progress](https://docs.lightly.ai/train/stable/pretrain_distill.html#logging)
+- [Monitor training progress](https://docs.lightly.ai/train/stable/pretrain_distill/index.html#logging)
   with MLflow, TensorBoard, Weights & Biases, and more
 - Runs fully on-premises with no API authentication
 - Export models in their native format for fine-tuning or inference


### PR DESCRIPTION
Closes #932

## What was wrong

The Features list linked to `pretrain_distill.html#logging`, which returns **404**. `pretrain_distill` is a docs *directory*, not a page — the neighbouring links already use the directory form (e.g. `pretrain_distill/methods/distillation.html`).

Fixed in the two places the issue names — the GitHub README and the docs landing page:

```
- https://docs.lightly.ai/train/stable/pretrain_distill.html#logging
+ https://docs.lightly.ai/train/stable/pretrain_distill/index.html#logging
```

## Verification

- `pretrain_distill.html` → `404`
- `pretrain_distill/index.html` → `200`
- The page really does emit `id="logging"`, so the anchor lands on the Loggers section rather than silently falling back to the top of the page
- Anchor source confirmed at `docs/source/pretrain_distill/index.md:217` (`(logging)=` immediately above `## Loggers`)

## Four more instances of the same broken URL (not fixed here)

Grepping the repo, the same dead `pretrain_distill.html` base appears in four other places. I've left them out of this PR since the issue is specifically about the Features link, but they're all currently 404 and worth a follow-up:

| file | link | note |
|---|---|---|
| `src/lightly_train/_cli.py:57` | `pretrain_distill.html` | → `pretrain_distill/index.html` (verified 200) |
| `src/lightly_train/_commands/train.py:88` | `pretrain_distill.html` | → `pretrain_distill/index.html` (verified 200) |
| `examples/notebooks/distillation.ipynb:384` | `pretrain_distill.html` | → `pretrain_distill/index.html` (verified 200) |
| `examples/notebooks/distillation.ipynb:90` | `pretrain_distill.html#train-data` | **needs a decision** — see below |

The first three are a straight swap. The last one is different: I couldn't find a `(train-data)=` anchor anywhere under `docs/source/`, so that anchor looks dangling independently of the path problem and I didn't want to guess at the intended destination.

Happy to fold any or all of these into this PR, or open a separate one — just say which you'd prefer.