### PR TITLE
perf(tests): speed up unit test CI by fixing root causes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,11 +222,16 @@ test:
 
 .PHONY: test-ci-minimal
 test-ci-minimal:
-	uv run --frozen --group pinned-torch-minimal pytest tests -v --durations=20
+	uv run --frozen --group pinned-torch-minimal pytest tests -v --durations=20 -m "not long_running_test"
 
 .PHONY: test-ci-maximal
 test-ci-maximal:
-	uv run --frozen --group pinned-torch-maximal pytest tests -v --durations=20
+	uv run --frozen --group pinned-torch-maximal pytest tests -v --durations=20 -m "not long_running_test"
+
+# run tests marked as long running, e.g. tests excluded from test-ci-minimal/test-ci-maximal
+.PHONY: test-slow
+test-slow:
+	uv run --frozen pytest tests -v --durations=20 -m long_running_test
 
 
 ### Virtual Environment

--- a/src/lightly_train/_models/ecvit/ecvit.py
+++ b/src/lightly_train/_models/ecvit/ecvit.py
@@ -39,7 +39,7 @@ import warnings
 from collections.abc import Mapping
 from functools import partial
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, List, cast
 
 import torch
 import torch.nn as nn
@@ -522,7 +522,7 @@ class ECViTModelWrapper(
             int, preset.get("depth", 12) if depth is _DEFAULT else depth
         )
         resolved_interaction_indexes = interaction_indexes or cast(
-            list[int], preset.get("interaction_indexes", [10, 11])
+            List[int], preset.get("interaction_indexes", [10, 11])
         )
 
         self.name = name

--- a/src/lightly_train/_models/ecvit/ecvit.py
+++ b/src/lightly_train/_models/ecvit/ecvit.py
@@ -74,7 +74,7 @@ ECVIT_PRETRAINED_URLS: dict[str, str] = {
 }
 
 
