### PR TITLE
Speed up validation mAP with an optional faster-coco-eval backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Fine-tuning now requires `torchmetrics>=1.5` and fails with a clear error message if
+  an older version is installed. This happens for example when SuperGradients is
+  installed, as it requires `torchmetrics==0.8`. Classification, segmentation, and
+  panoptic fine-tuning already failed on such versions because the metrics they use
+  don't exist yet. Object detection fine-tuning previously ran, but silently ignored the
+  `average` and `backend` metric arguments and reported mAP from an outdated
+  implementation that does not match COCO eval.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-
-- Fail with a clear error message instead of an unrelated `TypeError` when fine-tuning
-  is started with a torchmetrics version that is too old for the task metrics. This
-  happens when SuperGradients is installed, as it requires `torchmetrics==0.8`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   AMD GPUs.
 - Restore the DINOv3.1 pretraining method now that its LightlySSL dependencies are
   available from PyPI.
+- Add an optional `faster-coco-eval` dependency that speeds up the mAP computation at
+  the end of every validation run by ~5x for object detection. Install it with
+  `pip install "lightly-train[faster-coco-eval]"`; it is then used automatically. Both
+  backends return identical metric values. The backend can be selected explicitly with
+  `metric_args={"map": {"backend": ...}}`.
 
 ### Changed
 
@@ -24,6 +29,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 
 ### Fixed
+
+- Fail with a clear error message instead of an unrelated `TypeError` when fine-tuning
+  is started with a torchmetrics version that is too old for the task metrics. This
+  happens when SuperGradients is installed, as it requires `torchmetrics==0.8`.
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -286,11 +286,14 @@ EXTRAS_PY38 := [dicom,mlflow,onnx,tensorboard,timm,ultralytics,wandb]
 # bitsandbytes is added so CI exercises the optional 8-bit AdamW optimizer
 # (optim_type="adamw8bit"); it has no Python 3.8 wheel, so it is deliberately
 # absent from EXTRAS_PY38 above.
-EXTRAS_PY313 := [bitsandbytes,dicom,mlflow,notebook,onnx,onnxruntime,onnxslim,rfdetr,tensorboard,timm,ultralytics,wandb]
+# faster-coco-eval is added so CI exercises the faster mAP backend; it requires
+# Python>=3.9, so it is deliberately absent from EXTRAS_PY38 above.
+EXTRAS_PY313 := [bitsandbytes,dicom,faster-coco-eval,mlflow,notebook,onnx,onnxruntime,onnxslim,rfdetr,tensorboard,timm,ultralytics,wandb]
 
 # SuperGradients is excluded as it is not compatible with Python>=3.10.
 # bitsandbytes: see EXTRAS_PY313 above (exercised in dev/CI; no Python 3.8 wheel).
