### PR TITLE
perf(eomt): reduce instance segmentation validation peak memory

### DIFF
--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
@@ -44,6 +44,9 @@ from lightly_train._task_models.dinov2_eomt_instance_segmentation.transforms imp
     DINOv2EoMTInstanceSegmentationValTransformArgs,
 )
 from lightly_train._task_models.eomt import hooks
+from lightly_train._task_models.eomt.instance_segmentation_validation import (
+    get_chunked_labels_masks_scores,
+)
 from lightly_train._task_models.train_model import (
     TaskStepResult,
     TrainModel,
@@ -294,7 +297,7 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
                 preds=[
                     {
                         "labels": labels[i],
-                        "masks": masks[i],
+                        "masks": masks[i].cpu(),
                         "scores": scores[i],
                     }
                     for i in range(len(labels))
@@ -405,21 +408,19 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
         ):
             logits = logits.unsqueeze(0)  # (1, Q, H', W')
             class_logits = class_logits.unsqueeze(0)  # (1, Q, num_classes)
-            # Resize to same size as before passing through the model. This is usually
-            # (1, Q, 640, 640) and depends on self.model.image_size.
-            logits = F.interpolate(logits, resized_images.shape[-2:], mode="bilinear")
             # Revert resize and pad from self.model.resize_and_pad
             logits = logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
-            # (1, Q, H, W)
-            logits = F.interpolate(logits, (image_h, image_w), mode="bilinear")
-            # (1, Q), (1, Q, H, W), (1, Q)
-            labels, masks, scores = self.model.get_labels_masks_scores(
-                mask_logits=logits, class_logits=class_logits
+            # Chunk queries to keep the resized mask logits footprint bounded.
+            labels, masks, scores = get_chunked_labels_masks_scores(
+                mask_logits=logits,
+                class_logits=class_logits,
+                output_size=(image_h, image_w),
+                get_labels_masks_scores=self.model.get_labels_masks_scores,
             )
             predictions.append(
                 {
                     "labels": labels[0],
-                    "masks": masks[0],
+                    "masks": masks[0].cpu(),
                     "scores": scores[0],
                 }
             )

--- a/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov2_eomt_instance_segmentation/train_model.py
@@ -408,12 +408,14 @@ class DINOv2EoMTInstanceSegmentationTrain(TrainModel):
         ):
             logits = logits.unsqueeze(0)  # (1, Q, H', W')
             class_logits = class_logits.unsqueeze(0)  # (1, Q, num_classes)
-            # Revert resize and pad from self.model.resize_and_pad
-            logits = logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
             # Chunk queries to keep the resized mask logits footprint bounded.
+            # The helper resizes the logits to the padded model input size,
+            # removes the padded region, and resizes to the original image size.
             labels, masks, scores = get_chunked_labels_masks_scores(
                 mask_logits=logits,
                 class_logits=class_logits,
+                resize_size=resized_images.shape[-2:],
+                crop_size=(crop_h, crop_w),
                 output_size=(image_h, image_w),
                 get_labels_masks_scores=self.model.get_labels_masks_scores,
             )

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -44,6 +44,9 @@ from lightly_train._task_models.dinov3_eomt_instance_segmentation.transforms imp
     DINOv3EoMTInstanceSegmentationValTransformArgs,
 )
 from lightly_train._task_models.eomt import hooks