-ECVIT_PRESETS: dict[str, dict[str, int | None | float]] = {
+ECVIT_PRESETS: dict[str, dict[str, int | None | float | list[int]]] = {
     "ecvitt": {
         "embed_dim": 192,
         "num_heads": 3,
@@ -98,6 +98,17 @@ ECVIT_PRESETS: dict[str, dict[str, int | None | float]] = {
         "num_heads": 6,
         "proj_dim": 256,
         "ffn_ratio": 6.0,
+    },
+    # Genuinely tiny preset for fast tests: small width and depth, unlike the
+    # "-notpretrained" variants of the presets above, which only skip weight
+    # loading and keep the full production-sized architecture.
+    "ecvittest": {
+        "embed_dim": 8,
+        "num_heads": 1,
+        "proj_dim": None,
+        "ffn_ratio": 1.0,
+        "depth": 2,
+        "interaction_indexes": [0, 1],
     },
 }
 
@@ -463,6 +474,7 @@ class ECViTModelWrapper(
         embed_layer: str = "ConvPyramidPatchEmbed",
         ffn_layer: str = "mlp",
         ffn_ratio: float | object = _DEFAULT,
+        depth: int | object = _DEFAULT,
         skip_load_backbone: bool = False,
         **kwargs: Any,
     ) -> None:
@@ -504,7 +516,12 @@ class ECViTModelWrapper(
         resolved_ffn_ratio = cast(
             float, preset["ffn_ratio"] if ffn_ratio is _DEFAULT else ffn_ratio
         )
-        resolved_interaction_indexes = interaction_indexes or [10, 11]
+        resolved_depth = cast(
+            int, preset.get("depth", 12) if depth is _DEFAULT else depth
+        )
+        resolved_interaction_indexes = interaction_indexes or cast(
+            list[int], preset.get("interaction_indexes", [10, 11])
+        )
 
         self.name = name
         self.interaction_indexes = resolved_interaction_indexes
@@ -521,6 +538,7 @@ class ECViTModelWrapper(
         self.backbone = VisionTransformer(
             embed_dim=resolved_embed_dim,
             num_heads=resolved_num_heads,
+            depth=resolved_depth,
             return_layers=resolved_interaction_indexes,
             patch_size=patch_size,
             embed_layer=EMBED_LAYER_REGISTRY[embed_layer],

--- a/src/lightly_train/_models/ecvit/ecvit.py
+++ b/src/lightly_train/_models/ecvit/ecvit.py
@@ -28,6 +28,8 @@ Modified from https://huggingface.co/spaces/Hila/RobustViT/blob/main/ViT/ViT_new
 - Ported the ECViT backbone adapter to Lightly.
 - Removed EdgeCrafter registry/distributed dependencies.
 - Added typed LTDETR-compatible tuple output.
+- Added opt-in activation checkpointing for the transformer blocks.
+- Added a configurable `depth` and a tiny "ecvittest" preset for fast tests.
 """
 
 from __future__ import annotations

--- a/src/lightly_train/_models/ecvit/ecvit_package.py
+++ b/src/lightly_train/_models/ecvit/ecvit_package.py
@@ -57,6 +57,12 @@ MODEL_NAME_TO_INFO: dict[str, _ECViTModelInfo] = {
         local_path="ecvits.pth",
         list=True,
     ),
+    "_ecvittest-notpretrained": _ECViTModelInfo(
+        preset_name="ecvittest",
+        default_weights=None,
+        local_path=None,
+        list=False,
+    ),
     "ecvitsplus": _ECViTModelInfo(
         preset_name="ecvitsplus",
         default_weights=ECVIT_PRETRAINED_URLS["ecvitsplus"],

--- a/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
+++ b/src/lightly_train/_task_models/ltdetr_instance_segmentation/config.py
@@ -72,6 +72,19 @@ class HybridEncoderConfig(PydanticConfig):
 
 
 class LTDETRHybridEncoderConfig(ConfigsNamespace):
+    class ViTTest(HybridEncoderConfig):
+        in_channels: list[int] = [8, 8, 8]
+        hidden_dim: int = 8
+        use_encoder_idx: list[int] = [2]
+        num_encoder_layers: int = 1
+        nhead: int = 1
+        dim_feedforward: int = 32
+        dropout: float = 0.0
+        enc_act: str = "gelu"
+        expansion: float = 1.0
+        depth_mult: float = 1.0
+        act: str = "silu"
+
     class ViTTiny(HybridEncoderConfig):
         in_channels: list[int] = [192, 192, 192]
         hidden_dim: int = 192
@@ -127,6 +140,13 @@ class ECSegTransformerConfig(PydanticConfig):
 
 
 class LTDETRECSegTransformerConfig(ConfigsNamespace):
+    class ViTTest(ECSegTransformerConfig):
+        feat_channels: list[int] = [8, 8, 8]
+        hidden_dim: int = 8
+        num_layers: int = 1
+        num_queries: int = 20
+        dim_feedforward: int = 32
+
     class ViTTiny(ECSegTransformerConfig):
         feat_channels: list[int] = [192, 192, 192]
         hidden_dim: int = 192
@@ -155,6 +175,11 @@ class ECSegPostProcessorConfig(PydanticConfig):
     num_top_queries: int = 300
 
 
+class LTDETRECSegPostProcessorConfig(ConfigsNamespace):
+    class ViTTest(ECSegPostProcessorConfig):
+        num_top_queries: int = 20
+
+
 class SegmentorConfig(PydanticConfig):
     backbone_name: str
     hybrid_encoder: HybridEncoderConfig
@@ -170,6 +195,14 @@ class SegmentorConfig(PydanticConfig):
 
 
 class LTDETRBaseConfig(ConfigsNamespace):
+    class ViTTest(SegmentorConfig):
+        hybrid_encoder: HybridEncoderConfig = Field(
+            default_factory=LTDETRHybridEncoderConfig.ViTTest
+        )
+        ecseg_postprocessor: ECSegPostProcessorConfig = Field(
+            default_factory=LTDETRECSegPostProcessorConfig.ViTTest
+        )
+
     class ViTTiny(SegmentorConfig):
         hybrid_encoder: HybridEncoderConfig = Field(
             default_factory=LTDETRHybridEncoderConfig.ViTTiny
@@ -188,6 +221,19 @@ class LTDETRBaseConfig(ConfigsNamespace):
 
 
 class LTDETRv2ConfigRegistry(ConfigsNamespace):
+    @LTDETR_SEG_MODEL_REGISTRY.register("edgecrafter/_ecvittest-ltdetr-seg")
+    class EdgeCrafterECViTTest(LTDETRBaseConfig.ViTTest):
+        backbone_name: str = "edgecrafter/_ecvittest-notpretrained"
+        transformer: ECSegTransformerConfig = Field(
+            default_factory=LTDETRECSegTransformerConfig.ViTTest
+        )
+        backbone_wrapper: ECViTBackboneWrapperConfig = Field(
+            default_factory=ECViTBackboneWrapperConfig
+        )
+        backbone_args: dict[str, Any] = Field(
+            default_factory=lambda: {"patch_size": 16}
+        )
+
     @LTDETR_SEG_MODEL_REGISTRY.register(
         "edgecrafter/ecvitt-ltdetr-seg",
         ModelAlias(

--- a/src/lightly_train/_task_models/ltdetr_object_detection/config.py
+++ b/src/lightly_train/_task_models/ltdetr_object_detection/config.py
@@ -1099,6 +1099,20 @@ class LTDETRConfigRegistry(ConfigsNamespace):
 
 
 class LTDETRv2ConfigRegistry(ConfigsNamespace):
+    @LTDETR_MODEL_REGISTRY.register("dinov2/_vittest14-ltdetrv2")
+    class ViTTestV2(LTDETRBaseConfig.ViTTest):
+        version: Literal["v2"] = "v2"
+        backbone_name: str = "dinov2/_vittest14"
+        transformer: RTDETRTransformerv2Config | DFINETransformerConfig = Field(
+            default_factory=LTDETRDFINETransformerConfig.ViTTest
+        )
+        backbone_wrapper: RTDETRBackboneWrapperConfig = Field(
+            default_factory=LTDETRRTDETRNoSTABackboneWrapperConfig.ViTTest
+        )
+        backbone_args: dict[str, Any] = Field(
+            default_factory=lambda: {"patch_size": 14, "drop_path_rate": 0.0}
+        )
+
     @LTDETR_MODEL_REGISTRY.register(
         "edgecrafter/ecvitt-ltdetr",
         ModelAlias(

--- a/templates/train_object_detection.jinja2
+++ b/templates/train_object_detection.jinja2
@@ -6,7 +6,7 @@ lightly_train.train_object_detection(
 
     # Output
     ## Output directory where checkpoints, logs, and exported models are written.
-    out="{{ out }}",
+    out="{{ out|replace('\\', '\\\\') }}",
     ## Whether to overwrite the output directory if it already exists.
     overwrite={{ overwrite|default(False) }},
 
@@ -17,15 +17,15 @@ lightly_train.train_object_detection(
         "format": "coco",
         "train": {
             # Path to the training annotations file in COCO format.
-            "annotations": "{{ train_annotations }}",
+            "annotations": "{{ train_annotations|replace('\\', '\\\\') }}",
             # Path to the training images directory. Defaults to None (inferred from annotations).
-            "images": {% if train_images %}"{{ train_images }}"{% else %}None{% endif %}
+            "images": {% if train_images %}"{{ train_images|replace('\\', '\\\\') }}"{% else %}None{% endif %}
         },
         "val": {
             # Path to the validation annotations file in COCO format.
-            "annotations": "{{ val_annotations }}",
+            "annotations": "{{ val_annotations|replace('\\', '\\\\') }}",
             # Path to the validation images directory. Defaults to None (inferred from annotations).
-            "images": {% if val_images %}"{{ val_images }}"{% else %}None{% endif %}
+            "images": {% if val_images %}"{{ val_images|replace('\\', '\\\\') }}"{% else %}None{% endif %}
         },
         # Skip images that have no matching annotations instead of raising an error.
         "skip_if_annotations_missing": {{ skip_if_annotations_missing|default(True) }},

--- a/tests/_commands/test_predict_task.py
+++ b/tests/_commands/test_predict_task.py
@@ -20,7 +20,7 @@ from .. import helpers
 is_self_hosted_docker_runner = "GH_RUNNER_NAME" in os.environ
 
 
-def create_dinov2_vits14_eomt_test_checkpoint(
+def create_dinov2_vittest14_eomt_test_checkpoint(
     directory: Path, num_channels: int = 3
 ) -> Path:
     out = directory / "out"
@@ -50,7 +50,8 @@ def create_dinov2_vits14_eomt_test_checkpoint(
                 1: "car",
             },
         },
-        model="dinov2/vits14-eomt",
+        model="dinov2/_vittest14-eomt",
+        model_args={"num_joint_blocks": 1},
         transform_args={"num_channels": num_channels},
         # The operator 'aten::upsample_bicubic2d.out' raises a NotImplementedError
         # on macOS with MPS backend.
@@ -67,17 +68,17 @@ def create_dinov2_vits14_eomt_test_checkpoint(
 
 
 @pytest.fixture(scope="module")
-def dinov2_vits14_eomt_checkpoint(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def dinov2_vittest14_eomt_checkpoint(tmp_path_factory: pytest.TempPathFactory) -> Path:
     tmp = tmp_path_factory.mktemp("tmp")
-    return create_dinov2_vits14_eomt_test_checkpoint(directory=tmp)
+    return create_dinov2_vittest14_eomt_test_checkpoint(directory=tmp)
 
 
 @pytest.fixture(scope="module")
-def dinov2_vits14_eomt_4_channels_checkpoint(
+def dinov2_vittest14_eomt_4_channels_checkpoint(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Path:
     tmp = tmp_path_factory.mktemp("tmp")
-    return create_dinov2_vits14_eomt_test_checkpoint(directory=tmp, num_channels=4)
+    return create_dinov2_vittest14_eomt_test_checkpoint(directory=tmp, num_channels=4)
 
 
 @pytest.mark.skipif(
@@ -92,8 +93,8 @@ def dinov2_vits14_eomt_4_channels_checkpoint(
 def test_predict_semantic_segmentation(
     tmp_path: Path,
     num_channels: int,
-    dinov2_vits14_eomt_checkpoint: Path,
-    dinov2_vits14_eomt_4_channels_checkpoint: Path,
+    dinov2_vittest14_eomt_checkpoint: Path,
+    dinov2_vittest14_eomt_4_channels_checkpoint: Path,
 ) -> None:
     out = tmp_path / "out"
     data = tmp_path / "data"
@@ -103,8 +104,8 @@ def test_predict_semantic_segmentation(
     helpers.create_images(data, num_channels=num_channels, mode=mode, files=num_images)
 
     checkpoint_path = {
-        3: dinov2_vits14_eomt_checkpoint,
-        4: dinov2_vits14_eomt_4_channels_checkpoint,
+        3: dinov2_vittest14_eomt_checkpoint,
+        4: dinov2_vittest14_eomt_4_channels_checkpoint,
     }[num_channels]
 
     lightly_train.predict_semantic_segmentation(

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -101,7 +101,7 @@ def test_train_image_classification__multiclass(tmp_path: Path) -> None:
         },
         steps=2,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         devices=1,
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
     )
@@ -149,7 +149,7 @@ def test_train_image_classification__multilabel(tmp_path: Path) -> None:
         },
         steps=2,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         devices=1,
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
     )
@@ -199,9 +199,9 @@ def test_train_image_classification_multihead(
         model_args={
             "lr": [0.001, 0.01, 0.1],
         },
-        steps=10,
+        steps=2,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         devices=1,
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
     )
@@ -218,7 +218,11 @@ def test_train_image_classification_multihead(
     assert model is not None
 
 
+@pytest.mark.long_running_test
 def test_train_object_detection_yolo(tmp_path: Path) -> None:
+    """Kept with real DataLoader workers (num_workers=2) so the suite retains
+    coverage of the multi-worker code path; excluded from fast CI because worker
+    process spawn dominates its runtime, especially on Windows."""
     out = tmp_path / "out"
     data = tmp_path / "data"
     # Create dataset with 4 files, including one without a label file (index 2) and
@@ -313,7 +317,7 @@ def test_train_instance_segmentation(
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,
     )
     assert out.exists()
@@ -375,7 +379,7 @@ def test_train_panoptic_segmentation(
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,
     )
     assert out.exists()
@@ -436,7 +440,7 @@ def test_train_panoptic_segmentation__dinov2(
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,
     )
     assert out.exists()
@@ -514,7 +518,7 @@ def test_train_semantic_segmentation(
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,
         transform_args={
             "num_channels": num_channels,
@@ -621,7 +625,7 @@ def test_train_semantic_segmentation__dicom(
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,
         transform_args={
             "num_channels": num_channels,
@@ -682,7 +686,7 @@ def test_train_semantic_segmentation__export(
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,
         transform_args={
             "num_channels": num_channels,
@@ -934,14 +938,14 @@ def test_train_semantic_segmentation_multihead__integration__runs_with_multiple_
                 1: "car",
             },
         },
-        model="dinov2/vits14",  # Use smallest standard model for fast testing
+        model="dinov2/_vittest14",  # Tiny test-only model for fast testing
         model_args={
             "lr": [0.001, 0.01],  # Test with two learning rates
         },
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,
         batch_size=2,
-        num_workers=2,
+        num_workers=0,
         steps=2,  # Minimal steps for fast test
     )
 

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -245,7 +245,7 @@ def test_train_object_detection_yolo(tmp_path: Path, num_workers: int) -> None:
     # Check training
     lightly_train.train_object_detection(
         out=out,
-        model="_ltdetrv2-s-notpretrained",
+        model="dinov2/_vittest14-ltdetrv2",
         data={
             "path": data,
             "train": Path("train", "images"),
@@ -319,7 +319,7 @@ def test_train_instance_segmentation(
             "train": {"annotations": str(data / "train.json"), "images": "train"},
             "val": {"annotations": str(data / "val.json"), "images": "val"},
         },
-        model="_ltdetrv2-seg-s-notpretrained",
+        model="edgecrafter/_ecvittest-ltdetr-seg",
         model_args={"scheduler_name": "linear"},
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
         devices=1,

--- a/tests/_commands/test_train_task.py
+++ b/tests/_commands/test_train_task.py
@@ -218,11 +218,18 @@ def test_train_image_classification_multihead(
     assert model is not None
 
 
-@pytest.mark.long_running_test
-def test_train_object_detection_yolo(tmp_path: Path) -> None:
-    """Kept with real DataLoader workers (num_workers=2) so the suite retains
-    coverage of the multi-worker code path; excluded from fast CI because worker
-    process spawn dominates its runtime, especially on Windows."""
+@pytest.mark.parametrize(
+    "num_workers",
+    [
+        0,
+        # num_workers=2 exercises the real multi-worker DataLoader code path,
+        # but worker process spawn dominates its runtime (especially on
+        # Windows), so it's excluded from fast CI via long_running_test.
+        pytest.param(2, marks=pytest.mark.long_running_test),
+    ],
+    ids=["fast", "multi_worker_dataloader"],
+)
+def test_train_object_detection_yolo(tmp_path: Path, num_workers: int) -> None:
     out = tmp_path / "out"
     data = tmp_path / "data"
     # Create dataset with 4 files, including one without a label file (index 2) and
@@ -253,7 +260,7 @@ def test_train_object_detection_yolo(tmp_path: Path) -> None:
         },
         steps=2,
         batch_size=2,
-        num_workers=2,
+        num_workers=num_workers,
         devices=1,
         accelerator="auto" if not sys.platform.startswith("darwin") else "cpu",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,18 +53,11 @@ def lightly_train_cache_dir(
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "long_running_test: marks tests as long running (skipped on GitHub CI)",
+        "long_running_test: marks tests as long running. Excluded from "
+        "test-ci-minimal/test-ci-maximal via '-m \"not long_running_test\"', but "
+        "still run by 'make test' and by the unfiltered nightly CI in "
+        "lightly-train-private.",
     )
-
-
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
-    if os.environ.get("GITHUB_ACTIONS"):
-        skip_long = pytest.mark.skip(reason="long running test, skipped on Github CI")
-        for item in items:
-            if "long_running_test" in item.keywords:
-                item.add_marker(skip_long)
 
 
 @pytest.fixture(autouse=True)  # Apply to all tests

--- a/tests/templates/test_train_object_detection.py
+++ b/tests/templates/test_train_object_detection.py
@@ -5,15 +5,13 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 #
-import sys
 from pathlib import Path
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
+from pytest_mock import MockerFixture
 
 from lightly_train._commands.train_task import TORCHMETRICS_SUPPORTED
-
-from .. import helpers
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
 
@@ -159,21 +157,33 @@ class TestTrainObjectDetectionTemplate:
         compile(result, "<template>", "exec")
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
 @skip_if_old_torchmetrics
-def test_rendered_template_runs_training_with_defaults(tmp_path: Path) -> None:
-    """Integration test: render with default parameters (except model) and run."""
+def test_rendered_template_runs_training_with_defaults(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Verify the rendered-and-exec'd template calls train_object_detection with
+    the exact resolved arguments.
+
+    This mocks train_object_detection instead of running real training: the
+    string-based render tests above already cover that the template renders
+    correctly, and tests/_commands/test_train_task.py already covers that
+    training itself works. What's unique here is verifying the generated
+    *code*, once exec'd, actually wires arguments through to the real API
+    correctly -- which this checks more strongly than the previous
+    file-existence assertions did.
+    """
     data = tmp_path / "data"
     out = tmp_path / "out"
-    helpers.create_coco_object_detection_dataset(data, num_files=4)
 
-    template_args = dict(
+    result = _render(
         out=str(out),
         train_annotations=str(data / "train.json"),
         train_images=str(data / "train"),
         val_annotations=str(data / "val.json"),
         val_images=str(data / "val"),
-        # Override model, steps, batch_size, num_workers, and devices to keep the test fast.
+        # Override model, steps, batch_size, num_workers, and devices to verify
+        # they are threaded through; everything else should fall back to the
+        # template's defaults.
         model="dinov3/vitt16-notpretrained-ltdetr",
         model_args={
             "scheduler_name": "linear",
@@ -183,25 +193,57 @@ def test_rendered_template_runs_training_with_defaults(tmp_path: Path) -> None:
         num_workers=2,
         devices=1,
     )
-    if sys.platform.startswith("darwin"):
-        template_args["accelerator"] = "cpu"
 
-    result = _render(**template_args)
-
+    mock_train = mocker.patch("lightly_train.train_object_detection")
     exec(compile(result, "<template>", "exec"))
 
-    assert out.exists()
-    assert (out / "train.log").exists()
-    assert (out / "exported_models" / "exported_last.pt").exists()
+    mock_train.assert_called_once_with(
+        out=str(out),
+        overwrite=False,
+        data={
+            "format": "coco",
+            "train": {
+                "annotations": str(data / "train.json"),
+                "images": str(data / "train"),
+            },
+            "val": {
+                "annotations": str(data / "val.json"),
+                "images": str(data / "val"),
+            },
+            "skip_if_annotations_missing": True,
+        },
+        batch_size=2,
+        num_workers=2,
+        model="dinov3/vitt16-notpretrained-ltdetr",
+        model_args={"scheduler_name": "linear"},
+        steps=2,
+        precision="bf16-mixed",
+        seed=0,
+        devices=1,
+        accelerator="auto",
+        num_nodes=1,
+        strategy="auto",
+        resume_interrupted=False,
+        save_checkpoint_args=None,
+        logger_args=None,
+        transform_args=None,
+        metric_args=None,
+        torch_compile_args=None,
+    )
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Slow on windows")
 @skip_if_old_torchmetrics
-def test_rendered_template_runs_training_with_all_params(tmp_path: Path) -> None:
-    """Integration test: render with all parameters set explicitly and run."""
+def test_rendered_template_runs_training_with_all_params(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Verify the rendered-and-exec'd template calls train_object_detection with
+    the exact resolved arguments when every parameter is set explicitly.
+
+    See test_rendered_template_runs_training_with_defaults for why this mocks
+    train_object_detection instead of running real training.
+    """
     data = tmp_path / "data"
     out = tmp_path / "out"
-    helpers.create_coco_object_detection_dataset(data, num_files=4)
 
     result = _render(
         out=str(out),
@@ -232,8 +274,39 @@ def test_rendered_template_runs_training_with_all_params(tmp_path: Path) -> None
         torch_compile_args={"disable": True},
     )
 
+    mock_train = mocker.patch("lightly_train.train_object_detection")
     exec(compile(result, "<template>", "exec"))
 
-    assert out.exists()
-    assert (out / "train.log").exists()
-    assert (out / "exported_models" / "exported_last.pt").exists()
+    mock_train.assert_called_once_with(
+        out=str(out),
+        overwrite=False,
+        data={
+            "format": "coco",
+            "train": {
+                "annotations": str(data / "train.json"),
+                "images": str(data / "train"),
+            },
+            "val": {
+                "annotations": str(data / "val.json"),
+                "images": str(data / "val"),
+            },
+            "skip_if_annotations_missing": True,
+        },
+        batch_size=2,
+        num_workers=2,
+        model="dinov3/vitt16-notpretrained-ltdetr",
+        model_args={"scheduler_name": "linear"},
+        steps=2,
+        precision="32",
+        seed=42,
+        devices=1,
+        accelerator="cpu",
+        num_nodes=1,
+        strategy="auto",
+        resume_interrupted=False,
+        save_checkpoint_args={"save_last": True},
+        logger_args={"log_every_num_steps": 1},
+        transform_args={"image_size": "auto"},
+        metric_args={"classwise": False},
+        torch_compile_args={"disable": True},
+    )


### PR DESCRIPTION
## Summary
CI-log analysis (`--durations=20` across 8 recent successful `main` runs) showed a handful of tests dominating `test_unit.yml`/`test_unit_minimal_dependencies.yml` wall-clock, led by `test_train_object_detection_yolo` (~300s avg, ~490s specifically on `windows-latest`). Rather than just deferring slow tests to nightly, this fixes the actual root causes:

- **`num_workers=2` → `0`** across ~10 training integration tests in `test_train_task.py`. These use 2-4 image synthetic datasets, so real parallel loading buys nothing — it only pays for DataLoader worker process spawn, which is especially expensive on `windows-latest` (`spawn` reimports torch/lightning per worker vs. Linux `fork`).
- **Swapped two tests off real production-size DINOv2 backbones** (`dinov2/vits14`, `dinov2/vits14-eomt`) onto the tiny `dinov2/_vittest14`/`-eomt` test doubles every sibling test in the same files already uses, for identical coverage.
- **`test_train_image_classification_multihead`**: `steps=10` → `steps=2`, matching every other training test in the file.
- **Template-rendering tests** (`test_rendered_template_runs_training_with_{defaults,all_params}`) no longer run a full real training loop just to prove the Jinja2-generated code is wired correctly. They now mock `lightly_train.train_object_detection` and assert it's called with the exact resolved kwargs — a stronger check than the previous file-existence asserts, at near-zero cost. This also removes the existing Windows skip on these two tests, since they're fast enough to run everywhere now.
- **Added toy LTDETRv2 test models for object detection and instance segmentation.** `test_train_instance_segmentation` (~219s) and `test_train_object_detection_yolo[fast]` (~109s) were still dominating wall-clock after the fixes above, because their `"-notpretrained"` models only skip downloading pretrained *weights* — the backbone architecture was still the real production `edgecrafter/ecvitt` (12 layers, embed_dim=192), unlike every sibling test which already uses a genuinely tiny test double. Fixed by:
  - Wiring up `dinov2/_vittest14-ltdetrv2` in the object detection model registry, reusing the existing (previously unused) toy DFINE transformer config.
  - Adding a new tiny `"ecvittest"` ECViT preset (depth=2, embed_dim=8) plus matching toy transformer/postprocessor configs, registered as `edgecrafter/_ecvittest-ltdetr-seg` — instance segmentation had no toy model at all, so this also required exposing `depth`/`interaction_indexes` as preset-resolvable fields on `ECViTModelWrapper`.
  - Both slow tests now use these toy models with identical assertions and run in single-digit seconds.

One test is intentionally kept expensive: `test_train_object_detection_yolo` stays at `num_workers=2` and is marked `@pytest.mark.long_running_test`, so the suite retains real multi-worker DataLoader coverage somewhere — it's just not paid on every PR.

Also fixes an alignment bug: `tests/conftest.py` previously auto-skipped `long_running_test`-marked tests whenever `GITHUB_ACTIONS` was set, which is true in `lightly-train-private`'s cron runs too — so the one existing marked test never actually ran anywhere. It's now driven explicitly via `-m "not long_running_test"` in the `test-ci-minimal`/`test-ci-maximal` Makefile targets; `lightly-train-private`'s workflows call `pytest tests` directly (no `-m` filter), so they're unaffected and will now actually exercise `long_running_test`-marked tests.

## Measured impact (local, Apple Silicon — not directly comparable to CI runners but indicative)
| Test | Before | After |
|---|---|---|
| `test_rendered_template_runs_training_with_defaults` + `_with_all_params` | ~250s combined (CI avg) | <6s combined |
| `test_predict_semantic_segmentation` (both params) | ~135s avg (CI) | ~17s each |
| `test_train_semantic_segmentation_multihead__integration__runs_with_multiple_heads` | ~126s avg (CI) | ~8.5s |
| `test_train_image_classification_multihead` | ~92s avg (CI) | ~2.6s |
| `test_train_instance_segmentation` | ~207s avg (CI, ubuntu) | ~7s (toy model) |
| `test_train_object_detection_yolo[fast]` | ~109s avg (CI) | ~4.3s (toy model) |

## Test plan
- [x] `pytest tests/templates/test_train_object_detection.py -v` — 9 passed
- [x] `pytest tests/_commands/test_predict_task.py -v` — 2 passed
- [x] `pytest tests/_commands/test_train_task.py -m "not long_running_test" -v` — 52 passed, 1 deselected
- [x] `pytest tests -m long_running_test --collect-only` — confirms exactly the intended 2 tests are selected (`test_train_object_detection_yolo` + the pre-existing `dinov3_eomt_panoptic_segmentation` marked test)
- [x] `pytest tests -m "not long_running_test" --collect-only` — confirms those 2 are the only ones deselected
- [x] `pytest tests/_commands/test_train_task.py::test_train_object_detection_yolo tests/_commands/test_train_task.py::test_train_instance_segmentation -v` — 3 passed (fast/multi_worker_dataloader/instance_segmentation), durations dropped as shown above
- [x] `pytest tests/_task_models/ltdetr_object_detection/ tests/_task_models/ltdetr_instance_segmentation/ -m "not long_running_test"` — 173 passed, 5 skipped, no regressions
- [x] `pytest tests/_models/ecvit/` — 17 passed, 5 skipped, existing (non-toy) presets unaffected
- [x] `make static-checks` (ruff, mypy, pre-commit) — passes
- [ ] Confirm actual CI wall-clock improvement on `ubuntu-latest`/`windows-latest` once this PR's `test_unit.yml`/`test_unit_minimal_dependencies.yml` runs complete
- [ ] Recommended: manually trigger `lightly-train-private`'s `test_unit.yml` via `workflow_dispatch` with `branch: lionel/speed-up-unit-test-ci`, to confirm `long_running_test`-marked tests are now actually collected and run there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a3xFdJ9APo3ysAGxJREiN
