### PR TITLE
Fix remaining broken pretrain_distill docs links

### DIFF
--- a/examples/notebooks/distillation.ipynb
+++ b/examples/notebooks/distillation.ipynb
@@ -87,7 +87,7 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "See the [data guide](https://docs.lightly.ai/train/stable/pretrain_distill.html#train-data)\n",
+    "See the [data guide](https://docs.lightly.ai/train/stable/pretrain_distill/index.html#pretrain-data)\n",
     "for more information on supported data formats.\n",
     "\n",
     "In this example, the dataset looks like this:\n",
@@ -381,7 +381,7 @@
     "inference, head over to the [Object Detection Quick Start](https://docs.lightly.ai/train/stable/quick_start_detection.html).\n",
     "\n",
     "If you want to learn more about distillation and how to pretrain any model with it,\n",
-    "head over to the [Distillation Guide](https://docs.lightly.ai/train/stable/pretrain_distill.html).\n",
+    "head over to the [Distillation Guide](https://docs.lightly.ai/train/stable/pretrain_distill/index.html).\n",
     "\n",
     "If you want to learn how to pretrain foundation models, check out the [DINOv2 Pretraining page](https://docs.lightly.ai/train/stable/pretrain_dinov2.html)."
    ]

--- a/src/lightly_train/_cli.py
+++ b/src/lightly_train/_cli.py
@@ -54,7 +54,7 @@ _train_cfg = CLITrainConfig(out="", data="", model="")
 _PRETRAIN_HELP_MSG = f"""
     Pretrain a model with self-supervised learning or distill from a teacher model.
 
-    See the documentation for more information: https://docs.lightly.ai/train/stable/pretrain_distill.html
+    See the documentation for more information: https://docs.lightly.ai/train/stable/pretrain_distill/index.html
 
     The training process can be monitored with TensorBoard:
 

--- a/src/lightly_train/_commands/train.py
+++ b/src/lightly_train/_commands/train.py
@@ -85,7 +85,7 @@ def pretrain(
 ) -> None:
     """Pretrain a self-supervised model.
 
-    See the documentation for more information: https://docs.lightly.ai/train/stable/pretrain_distill.html
+    See the documentation for more information: https://docs.lightly.ai/train/stable/pretrain_distill/index.html
 
     The pretraining process can be monitored with TensorBoard:
 


### PR DESCRIPTION
Follow-up to #934, picking up the instances I listed there but deliberately left out of that PR.

#934 fixed the two occurrences the issue named (README + docs landing page). The same dead base URL was still present in three more places, all now 404:

| file | before | after |
|---|---|---|
| `src/lightly_train/_cli.py:57` | `pretrain_distill.html` | `pretrain_distill/index.html` |
| `src/lightly_train/_commands/train.py:88` | `pretrain_distill.html` | `pretrain_distill/index.html` |
| `examples/notebooks/distillation.ipynb:384` | `pretrain_distill.html` | `pretrain_distill/index.html` |
| `examples/notebooks/distillation.ipynb:90` | `pretrain_distill.html#train-data` | `pretrain_distill/index.html#pretrain-data` |

## The fourth one

In #934 I flagged the notebook's data-guide link as needing a decision, because its `#train-data` anchor doesn't exist. I've since found the intended target: the Data section in `docs/source/pretrain_distill/index.md` is anchored `(pretrain-data)=` (line 120), not `train-data`. So that link now points at `#pretrain-data`.

If that isn't the section you meant it to reach, say so and I'll change it — but it's the only Data anchor in that page.

## Verification

- `pretrain_distill.html` → **404**; `pretrain_distill/index.html` → **200**
- `id="pretrain-data"` is present on the rendered page; `id="train-data"` is not
- `pretrain_distill/index.html` is already the form used elsewhere in these same files (e.g. the `#resume-training` links at `_cli.py:119`/`133`), so this is consistent rather than a new convention
- `distillation.ipynb` still parses as valid JSON (21 cells)
- `_cli.py` and `_commands/train.py` both compile

After this, `grep -rn "pretrain_distill\.html"` returns nothing across the repo.