+from lightly_train._task_models.eomt.instance_segmentation_validation import (
+    get_chunked_labels_masks_scores,
+)
 from lightly_train._task_models.train_model import (
     TaskStepResult,
     TrainModel,
@@ -300,7 +303,7 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
                 preds=[
                     {
                         "labels": labels[i],
-                        "masks": masks[i],
+                        "masks": masks[i].cpu(),
                         "scores": scores[i],
                     }
                     for i in range(len(labels))
@@ -409,21 +412,19 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         ):
             logits = logits.unsqueeze(0)  # (1, Q, H', W')
             class_logits = class_logits.unsqueeze(0)  # (1, Q, num_classes)
-            # Resize to same size as before passing through the model. This is usually
-            # (1, Q, 640, 640) and depends on self.model.image_size.
-            logits = F.interpolate(logits, resized_images.shape[-2:], mode="bilinear")
             # Revert resize and pad from self.model.resize_and_pad
             logits = logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
-            # (1, Q, H, W)
-            logits = F.interpolate(logits, (image_h, image_w), mode="bilinear")
-            # (1, Q), (1, Q, H, W), (1, Q)
-            labels, masks, scores = self.model.get_labels_masks_scores(
-                mask_logits=logits, class_logits=class_logits
+            # Chunk queries to keep the resized mask logits footprint bounded.
+            labels, masks, scores = get_chunked_labels_masks_scores(
+                mask_logits=logits,
+                class_logits=class_logits,
+                output_size=(image_h, image_w),
+                get_labels_masks_scores=self.model.get_labels_masks_scores,
             )
             predictions.append(
                 {
                     "labels": labels[0],
-                    "masks": masks[0],
+                    "masks": masks[0].cpu(),
                     "scores": scores[0],
                 }
             )

--- a/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
+++ b/src/lightly_train/_task_models/dinov3_eomt_instance_segmentation/train_model.py
@@ -412,12 +412,14 @@ class DINOv3EoMTInstanceSegmentationTrain(TrainModel):
         ):
             logits = logits.unsqueeze(0)  # (1, Q, H', W')
             class_logits = class_logits.unsqueeze(0)  # (1, Q, num_classes)
-            # Revert resize and pad from self.model.resize_and_pad
-            logits = logits[..., :crop_h, :crop_w]  # (1, Q, crop_h, crop_w)
             # Chunk queries to keep the resized mask logits footprint bounded.
+            # The helper resizes the logits to the padded model input size,
+            # removes the padded region, and resizes to the original image size.
             labels, masks, scores = get_chunked_labels_masks_scores(
                 mask_logits=logits,
                 class_logits=class_logits,
+                resize_size=resized_images.shape[-2:],
+                crop_size=(crop_h, crop_w),
                 output_size=(image_h, image_w),
                 get_labels_masks_scores=self.model.get_labels_masks_scores,
             )

--- a/src/lightly_train/_task_models/eomt/instance_segmentation_validation.py
+++ b/src/lightly_train/_task_models/eomt/instance_segmentation_validation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+GetLabelsMasksScoresFn = Callable[[Tensor, Tensor], tuple[Tensor, Tensor, Tensor]]
+
+
+def get_chunked_labels_masks_scores(
+    *,
+    mask_logits: Tensor,
+    class_logits: Tensor,
+    output_size: tuple[int, int],
+    get_labels_masks_scores: GetLabelsMasksScoresFn,
+    max_chunk_bytes: int = 128 * 1024 * 1024,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Resize query masks in chunks to reduce peak validation memory."""
+    if mask_logits.ndim != 4:
+        raise ValueError(f"Expected mask_logits with 4 dimensions, got {mask_logits.ndim}.")
+    if class_logits.ndim != 3:
+        raise ValueError(
+            f"Expected class_logits with 3 dimensions, got {class_logits.ndim}."
+        )
+    if mask_logits.shape[:2] != class_logits.shape[:2]:
+        raise ValueError(
+            "mask_logits and class_logits must agree on batch size and query count."
+        )
+
+    num_queries = mask_logits.shape[1]
+    if num_queries == 0:
+        resized_mask_logits = F.interpolate(mask_logits, output_size, mode="bilinear")
+        return get_labels_masks_scores(resized_mask_logits, class_logits)
+
+    bytes_per_query = (
+        mask_logits.element_size()
+        * mask_logits.shape[0]
+        * output_size[0]
+        * output_size[1]
+    )
+    chunk_size = max(1, max_chunk_bytes // bytes_per_query)
+
+    if chunk_size >= num_queries:
+        resized_mask_logits = F.interpolate(mask_logits, output_size, mode="bilinear")
+        return get_labels_masks_scores(resized_mask_logits, class_logits)
+
+    labels_chunks: list[Tensor] = []
+    masks_chunks: list[Tensor] = []
+    scores_chunks: list[Tensor] = []
+    for start in range(0, num_queries, chunk_size):
+        end = min(start + chunk_size, num_queries)
+        resized_mask_logits = F.interpolate(
+            mask_logits[:, start:end], output_size, mode="bilinear"
+        )
+        labels, masks, scores = get_labels_masks_scores(
+            resized_mask_logits,
+            class_logits[:, start:end],
+        )
+        labels_chunks.append(labels)
+        masks_chunks.append(masks)
+        scores_chunks.append(scores)
+
+    return (
+        torch.cat(labels_chunks, dim=1),
+        torch.cat(masks_chunks, dim=1),
+        torch.cat(scores_chunks, dim=1),
+    )

--- a/src/lightly_train/_task_models/eomt/instance_segmentation_validation.py
+++ b/src/lightly_train/_task_models/eomt/instance_segmentation_validation.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import Callable, Tuple
 
 import torch
 import torch.nn.functional as F
 from torch import Tensor
 
-GetLabelsMasksScoresFn = Callable[[Tensor, Tensor], tuple[Tensor, Tensor, Tensor]]
+# Module-level aliases are evaluated at import time, so they must not use
+# builtin-generic subscription (tuple[...]) that Python 3.8 evaluates eagerly —
+# unlike the function annotations in this file, which are strings under
+# `from __future__ import annotations`. typing.Callable/Tuple are 3.8-safe.
+GetLabelsMasksScoresFn = Callable[[Tensor, Tensor], Tuple[Tensor, Tensor, Tensor]]
 
 
 def get_chunked_labels_masks_scores(
@@ -50,7 +54,9 @@ def get_chunked_labels_masks_scores(
             Soft byte budget for the resized mask logits of a single chunk.
     """
     if mask_logits.ndim != 4:
-        raise ValueError(f"Expected mask_logits with 4 dimensions, got {mask_logits.ndim}.")
+        raise ValueError(
+            f"Expected mask_logits with 4 dimensions, got {mask_logits.ndim}."
+        )
     if class_logits.ndim != 3:
         raise ValueError(
             f"Expected class_logits with 3 dimensions, got {class_logits.ndim}."
@@ -70,7 +76,9 @@ def get_chunked_labels_masks_scores(
     resize_w = max(resize_w, output_size[1])
 
     num_queries = mask_logits.shape[1]
-    bytes_per_query = mask_logits.element_size() * mask_logits.shape[0] * resize_h * resize_w
+    bytes_per_query = (
+        mask_logits.element_size() * mask_logits.shape[0] * resize_h * resize_w
+    )
     chunk_size = max(1, max_chunk_bytes // bytes_per_query)
 
     labels_chunks: list[Tensor] = []

--- a/src/lightly_train/_task_models/eomt/instance_segmentation_validation.py
+++ b/src/lightly_train/_task_models/eomt/instance_segmentation_validation.py
@@ -13,11 +13,42 @@ def get_chunked_labels_masks_scores(
     *,
     mask_logits: Tensor,
     class_logits: Tensor,
+    resize_size: tuple[int, int],
+    crop_size: tuple[int, int] | None,
     output_size: tuple[int, int],
     get_labels_masks_scores: GetLabelsMasksScoresFn,
     max_chunk_bytes: int = 128 * 1024 * 1024,
 ) -> tuple[Tensor, Tensor, Tensor]:
-    """Resize query masks in chunks to reduce peak validation memory."""
+    """Resize query masks in chunks to reduce peak validation memory.
+
+    The mask logits are resized per query chunk to ``resize_size`` (the padded
+    model input size). Afterwards the padded region is cropped with
+    ``crop_size`` and the remaining logits are resized to ``output_size``
+    before ``get_labels_masks_scores`` is called on each chunk. This matches
+    the unchunked validation path while bounding the temporary memory of the
+    resized mask logits.
+
+    Args:
+        mask_logits:
+            Mask logits of shape (1, Q, H', W') at the patch grid resolution.
+        class_logits:
+            Class logits of shape (1, Q, num_classes).
+        resize_size:
+            The padded model input size the logits are resized to, e.g.
+            ``self.model.image_size``.
+        crop_size:
+            The ``(crop_h, crop_w)`` size of the non-padded image region in
+            ``resize_size`` coordinates, as returned by
+            ``resize_and_pad``. Pass ``None`` to skip cropping.
+        output_size:
+            The original image size ``(image_h, image_w)`` the cropped logits
+            are resized to.
+        get_labels_masks_scores:
+            Function returning ``(labels, masks, scores)`` for a chunk of
+            resized mask logits and class logits.
+        max_chunk_bytes:
+            Soft byte budget for the resized mask logits of a single chunk.
+    """
     if mask_logits.ndim != 4:
         raise ValueError(f"Expected mask_logits with 4 dimensions, got {mask_logits.ndim}.")
     if class_logits.ndim != 3:
@@ -29,30 +60,36 @@ def get_chunked_labels_masks_scores(
             "mask_logits and class_logits must agree on batch size and query count."
         )
 
+    # The peak memory is dominated by the resize to the padded model input
+    # size, which is usually much larger than the cropped and final sizes.
+    resize_h, resize_w = resize_size
+    if crop_size is not None:
+        resize_h = max(resize_h, crop_size[0])
+        resize_w = max(resize_w, crop_size[1])
+    resize_h = max(resize_h, output_size[0])
+    resize_w = max(resize_w, output_size[1])
+
     num_queries = mask_logits.shape[1]
-    if num_queries == 0:
-        resized_mask_logits = F.interpolate(mask_logits, output_size, mode="bilinear")
-        return get_labels_masks_scores(resized_mask_logits, class_logits)
-
-    bytes_per_query = (
-        mask_logits.element_size()
-        * mask_logits.shape[0]
-        * output_size[0]
-        * output_size[1]
-    )
+    bytes_per_query = mask_logits.element_size() * mask_logits.shape[0] * resize_h * resize_w
     chunk_size = max(1, max_chunk_bytes // bytes_per_query)
-
-    if chunk_size >= num_queries:
-        resized_mask_logits = F.interpolate(mask_logits, output_size, mode="bilinear")
-        return get_labels_masks_scores(resized_mask_logits, class_logits)
 
     labels_chunks: list[Tensor] = []
     masks_chunks: list[Tensor] = []
     scores_chunks: list[Tensor] = []
     for start in range(0, num_queries, chunk_size):
         end = min(start + chunk_size, num_queries)
+        # Resize to the padded model input size.
         resized_mask_logits = F.interpolate(
-            mask_logits[:, start:end], output_size, mode="bilinear"
+            mask_logits[:, start:end], resize_size, mode="bilinear"
+        )
+        # Remove the padded region.
+        if crop_size is not None:
+            resized_mask_logits = resized_mask_logits[
+                ..., : crop_size[0], : crop_size[1]
+            ]
+        # Resize to the original image size.
+        resized_mask_logits = F.interpolate(
+            resized_mask_logits, output_size, mode="bilinear"
         )
         labels, masks, scores = get_labels_masks_scores(
             resized_mask_logits,

--- a/tests/_task_models/eomt/test_instance_segmentation_validation.py
+++ b/tests/_task_models/eomt/test_instance_segmentation_validation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from lightly_train._task_models.eomt.instance_segmentation_validation import (
+    get_chunked_labels_masks_scores,
+)
+
+
+def test_get_chunked_labels_masks_scores_matches_unchunked() -> None:
+    torch.manual_seed(0)
+    mask_logits = torch.randn(1, 4, 3, 5)
+    class_logits = torch.randn(1, 4, 6)
+    output_size = (7, 9)
+
+    chunk_call_count = 0
+
+    def chunked_get_labels_masks_scores(
+        mask_logits: Tensor, class_logits: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        nonlocal chunk_call_count
+        chunk_call_count += 1
+        labels = class_logits.argmax(dim=-1)
+        masks = mask_logits.sigmoid()
+        scores = class_logits.softmax(dim=-1).amax(dim=-1)
+        return labels, masks, scores
+
+    def reference_get_labels_masks_scores(
+        mask_logits: Tensor, class_logits: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        labels = class_logits.argmax(dim=-1)
+        masks = mask_logits.sigmoid()
+        scores = class_logits.softmax(dim=-1).amax(dim=-1)
+        return labels, masks, scores
+
+    max_chunk_bytes = mask_logits.element_size() * output_size[0] * output_size[1]
+    chunked = get_chunked_labels_masks_scores(
+        mask_logits=mask_logits,
+        class_logits=class_logits,
+        output_size=output_size,
+        get_labels_masks_scores=chunked_get_labels_masks_scores,
+        max_chunk_bytes=max_chunk_bytes,
+    )
+    assert chunk_call_count == mask_logits.shape[1]
+
+    expected = reference_get_labels_masks_scores(
+        F.interpolate(mask_logits, output_size, mode="bilinear"),
+        class_logits,
+    )
+
+    for actual, expected_part in zip(chunked, expected):
+        torch.testing.assert_close(actual, expected_part)

--- a/tests/_task_models/eomt/test_instance_segmentation_validation.py
+++ b/tests/_task_models/eomt/test_instance_segmentation_validation.py
@@ -9,11 +9,22 @@ from lightly_train._task_models.eomt.instance_segmentation_validation import (
 )
 
 
+def _reference_get_labels_masks_scores(
+    mask_logits: Tensor, class_logits: Tensor
+) -> tuple[Tensor, Tensor, Tensor]:
+    labels = class_logits.argmax(dim=-1)
+    masks = mask_logits.sigmoid()
+    scores = class_logits.softmax(dim=-1).amax(dim=-1)
+    return labels, masks, scores
+
+
 def test_get_chunked_labels_masks_scores_matches_unchunked() -> None:
     torch.manual_seed(0)
     mask_logits = torch.randn(1, 4, 3, 5)
     class_logits = torch.randn(1, 4, 6)
-    output_size = (7, 9)
+    resize_size = (7, 9)
+    crop_size = (5, 9)
+    output_size = (12, 20)
 
     chunk_call_count = 0
 
@@ -22,33 +33,112 @@ def test_get_chunked_labels_masks_scores_matches_unchunked() -> None:
     ) -> tuple[Tensor, Tensor, Tensor]:
         nonlocal chunk_call_count
         chunk_call_count += 1
-        labels = class_logits.argmax(dim=-1)
-        masks = mask_logits.sigmoid()
-        scores = class_logits.softmax(dim=-1).amax(dim=-1)
-        return labels, masks, scores
+        return _reference_get_labels_masks_scores(mask_logits, class_logits)
 
-    def reference_get_labels_masks_scores(
-        mask_logits: Tensor, class_logits: Tensor
-    ) -> tuple[Tensor, Tensor, Tensor]:
-        labels = class_logits.argmax(dim=-1)
-        masks = mask_logits.sigmoid()
-        scores = class_logits.softmax(dim=-1).amax(dim=-1)
-        return labels, masks, scores
-
-    max_chunk_bytes = mask_logits.element_size() * output_size[0] * output_size[1]
+    # Force one query per chunk.
+    max_chunk_bytes = mask_logits.element_size() * resize_size[0] * resize_size[1]
     chunked = get_chunked_labels_masks_scores(
         mask_logits=mask_logits,
         class_logits=class_logits,
+        resize_size=resize_size,
+        crop_size=crop_size,
         output_size=output_size,
         get_labels_masks_scores=chunked_get_labels_masks_scores,
         max_chunk_bytes=max_chunk_bytes,
     )
     assert chunk_call_count == mask_logits.shape[1]
 
-    expected = reference_get_labels_masks_scores(
-        F.interpolate(mask_logits, output_size, mode="bilinear"),
-        class_logits,
+    # Reference: resize to padded model input size, crop the padded region,
+    # then resize to the original image size before converting to masks.
+    reference_logits = F.interpolate(mask_logits, resize_size, mode="bilinear")
+    reference_logits = reference_logits[..., : crop_size[0], : crop_size[1]]
+    reference_logits = F.interpolate(reference_logits, output_size, mode="bilinear")
+    expected = _reference_get_labels_masks_scores(reference_logits, class_logits)
+
+    for actual, expected_part in zip(chunked, expected):
+        torch.testing.assert_close(actual, expected_part)
+
+
+def test_get_chunked_labels_masks_scores_single_chunk_matches_unchunked() -> None:
+    """Chunking must not change results when all queries fit into one chunk."""
+    torch.manual_seed(0)
+    mask_logits = torch.randn(1, 4, 6, 6)
+    class_logits = torch.randn(1, 4, 6)
+    resize_size = (8, 8)
+    crop_size = (8, 6)
+    output_size = (16, 14)
+
+    chunked = get_chunked_labels_masks_scores(
+        mask_logits=mask_logits,
+        class_logits=class_logits,
+        resize_size=resize_size,
+        crop_size=crop_size,
+        output_size=output_size,
+        get_labels_masks_scores=_reference_get_labels_masks_scores,
     )
+
+    reference_logits = F.interpolate(mask_logits, resize_size, mode="bilinear")
+    reference_logits = reference_logits[..., : crop_size[0], : crop_size[1]]
+    reference_logits = F.interpolate(reference_logits, output_size, mode="bilinear")
+    expected = _reference_get_labels_masks_scores(reference_logits, class_logits)
+
+    for actual, expected_part in zip(chunked, expected):
+        torch.testing.assert_close(actual, expected_part)
+
+
+def test_get_chunked_labels_masks_scores_crops_padded_region() -> None:
+    """A query active only in the padded region must be cropped away.
+
+    This mirrors the padded validation case: a small logit patch whose signal
+    lies entirely in the padded columns must not leak into the final mask.
+    """
+    # Single query, single logit pixel that lands in the padded region after
+    # the resize to the padded model input size.
+    mask_logits = torch.full((1, 1, 2, 2), 10.0)
+    class_logits = torch.tensor([[[0.0, 1.0]]])
+    resize_size = (4, 4)
+    # Only the left half of the padded input is real image content.
+    crop_size = (4, 2)
+    output_size = (4, 2)
+
+    labels, masks, scores = get_chunked_labels_masks_scores(
+        mask_logits=mask_logits,
+        class_logits=class_logits,
+        resize_size=resize_size,
+        crop_size=crop_size,
+        output_size=output_size,
+        get_labels_masks_scores=_reference_get_labels_masks_scores,
+    )
+
+    reference_logits = F.interpolate(mask_logits, resize_size, mode="bilinear")
+    reference_logits = reference_logits[..., : crop_size[0], : crop_size[1]]
+    reference_logits = F.interpolate(reference_logits, output_size, mode="bilinear")
+    expected = _reference_get_labels_masks_scores(reference_logits, class_logits)
+
+    for actual, expected_part in zip((labels, masks, scores), expected):
+        torch.testing.assert_close(actual, expected_part)
+
+
+def test_get_chunked_labels_masks_scores_no_crop() -> None:
+    """crop_size=None skips cropping (square inputs without padding)."""
+    torch.manual_seed(0)
+    mask_logits = torch.randn(1, 3, 4, 4)
+    class_logits = torch.randn(1, 3, 5)
+    resize_size = (6, 6)
+    output_size = (10, 10)
+
+    chunked = get_chunked_labels_masks_scores(
+        mask_logits=mask_logits,
+        class_logits=class_logits,
+        resize_size=resize_size,
+        crop_size=None,
+        output_size=output_size,
+        get_labels_masks_scores=_reference_get_labels_masks_scores,
+    )
+
+    reference_logits = F.interpolate(mask_logits, resize_size, mode="bilinear")
+    reference_logits = F.interpolate(reference_logits, output_size, mode="bilinear")
+    expected = _reference_get_labels_masks_scores(reference_logits, class_logits)
 
     for actual, expected_part in zip(chunked, expected):
         torch.testing.assert_close(actual, expected_part)


### PR DESCRIPTION
## Summary

This PR reduces peak GPU memory in EoMT instance-segmentation validation without changing metric values.

Scope is limited to Task 1:
- DINOv2 instance segmentation validation
- DINOv3 instance segmentation validation

## Approach

- split the query dimension into byte-budgeted chunks
- resize mask logits per chunk
- call `get_labels_masks_scores` on each chunk
- keep `labels` and `scores` on CUDA
- move predicted masks to CPU before metric storage

## Why this works

The validation path currently resizes all queries at once to original image size, which creates large temporary tensors and can trigger OOM on wide images.

Chunking preserves the same math while lowering peak memory.

## What is not changed

- `task_model.py` remains untouched
- metric values should remain identical
- ONNX / TensorRT-related behavior is not modified
- panoptic and semantic fixes are left for separate PRs

## Testing

- added a regression test comparing chunked vs non-chunked outputs
- verified the modified files compile successfully with `py_compile`

## Notes

I could not run the full pytest suite in the current Python environment because `pytest` and `torch` are not installed there.