-EXTRAS_DEV := [bitsandbytes,dicom,mlflow,notebook,onnx,onnxruntime,onnxslim,rfdetr,tensorboard,timm,ultralytics,wandb]
+# faster-coco-eval: see EXTRAS_PY313 above (exercised in dev/CI; requires Python>=3.9).
+EXTRAS_DEV := [bitsandbytes,dicom,faster-coco-eval,mlflow,notebook,onnx,onnxruntime,onnxslim,rfdetr,tensorboard,timm,ultralytics,wandb]
 
 # Exclude ultralytics from docker extras as it has an AGPL license and we should not
 # distribute it with the docker image.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -67,6 +67,11 @@ following dependencies are available:
 - `timm`: For [TIMM](#models-timm) models
 - `ultralytics`: For [Ultralytics](#models-ultralytics) models
 
+### Performance
+
+- `faster-coco-eval`: For faster mAP computation in object detection, see
+  {ref}`speeding-up-validation-metrics`
+
 To install optional dependencies, run:
 
 ```bash

--- a/docs/source/performance/index.md
+++ b/docs/source/performance/index.md
@@ -86,7 +86,7 @@ encoding masks rather than computing mAP, and faster-coco-eval's mask encoding i
 slower, which would make the overall validation slower rather than faster.
 
 You can always select a backend explicitly via
-[`metric_args`](#metric_args):
+[`metric_args`](../settings/train_settings.md#metric_args):
 
     metric_args={"map": {"backend": "faster_coco_eval"}}
 ```

--- a/docs/source/performance/index.md
+++ b/docs/source/performance/index.md
@@ -59,6 +59,41 @@ might contain performance improvements.
   they were built with support for your CUDA version.
 - Install newer versions of Python.
 
+(speeding-up-validation-metrics)=
+
+## Speeding Up Validation Metrics
+
+For object detection and instance segmentation, mAP is computed in a single blocking
+call at the end of every validation run. On large validation sets this can take a
+noticeable amount of time during which no training happens.
+
+The mAP computation is done by [pycocotools](https://github.com/ppwwyyxx/cocoapi) by
+default. Installing [faster-coco-eval](https://github.com/MiXaiLL76/faster_coco_eval), a
+C++ reimplementation of the same algorithm, makes it roughly **5x faster**:
+
+```bash
+pip install "lightly-train[faster-coco-eval]"
+```
+
+Both backends return identical values, so this does not change your metrics or which
+checkpoint is selected as the best one. Once installed, it is used automatically for
+object detection; no configuration is needed.
+
+```{note}
+For instance segmentation, Lightly**Train** keeps using pycocotools even when
+faster-coco-eval is installed. Instance segmentation spends most of its metric time
+encoding masks rather than computing mAP, and faster-coco-eval's mask encoding is
+slower, which would make the overall validation slower rather than faster.
+
+You can always select a backend explicitly via
+[`metric_args`](#metric_args):
+
+    metric_args={"map": {"backend": "faster_coco_eval"}}
+```
+
+This does not affect semantic segmentation, panoptic segmentation, or classification,
+which use metrics that do not depend on pycocotools.
+
 (finding-the-performance-bottleneck)=
 
 ## Finding the Performance Bottleneck

--- a/docs/source/settings/train_settings.md
+++ b/docs/source/settings/train_settings.md
@@ -879,6 +879,36 @@ lightly_train.train_image_classification(
 )
 ```
 
+#### `backend`
+
+Only available for the `map` metric of object detection and instance segmentation.
+Selects the implementation used to compute mAP. Both implementations return identical
+values but differ in speed.
+
+| Value              | Description                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------ |
+| `auto`             | Default. Uses `faster_coco_eval` where it is faster and installed, otherwise `pycocotools`.            |
+| `pycocotools`      | Always use [pycocotools](https://github.com/ppwwyyxx/cocoapi).                                         |
+| `faster_coco_eval` | Always use [faster-coco-eval](https://github.com/MiXaiLL76/faster_coco_eval). Must be installed first. |
+
+`faster_coco_eval` computes mAP roughly 5x faster, but is only installed with the
+optional `faster-coco-eval` dependency. With `auto` it is used for object detection but
+not for instance segmentation, where it would make validation slower overall. See
+{ref}`speeding-up-validation-metrics` for details.
+
+```python
+import lightly_train
+
+lightly_train.train_object_detection(
+    ...,
+    metric_args={
+        "map": {
+            "backend": "faster_coco_eval",
+        },
+    },
+)
+```
+
 #### `classwise`
 
 If set to `True`, per-class metrics (for example AP per class) are logged in addition to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,15 @@ bitsandbytes = [
 dicom = [
     "pydicom>=2.1.0",
 ]
+faster-coco-eval = [
+    # Faster C++ COCOeval used for the mAP metric. Selected automatically for object
+    # detection when installed, see _metrics/mean_average_precision.py.
+    # Requires torchmetrics>=1.2, which added the `backend` argument.
+    # 1.6.3 is the version torchmetrics itself tests against.
+    # No wheels are built for macOS x86_64 and musllinux, therefore this is an
+    # optional extra instead of a required dependency.
+    "faster-coco-eval>=1.6.3; python_version>='3.9'",
+]
 mlflow = [
     "mlflow>=2.8.0", # 2.8.0 added stepped image logging (key/step args to log_image)
     "pandas>=2.2.3; python_version>='3.12'",  # pandas<2.2.3 fails to build on Python>3.12 (no pkg_resources).

--- a/src/lightly_train/_commands/train_task.py
+++ b/src/lightly_train/_commands/train_task.py
@@ -16,6 +16,7 @@ from lightning_fabric import Fabric
 from lightning_fabric.accelerators.accelerator import Accelerator
 from lightning_fabric.connector import _PRECISION_INPUT  # type: ignore[attr-defined]
 from lightning_fabric.strategies.strategy import Strategy
+from lightning_utilities.core.imports import RequirementCache
 from pydantic import ConfigDict, Field, field_validator
 from torch.optim import Optimizer  # type: ignore[attr-defined]
 from typing_extensions import Annotated, override
@@ -72,9 +73,17 @@ from lightly_train._train_task_state import (
     TrainTaskState,
 )
 from lightly_train._training_step_timer import CUDAUtilization, TrainingStepTimer
+from lightly_train.errors import LightlyTrainError
 from lightly_train.types import PathLike
 
 logger = logging.getLogger(__name__)
+
+# Minimum torchmetrics version required by the task metrics. The package as a whole
+# allows torchmetrics>=0.8 because SuperGradients pins torchmetrics==0.8, but the task
+# metrics use arguments (e.g. `backend`, `average`) that were only added in later
+# versions. 1.5 is the version the metrics are tested against.
+TORCHMETRICS_MIN_VERSION = "1.5"
+TORCHMETRICS_SUPPORTED = RequirementCache(f"torchmetrics>={TORCHMETRICS_MIN_VERSION}")
 
 
 def train_image_classification(
@@ -1266,7 +1275,33 @@ def _train_task(
     _train_task_from_config(config=config)
 
 
+def _raise_if_torchmetrics_unsupported() -> None:
+    """Fails early if the installed torchmetrics version is too old for task metrics.
+
+    Without this check, training fails much later with a confusing TypeError about
+    unexpected keyword arguments once the metrics are instantiated.
+    """
+    if TORCHMETRICS_SUPPORTED:
+        return
+
+    try:
+        from torchmetrics import __version__ as torchmetrics_version
+
+        found = f"Found torchmetrics {torchmetrics_version}."
+    except ImportError:
+        found = "torchmetrics is not installed."
+
+    raise LightlyTrainError(
+        f"Fine-tuning requires torchmetrics>={TORCHMETRICS_MIN_VERSION}. {found} This "
+        "usually happens when SuperGradients is installed, as it requires "
+        "torchmetrics==0.8. Install a newer version with "
+        f"`pip install 'torchmetrics>={TORCHMETRICS_MIN_VERSION}'` or uninstall "
+        "SuperGradients."
+    )
+
+
 def _train_task_from_config(config: TrainTaskConfig) -> None:
+    _raise_if_torchmetrics_unsupported()
     initial_config = config.model_dump()
     # NOTE(Guarin, 07/25): We add callbacks and loggers later to fabric because we first
     # have to initialize the output directory and some other things. Fabric doesn't

--- a/src/lightly_train/_metrics/mean_average_precision.py
+++ b/src/lightly_train/_metrics/mean_average_precision.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Literal
 
+from lightning_utilities.core.imports import RequirementCache
 from torch import Tensor
 from torchmetrics import Metric as TorchmetricsMetric
 from torchmetrics.detection.mean_ap import (
@@ -19,13 +20,46 @@ from torchmetrics.detection.mean_ap import (
 
 from lightly_train._metrics.metric_args import MetricArgs
 
+# Use the same requirement string as torchmetrics' own _FASTER_COCO_EVAL_AVAILABLE so
+# that our check can never disagree with the backend validation inside torchmetrics.
+FASTER_COCO_EVAL_AVAILABLE = RequirementCache("faster_coco_eval")
+
+
+def get_default_backend(
+    iou_type: Literal["bbox", "segm"] | tuple[Literal["bbox", "segm"], ...],
+) -> Literal["pycocotools", "faster_coco_eval"]:
+    """Returns the mAP backend to use when the backend is set to "auto".
+
+    faster_coco_eval is a C++ reimplementation of COCOeval. Both backends return
+    identical values, but they have very different performance characteristics:
+
+    - The COCOeval part, which runs in a single blocking call at the end of every
+      validation run, is ~5x faster with faster_coco_eval.
+    - The mask RLE encoding, which runs on every update and therefore only matters for
+      iou_type="segm", is ~25% slower with faster_coco_eval.
+
+    For "bbox" there is no mask encoding, so faster_coco_eval is a clear win. For
+    "segm" the encoding dominates the total cost because masks are encoded at full
+    image resolution for every instance, which makes faster_coco_eval a net loss.
+    Hence we only default to it when no mask encoding is involved. Users can still
+    select either backend explicitly.
+    """
+    if not FASTER_COCO_EVAL_AVAILABLE:
+        return "pycocotools"
+    iou_types = (iou_type,) if isinstance(iou_type, str) else tuple(iou_type)
+    if "segm" in iou_types:
+        return "pycocotools"
+    return "faster_coco_eval"
+
 
 class MeanAveragePrecisionArgs(MetricArgs):
     iou_thresholds: list[float] | None = None
     rec_thresholds: list[float] | None = None
     max_detection_thresholds: list[int] | None = None
     average: Literal["macro", "micro"] = "macro"
-    backend: Literal["pycocotools", "faster_coco_eval"] = "pycocotools"
+    # "auto" picks the fastest backend available for the given iou_type, see
+    # get_default_backend.
+    backend: Literal["auto", "pycocotools", "faster_coco_eval"] = "auto"
 
     def get_torchmetrics_instances(
         self,
@@ -56,7 +90,7 @@ class MeanAveragePrecisionArgs(MetricArgs):
             iou_thresholds=self.iou_thresholds,
             rec_thresholds=self.rec_thresholds,
             max_detection_thresholds=self.max_detection_thresholds,
-            backend=self.backend,
+            backend=None if self.backend == "auto" else self.backend,
             average=self.average,
         )
         map_metric.warn_on_many_detections = False  # type: ignore[attr-defined]
@@ -111,9 +145,11 @@ class MeanAveragePrecision(TorchmetricsMeanAveragePrecision):
         class_metrics: bool = False,
         extended_summary: bool = False,
         average: Literal["macro", "micro"] = "macro",
-        backend: Literal["pycocotools", "faster_coco_eval"] = "pycocotools",
+        backend: Literal["pycocotools", "faster_coco_eval"] | None = None,
         **kwargs: Any,
     ) -> None:
+        if backend is None:
+            backend = get_default_backend(iou_type=iou_type)
         super().__init__(
             box_format=box_format,
             iou_type=iou_type,  # type: ignore

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -54,6 +54,7 @@ import torch
 import yaml
 
 import lightly_train
+from lightly_train._commands import train_task
 from lightly_train._commands.train_task import (
     ImageClassificationMulticlassTrainTaskConfig,
     ImageClassificationMultiheadMulticlassTrainTaskConfig,
@@ -66,6 +67,7 @@ from lightly_train._commands.train_task import (
     SemanticSegmentationTrainTaskConfig,
 )
 from lightly_train._data import data_helpers as data_arg_helpers
+from lightly_train.errors import LightlyTrainError
 
 from .. import helpers
 
@@ -1446,3 +1448,14 @@ def test_train_task_config_resolve_data_paths__direct_relative_to_cwd(
     assert config.data.path == (tmp_path / "dataset").resolve()
     assert config.data.train == Path("images/train")
     assert config.data.val == Path("images/val")
+
+
+class TestRaiseIfTorchmetricsUnsupported:
+    def test_supported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(train_task, "TORCHMETRICS_SUPPORTED", True, raising=True)
+        train_task._raise_if_torchmetrics_unsupported()
+
+    def test_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(train_task, "TORCHMETRICS_SUPPORTED", False, raising=True)
+        with pytest.raises(LightlyTrainError, match="requires torchmetrics>="):
+            train_task._raise_if_torchmetrics_unsupported()

--- a/tests/_metrics/test_mean_average_precision.py
+++ b/tests/_metrics/test_mean_average_precision.py
@@ -1,0 +1,242 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+import torch
+from lightning_utilities.core.imports import RequirementCache
+from pytest import MonkeyPatch
+from torch import Tensor
+
+if RequirementCache("torchmetrics<1.5"):
+    # Skip test if torchmetrics version is too old. This can happen if SuperGradients
+    # is installed which requires torchmetrics==0.8
+    pytest.skip("Old torchmetrics version", allow_module_level=True)
+
+
+from lightly_train._metrics import mean_average_precision
+from lightly_train._metrics.detection.task_metric import (
+    ObjectDetectionTaskMetric,
+    ObjectDetectionTaskMetricArgs,
+)
+from lightly_train._metrics.instance_segmentation.task_metric import (
+    InstanceSegmentationTaskMetric,
+    InstanceSegmentationTaskMetricArgs,
+)
+from lightly_train._metrics.mean_average_precision import (
+    MeanAveragePrecisionArgs,
+    get_default_backend,
+)
+
+skip_if_no_faster_coco_eval = pytest.mark.skipif(
+    not mean_average_precision.FASTER_COCO_EVAL_AVAILABLE,
+    reason="faster_coco_eval is not installed",
+)
+
+_CANVAS_SIZE = 400
+_LOSS_NAMES = ["loss", "loss_vfl", "loss_bbox", "loss_giou"]
+
+# Two images with boxes spanning the small (<32**2), medium, and large (>96**2) COCO
+# area buckets and both classes, with imperfect predictions so that the metrics are
+# neither 0 nor 1. This makes the backend comparison meaningful across all reported
+# metric keys.
+_TARGETS: list[dict[str, list[Any]]] = [
+    {
+        # 100x100 (large) and 20x20 (small).
+        "boxes": [[10.0, 10.0, 110.0, 110.0], [200.0, 200.0, 220.0, 220.0]],
+        "labels": [0, 1],
+    },
+    {
+        # 60x60 (medium).
+        "boxes": [[50.0, 50.0, 110.0, 110.0]],
+        "labels": [1],
+    },
+]
+_PREDICTIONS: list[dict[str, list[Any]]] = [
+    {
+        "boxes": [
+            [12.0, 12.0, 108.0, 108.0],  # Good match for the large box.
+            [200.0, 200.0, 225.0, 225.0],  # Loose match for the small box.
+            [300.0, 300.0, 340.0, 340.0],  # False positive.
+        ],
+        "scores": [0.9, 0.7, 0.4],
+        "labels": [0, 1, 0],
+    },
+    {
+        "boxes": [
+            [52.0, 48.0, 112.0, 108.0],  # Good match for the medium box.
+            [0.0, 0.0, 20.0, 20.0],  # False positive.
+        ],
+        "scores": [0.85, 0.3],
+        "labels": [1, 0],
+    },
+]
+
+
+def _boxes_to_masks(boxes: list[list[float]]) -> Tensor:
+    """Converts xyxy boxes to rectangular instance masks of shape (N, H, W)."""
+    masks = torch.zeros((len(boxes), _CANVAS_SIZE, _CANVAS_SIZE), dtype=torch.bool)
+    for i, (x1, y1, x2, y2) in enumerate(boxes):
+        masks[i, int(y1) : int(y2), int(x1) : int(x2)] = True
+    return masks
+
+
+def _detection_metric_values(
+    backend: Literal["pycocotools", "faster_coco_eval"],
+) -> dict[str, float]:
+    metric = ObjectDetectionTaskMetric(
+        task_metric_args=ObjectDetectionTaskMetricArgs(
+            map=MeanAveragePrecisionArgs(backend=backend)
+        ),
+        split="val",
+        class_names=["cat", "dog"],
+        box_format="xyxy",
+        loss_names=_LOSS_NAMES,
+    )
+    metric.update_with_predictions(
+        preds=[
+            {
+                "boxes": torch.tensor(pred["boxes"]),
+                "scores": torch.tensor(pred["scores"]),
+                "labels": torch.tensor(pred["labels"]),
+            }
+            for pred in _PREDICTIONS
+        ],
+        target=[
+            {
+                "boxes": torch.tensor(target["boxes"]),
+                "labels": torch.tensor(target["labels"]),
+            }
+            for target in _TARGETS
+        ],
+    )
+    metric.update_with_losses(
+        {name: torch.tensor(0.5) for name in _LOSS_NAMES}, weight=1
+    )
+    return metric.compute_aggregated_values().metric_values
+
+
+def _instance_segmentation_metric_values(
+    backend: Literal["pycocotools", "faster_coco_eval"],
+) -> dict[str, float]:
+    metric = InstanceSegmentationTaskMetric(
+        task_metric_args=InstanceSegmentationTaskMetricArgs(
+            map=MeanAveragePrecisionArgs(backend=backend)
+        ),
+        split="val",
+        class_names=["cat", "dog"],
+        loss_names=_LOSS_NAMES,
+    )
+    metric.update_with_predictions(
+        preds=[
+            {
+                "masks": _boxes_to_masks(pred["boxes"]),
+                "scores": torch.tensor(pred["scores"]),
+                "labels": torch.tensor(pred["labels"]),
+            }
+            for pred in _PREDICTIONS
+        ],
+        target=[
+            {
+                "masks": _boxes_to_masks(target["boxes"]),
+                "labels": torch.tensor(target["labels"]),
+            }
+            for target in _TARGETS
+        ],
+    )
+    metric.update_with_losses(
+        {name: torch.tensor(0.5) for name in _LOSS_NAMES}, weight=1
+    )
+    return metric.compute_aggregated_values().metric_values
+
+
+class TestGetDefaultBackend:
+    @pytest.mark.parametrize(
+        "iou_type, expected",
+        [
+            # faster_coco_eval only wins when no mask encoding is involved.
+            ("bbox", "faster_coco_eval"),
+            (("bbox",), "faster_coco_eval"),
+            ("segm", "pycocotools"),
+            (("segm",), "pycocotools"),
+            (("bbox", "segm"), "pycocotools"),
+        ],
+    )
+    def test_available(
+        self, monkeypatch: MonkeyPatch, iou_type: Any, expected: str
+    ) -> None:
+        monkeypatch.setattr(
+            mean_average_precision, "FASTER_COCO_EVAL_AVAILABLE", True, raising=True
+        )
+        assert get_default_backend(iou_type=iou_type) == expected
+
+    @pytest.mark.parametrize("iou_type", ["bbox", "segm", ("bbox", "segm")])
+    def test_not_available(self, monkeypatch: MonkeyPatch, iou_type: Any) -> None:
+        monkeypatch.setattr(
+            mean_average_precision, "FASTER_COCO_EVAL_AVAILABLE", False, raising=True
+        )
+        assert get_default_backend(iou_type=iou_type) == "pycocotools"
+
+    def test_default_is_auto(self) -> None:
+        assert MeanAveragePrecisionArgs().backend == "auto"
+
+    @pytest.mark.parametrize("backend", ["pycocotools", "faster_coco_eval"])
+    def test_explicit_backend_is_kept(self, backend: str) -> None:
+        assert MeanAveragePrecisionArgs(backend=backend).backend == backend  # type: ignore[arg-type]
+
+    @skip_if_no_faster_coco_eval
+    def test_auto_resolves_on_the_metric(self) -> None:
+        """The resolved backend must reach the underlying torchmetrics instance."""
+        detection = MeanAveragePrecisionArgs().get_torchmetrics_instances(
+            classwise=False,
+            prefix="val_metric",
+            class_names=["cat"],
+            box_format="xyxy",
+            iou_type="bbox",
+        )["map"]
+        segmentation = MeanAveragePrecisionArgs().get_torchmetrics_instances(
+            classwise=False,
+            prefix="val_metric",
+            class_names=["cat"],
+            box_format="xyxy",
+            iou_type="segm",
+        )["map"]
+        assert detection._coco_backend.backend == "faster_coco_eval"  # type: ignore[union-attr]
+        assert segmentation._coco_backend.backend == "pycocotools"  # type: ignore[union-attr]
+
+
+class TestBackendParity:
+    """The mAP backend feeds watch_metric and therefore best-checkpoint selection.
+
+    These tests guard that switching the backend does not change the reported values.
+    """
+
+    @skip_if_no_faster_coco_eval
+    def test_detection(self) -> None:
+        pycocotools_values = _detection_metric_values(backend="pycocotools")
+        faster_values = _detection_metric_values(backend="faster_coco_eval")
+
+        assert pycocotools_values.keys() == faster_values.keys()
+        # Guard against the metrics being trivially degenerate, which would make the
+        # comparison meaningless.
+        assert 0.0 < pycocotools_values["val_metric/map"] < 1.0
+        for name, value in pycocotools_values.items():
+            assert faster_values[name] == pytest.approx(value, rel=1e-6, abs=1e-6), name
+
+    @skip_if_no_faster_coco_eval
+    def test_instance_segmentation(self) -> None:
+        pycocotools_values = _instance_segmentation_metric_values(backend="pycocotools")
+        faster_values = _instance_segmentation_metric_values(backend="faster_coco_eval")
+
+        assert pycocotools_values.keys() == faster_values.keys()
+        assert 0.0 < pycocotools_values["val_metric/map"] < 1.0
+        for name, value in pycocotools_values.items():
+            assert faster_values[name] == pytest.approx(value, rel=1e-6, abs=1e-6), name

--- a/tests/templates/test_train_object_detection.py
+++ b/tests/templates/test_train_object_detection.py
@@ -11,9 +11,17 @@ from pathlib import Path
 import pytest
 from jinja2 import Environment, FileSystemLoader
 
+from lightly_train._commands.train_task import TORCHMETRICS_SUPPORTED
+
 from .. import helpers
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+
+# Fine-tuning requires a recent torchmetrics version. An old version can be installed
+# if SuperGradients is present, as it requires torchmetrics==0.8.
+skip_if_old_torchmetrics = pytest.mark.skipif(
+    not TORCHMETRICS_SUPPORTED, reason="Old torchmetrics version"
+)
 
 
 def _render(**kwargs: object) -> str:
@@ -152,6 +160,7 @@ class TestTrainObjectDetectionTemplate:
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
+@skip_if_old_torchmetrics
 def test_rendered_template_runs_training_with_defaults(tmp_path: Path) -> None:
     """Integration test: render with default parameters (except model) and run."""
     data = tmp_path / "data"
@@ -187,6 +196,7 @@ def test_rendered_template_runs_training_with_defaults(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
+@skip_if_old_torchmetrics
 def test_rendered_template_runs_training_with_all_params(tmp_path: Path) -> None:
     """Integration test: render with all parameters set explicitly and run."""
     data = tmp_path / "data"


### PR DESCRIPTION
## Motivation

Computing metrics at the end of a validation run takes a long time. The whole validation loop only accumulates state, and every metric is computed in one blocking burst on the last validation step, on the main thread and with the GPU idle:

```python
# src/lightly_train/_commands/train_task.py
if is_last_val_step:
    val_agg_metric_values = val_result.metrics.compute_aggregated_values()
```

The expensive metric is `MeanAveragePrecision`, which runs COCOeval through pycocotools. It is used by object detection and instance segmentation only; panoptic segmentation, semantic segmentation and classification use pure-torch metrics that are unaffected.

`faster-coco-eval` is a C++ reimplementation of COCOeval that torchmetrics already supports as a backend. This PR adds it as an optional dependency and uses it automatically where it is actually faster.

## Measurements

All numbers from a synthetic benchmark with realistic predictions (jittered copies of the targets plus false positives, so COCOeval does real matching work rather than short-circuiting on empty IoU sets).

**Object detection** — 500 images, 100 predictions/image, 80 classes:

| Backend | update | compute | total |
| --- | --- | --- | --- |
| pycocotools | 0.01s | 2.17s | 2.18s |
| faster-coco-eval | 0.01s | 0.43s | 0.44s |

**5.1x faster** on the blocking compute call.

**Instance segmentation** — 480x640 masks:

| Images / classes | pycocotools (update + compute) | faster-coco-eval (update + compute) | total |
| --- | --- | --- | --- |
| 100 / 40 | 1.05s + 0.20s | 1.31s + 0.27s | 0.79x |
| 500 / 40 | 6.09s + 0.82s | 7.89s + 0.46s | 0.83x |
| 500 / 80 | 5.49s + 1.20s | 7.91s + 0.28s | 0.82x |
| 1000 / 80 | 12.04s + 2.25s | 15.99s + 0.60s | 0.86x |

Instance segmentation encodes every instance mask to RLE on **every update** at full image resolution, and faster-coco-eval's mask encoding is ~25% slower. That cost dominates and outweighs the 1.8-4.3x win on compute, making it a net **15-20% regression**. This was reproducible across all four dataset sizes and in both interleaved orderings, so it is not warm-up or ordering noise. The masks used in the benchmark match what the models actually produce — full-resolution `(Q, H, W)` tensors, see `dinov2_eomt_instance_segmentation/train_model.py`.

Because of this, `backend="auto"` resolves per `iou_type`: faster-coco-eval for `bbox`, pycocotools for `segm`. Users can still select either backend explicitly.

## Metric parity

The backend feeds `watch_metric` and therefore best-checkpoint selection, so values must not change. Across all 13 reported metric values, for both bbox and segm, the two backends agree exactly (max absolute difference `0.00e+00`). This is covered by new parity tests rather than taken on trust.

## Why an extra and not a required dependency

faster-coco-eval ships no wheels for macOS x86_64 and no musllinux wheels. As a required dependency it would turn a plain `pip install lightly-train` into a source build (or an install failure) on those platforms. As an extra, everyone else keeps working exactly as before and the runtime falls back to pycocotools when it is absent.

```bash
pip install "lightly-train[faster-coco-eval]"
```

## Drive-by fix: torchmetrics version guard

The package declares `torchmetrics[detection]>=0.8`, a floor that exists only so the `super-gradients` extra (which pins `torchmetrics==0.8`) can resolve. But the task metrics have required `>=1.2` for a while already, since they pass `backend` and `average` unconditionally. On torchmetrics 0.8 fine-tuning therefore failed with an unrelated `TypeError` deep into training, and CI never caught it because all 10 metric test modules skip themselves on `torchmetrics<1.5`.

Fine-tuning now fails immediately with a clear message naming the required version and SuperGradients as the likely cause. The floor itself is unchanged, so the `super-gradients` extra still resolves.

## Note on the original problem

This shortens the detection stall ~5x, but the metric computation is still synchronous and still untimed (`timer.end_step("val_step")` fires before it). Making it genuinely non-blocking — blocking all-gather on the main thread, heavy eval in a background worker, joining at the next validation step with a broadcast so all ranks agree on the checkpoint decision — remains open. The GIL-releasing C++ backend is a precondition for it.

## Test plan

- New `tests/_metrics/test_mean_average_precision.py`: backend parity for bbox and segm, `auto` resolution per `iou_type` with and without faster-coco-eval available, explicit-override behaviour, and that the resolved backend reaches the underlying torchmetrics instance.
- New guard tests in `tests/_commands/test_train_task.py`.
- `tests/_metrics/`: 48 passed.
- End-to-end `test_train_object_detection_yolo` and `test_train_instance_segmentation`: passed.
- `make type-check` and `make format-check`: passed.
- Verified the fallback path by uninstalling faster-coco-eval — parity tests skip, `auto` resolves to pycocotools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
