### PR TITLE
ci: add auto-approve workflow and fix required checks on skipped pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
-# A GitHub App cannot be a code owner, so the Auto Approve bot can satisfy the required
-# approval count but never a code-owner review. This keeps CI behind a human.
+# A GitHub App cannot be a code owner, so the Auto Approve bot can never approve a change
+# in here. Everything under .github/ needs a review from a real person.
 #
-# CI alone cannot vet a change here: the test workflows exclude '.github/**' from their
-# path filters, and a job skipped that way reports to the ruleset as successful.
+# CI cannot catch a bad change here either: the test workflows ignore '.github/**', and a
+# job that is skipped for that reason still reports as successful.
 #
-# The whole directory, not just auto_approve.yml: otherwise a pull request could add a
-# new workflow that approves itself. GitHub reads this file from the base branch, so a
-# pull request cannot edit away its own protection.
+# The whole directory is listed, not just auto_approve.yml, because otherwise a pull
+# request could add a new workflow that approves itself. GitHub reads this file from the
+# base branch, so a pull request cannot turn off its own protection.
 #
 # Keep in sync with the allowlist in .github/workflows/auto_approve.yml.
 /.github/   @IgorSusmelj @mrpositron @gabrielfruet @liopeer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # A GitHub App cannot be a code owner, so the Auto Approve bot can satisfy the required
 # approval count but never a code-owner review. This keeps CI behind a human.
 #
+# CI alone cannot vet a change here: the test workflows exclude '.github/**' from their
+# path filters, and a job skipped that way reports to the ruleset as successful.
+#
 # The whole directory, not just auto_approve.yml: otherwise a pull request could add a
 # new workflow that approves itself. GitHub reads this file from the base branch, so a
 # pull request cannot edit away its own protection.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,9 @@
-# Locations that need a human review from one of the maintainers below.
+# A GitHub App cannot be a code owner, so the Auto Approve bot can satisfy the required
+# approval count but never a code-owner review. This keeps CI behind a human.
 #
-# A GitHub App cannot be a code owner, so the Auto Approve bot's approval can satisfy the
-# required-approval count but never the code-owner requirement on these paths. GitHub also
-# reads this file from the base branch, so a pull request cannot remove its own protection
-# by editing it here -- and /.github/ covers this file itself.
+# The whole directory, not just auto_approve.yml: otherwise a pull request could add a
+# new workflow that approves itself. GitHub reads this file from the base branch, so a
+# pull request cannot edit away its own protection.
 #
-# The whole directory rather than just auto_approve.yml: otherwise a pull request could
-# add a new workflow that approves itself.
-#
-# Keep this list in sync with the allowlist in .github/workflows/auto_approve.yml.
+# Keep in sync with the allowlist in .github/workflows/auto_approve.yml.
 /.github/   @IgorSusmelj @mrpositron @gabrielfruet @liopeer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,13 @@
-# A GitHub App cannot be a code owner, so the Auto Approve bot can never approve a change
-# in here. Everything under .github/ needs a review from a real person.
+# A GitHub App cannot be a code owner. As a result, the Auto Approve bot cannot approve a
+# change in this directory. Each change here needs a review from a person.
 #
-# CI cannot catch a bad change here either: the test workflows ignore '.github/**', and a
-# job that is skipped for that reason still reports as successful.
+# CI cannot find a bad change here. The test workflows do not run for '.github/**'. A job
+# that GitHub skips reports a success to the branch ruleset.
 #
-# The whole directory is listed, not just auto_approve.yml, because otherwise a pull
-# request could add a new workflow that approves itself. GitHub reads this file from the
-# base branch, so a pull request cannot turn off its own protection.
+# The rule is for the full directory, not only for auto_approve.yml. A rule for one file
+# is not sufficient, because a pull request can add a different workflow that approves
+# itself. GitHub reads this file from the base branch. As a result, a pull request cannot
+# remove its own protection.
 #
-# Keep in sync with the allowlist in .github/workflows/auto_approve.yml.
+# Keep this list equal to the allowlist in .github/workflows/auto_approve.yml.
 /.github/   @IgorSusmelj @mrpositron @gabrielfruet @liopeer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Locations that need a human review from one of the maintainers below.
+#
+# A GitHub App cannot be a code owner, so the Auto Approve bot's approval can satisfy the
+# required-approval count but never the code-owner requirement on these paths. GitHub also
+# reads this file from the base branch, so a pull request cannot remove its own protection
+# by editing it here -- and /.github/ covers this file itself.
+#
+# The whole directory rather than just auto_approve.yml: otherwise a pull request could
+# add a new workflow that approves itself.
+#
+# Keep this list in sync with the allowlist in .github/workflows/auto_approve.yml.
+/.github/   @IgorSusmelj @mrpositron @gabrielfruet @liopeer

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,20 +1,14 @@
 name: Auto Approve
 
-# Approve pull requests opened by an allowlisted maintainer, so they can use GitHub's
-# "Enable auto-merge" instead of waiting for a review. Only the approval requirement is
-# satisfied, all required status checks still have to pass. See CONTRIBUTING.md.
-#
-# The allowlist keys on the pull request author, not on paths. CODEOWNERS cannot do this:
-# it requires approval *from* an owner, who cannot approve their own pull request. It is
-# used for the opposite job in .github/CODEOWNERS, which keeps this workflow and the rest
-# of .github/ behind a human review.
+# Approve pull requests from allowlisted maintainers so they can use "Enable auto-merge".
+# This satisfies the approval requirement only, all required checks still have to pass.
+# .github/CODEOWNERS keeps this workflow and the rest of .github/ behind a human review.
 
 on:
   pull_request_target:
-    # No `synchronize`: the branch ruleset sets `dismiss_stale_reviews_on_push: false` and
-    # `require_last_push_approval: false`, so an approval stays valid across pushes and
-    # re-running on every push would only risk re-approving one a human dismissed. Revisit
-    # this if either of those settings is ever enabled.
+    # No `synchronize`: the branch ruleset keeps approvals valid across pushes, so
+    # re-running would only risk re-approving one a human dismissed. Revisit if
+    # `dismiss_stale_reviews_on_push` or `require_last_push_approval` is ever enabled.
     types:
       - opened
       - reopened
@@ -30,10 +24,10 @@ concurrency:
 jobs:
   auto-approve:
     name: Auto Approve
-    # This workflow runs on `pull_request_target` and therefore has access to secrets.
-    # Do NOT check out or execute pull request code here.
+    # Runs on `pull_request_target` and therefore has access to secrets. Do NOT check
+    # out or execute pull request code here.
     #
-    # Keep the continuation lines indented exactly as they are: a more-indented line in a
+    # Keep the continuation line indented exactly as it is: a more-indented line in a
     # `>-` block keeps its newline and breaks the expression.
     if: >-
       github.event.pull_request.draft == false &&
@@ -54,10 +48,7 @@ jobs:
       - name: Approve Pull Request
         uses: actions/github-script@v9
         env:
-          # The App's own slug, never attacker-controlled. Passed via env anyway, so that
-          # no `${{ }}` interpolation appears inside `script:` at all. Everything else the
-          # script needs comes from `context.payload`, where pull request values are plain
-          # JavaScript strings that are never re-parsed as code.
+          # Passed via env so that no `${{ }}` interpolation appears inside `script:`.
           BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -71,9 +62,8 @@ jobs:
             });
             const mine = reviews.filter((r) => r.user?.login === botLogin);
 
-            // Branch protection does not dismiss reviews on push here, so DISMISSED means
-            // a human revoked the approval to force a real review. Re-approving would
-            // undo that.
+            // Reviews are not dismissed on push here, so DISMISSED means a human
+            // revoked the approval to force a real review.
             if (mine.some((r) => r.state === "DISMISSED")) {
               core.info(`An approval by ${botLogin} was dismissed; leaving this pull request to a human.`);
               return;

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,22 +1,27 @@
 name: Auto Approve
 
-# Approve pull requests from the maintainers listed below, so they can use
-# "Enable auto-merge". This only ticks off the approval requirement, all required checks
-# still have to pass. Changes to this workflow itself always need a human review, see
-# .github/CODEOWNERS.
+# This workflow approves pull requests from the maintainers in the list below. Then these
+# maintainers can use "Enable auto-merge".
+#
+# The approval is the only requirement that this workflow satisfies. All required checks
+# must pass before a merge.
+#
+# A change to this workflow always needs a review from a person. See .github/CODEOWNERS.
 
 on:
   pull_request_target:
-    # `synchronize` (new commits pushed) is missing on purpose: approvals stay valid
-    # when someone pushes, so running again would only risk re-approving a pull request
-    # after a human removed the approval. Add it if the branch ruleset ever turns on
-    # `dismiss_stale_reviews_on_push` or `require_last_push_approval`.
+    # The list does not contain `synchronize`, the event for a new push. An approval
+    # stays valid after a push. A second run can only approve a pull request again after
+    # a person removed the approval.
+    #
+    # Add `synchronize` if the branch ruleset gets `dismiss_stale_reviews_on_push` or
+    # `require_last_push_approval`.
     types:
       - opened
       - reopened
       - ready_for_review
 
-# No permissions for the default token. Everything uses the App token created below.
+# The default token gets no permissions. All steps use the App token from the first step.
 permissions: {}
 
 concurrency:
@@ -26,11 +31,11 @@ concurrency:
 jobs:
   auto-approve:
     name: Auto Approve
-    # This runs on `pull_request_target`, which means it can read secrets. Never check
-    # out or run code from the pull request here.
+    # This job runs on `pull_request_target` and can read the repository secrets. Do not
+    # check out the code of the pull request. Do not run the code of the pull request.
     #
-    # Don't indent the second line of the `if` any further: in a `>-` block an extra
-    # indented line keeps its line break, which breaks the expression.
+    # Do not add more indentation to the second line of the `if`. In a `>-` block, a line
+    # with more indentation keeps its line break and breaks the expression.
     if: >-
       github.event.pull_request.draft == false &&
       contains(fromJSON('["IgorSusmelj", "mrpositron", "gabrielfruet", "liopeer"]'), github.event.pull_request.user.login)
@@ -41,8 +46,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          # Org-level secrets of the `lightly-fast-track-bot` App. Also used by
-          # lightly-studio.
+          # Organization secrets of the `lightly-fast-track-bot` App. The lightly-studio
+          # repository uses the same App.
           app-id: ${{ secrets.FAST_TRACK_APP_ID }}
           private-key: ${{ secrets.FAST_TRACK_APP_PRIVATE_KEY }}
           permission-pull-requests: write
@@ -50,8 +55,8 @@ jobs:
       - name: Approve Pull Request
         uses: actions/github-script@v9
         env:
-          # Passed as an env variable. Never write `${{ }}` inside `script:`, GitHub
-          # pastes the value straight into the code.
+          # The value comes from an environment variable. Do not write `${{ }}` in
+          # `script:`. GitHub puts the value directly into the code.
           BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -65,14 +70,14 @@ jobs:
             });
             const mine = reviews.filter((r) => r.user?.login === botLogin);
 
-            // Nothing dismisses reviews automatically, so a dismissed review means a
-            // human removed our approval on purpose. Don't approve again.
+            // No rule dismisses a review automatically. As a result, a dismissed review
+            // means that a person removed the approval. Do not approve a second time.
             if (mine.some((r) => r.state === "DISMISSED")) {
               core.info(`An approval by ${botLogin} was dismissed; leaving this pull request to a human.`);
               return;
             }
-            // `reopened` and `ready_for_review` can happen more than once per pull
-            // request, so we might have approved already.
+            // The events `reopened` and `ready_for_review` can occur more than one time
+            // for a pull request. An approval from an earlier run can exist.
             if (mine.some((r) => r.state === "APPROVED")) {
               core.info(`Already approved by ${botLogin}; nothing to do.`);
               return;

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -5,15 +5,20 @@ name: Auto Approve
 # satisfied, all required status checks still have to pass. See CONTRIBUTING.md.
 #
 # The allowlist keys on the pull request author, not on paths. CODEOWNERS cannot do this:
-# it requires approval *from* an owner, who cannot approve their own pull request.
+# it requires approval *from* an owner, who cannot approve their own pull request. It is
+# used for the opposite job in .github/CODEOWNERS, which keeps this workflow and the rest
+# of .github/ behind a human review.
 
 on:
   pull_request_target:
+    # No `synchronize`: the branch ruleset sets `dismiss_stale_reviews_on_push: false` and
+    # `require_last_push_approval: false`, so an approval stays valid across pushes and
+    # re-running on every push would only risk re-approving one a human dismissed. Revisit
+    # this if either of those settings is ever enabled.
     types:
       - opened
       - reopened
       - ready_for_review
-      - synchronize
 
 # All permissions come from the App token minted below.
 permissions: {}
@@ -27,6 +32,9 @@ jobs:
     name: Auto Approve
     # This workflow runs on `pull_request_target` and therefore has access to secrets.
     # Do NOT check out or execute pull request code here.
+    #
+    # Keep the continuation lines indented exactly as they are: a more-indented line in a
+    # `>-` block keeps its newline and breaks the expression.
     if: >-
       github.event.pull_request.draft == false &&
       contains(fromJSON('["IgorSusmelj", "mrpositron", "gabrielfruet", "liopeer"]'), github.event.pull_request.user.login)
@@ -44,41 +52,47 @@ jobs:
           permission-pull-requests: write
 
       - name: Approve Pull Request
+        uses: actions/github-script@v9
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # The App's own slug, never attacker-controlled. Passed via env anyway, so that
+          # no `${{ }}` interpolation appears inside `script:` at all. Everything else the
+          # script needs comes from `context.payload`, where pull request values are plain
+          # JavaScript strings that are never re-parsed as code.
           BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
-          # Passed via env rather than inline `${{ }}` to avoid script injection.
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          set -euo pipefail
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const botLogin = process.env.BOT_LOGIN;
 
-          # `synchronize` fires on every push, so skip when this App already has an
-          # active approval rather than stacking duplicate reviews. The full id list is
-          # captured before taking the first line, piping `gh` into `head -1` would kill
-          # it with SIGPIPE and fail the step under `pipefail`.
-          approvals=$(
-            gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-              --jq ".[] | select(.user.login == \"${BOT_LOGIN}\" and .state == \"APPROVED\") | .id"
-          )
-          if [ -n "${approvals}" ]; then
-            echo "Already approved by ${BOT_LOGIN} (review $(printf '%s\n' "${approvals}" | head -1)); nothing to do."
-            exit 0
-          fi
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              ...context.repo,
+              pull_number: pr.number,
+            });
+            const mine = reviews.filter((r) => r.user?.login === botLogin);
 
-          # Expanding heredoc: the message must not contain backticks or `$` other
-          # than the author.
-          body=$(cat <<EOF
-          Approved automatically: @${PR_AUTHOR} is on the auto-approve allowlist in .github/workflows/auto_approve.yml
+            // Branch protection does not dismiss reviews on push here, so DISMISSED means
+            // a human revoked the approval to force a real review. Re-approving would
+            // undo that.
+            if (mine.some((r) => r.state === "DISMISSED")) {
+              core.info(`An approval by ${botLogin} was dismissed; leaving this pull request to a human.`);
+              return;
+            }
+            // `reopened` and `ready_for_review` can fire more than once.
+            if (mine.some((r) => r.state === "APPROVED")) {
+              core.info(`Already approved by ${botLogin}; nothing to do.`);
+              return;
+            }
 
-          This satisfies the approval requirement only. All required status checks still have to pass before this pull request can merge.
-          EOF
-          )
-
-          gh api --method POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            -f "commit_id=${HEAD_SHA}" \
-            -f "event=APPROVE" \
-            -f "body=${body}"
-          echo "Approved #${PR_NUMBER} at ${HEAD_SHA} as ${BOT_LOGIN}."
+            await github.rest.pulls.createReview({
+              ...context.repo,
+              pull_number: pr.number,
+              commit_id: pr.head.sha,
+              event: "APPROVE",
+              body: [
+                `Approved automatically: @${pr.user.login} is on the auto-approve allowlist in .github/workflows/auto_approve.yml`,
+                "",
+                "This satisfies the approval requirement only. All required status checks still have to pass before this pull request can merge.",
+              ].join("\n"),
+            });
+            core.info(`Approved #${pr.number} at ${pr.head.sha} as ${botLogin}.`);

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,20 +1,22 @@
 name: Auto Approve
 
-# Approve pull requests from allowlisted maintainers so they can use "Enable auto-merge".
-# This satisfies the approval requirement only, all required checks still have to pass.
-# .github/CODEOWNERS keeps this workflow and the rest of .github/ behind a human review.
+# Approve pull requests from the maintainers listed below, so they can use
+# "Enable auto-merge". This only ticks off the approval requirement, all required checks
+# still have to pass. Changes to this workflow itself always need a human review, see
+# .github/CODEOWNERS.
 
 on:
   pull_request_target:
-    # No `synchronize`: the branch ruleset keeps approvals valid across pushes, so
-    # re-running would only risk re-approving one a human dismissed. Revisit if
-    # `dismiss_stale_reviews_on_push` or `require_last_push_approval` is ever enabled.
+    # `synchronize` (new commits pushed) is missing on purpose: approvals stay valid
+    # when someone pushes, so running again would only risk re-approving a pull request
+    # after a human removed the approval. Add it if the branch ruleset ever turns on
+    # `dismiss_stale_reviews_on_push` or `require_last_push_approval`.
     types:
       - opened
       - reopened
       - ready_for_review
 
-# All permissions come from the App token minted below.
+# No permissions for the default token. Everything uses the App token created below.
 permissions: {}
 
 concurrency:
@@ -24,11 +26,11 @@ concurrency:
 jobs:
   auto-approve:
     name: Auto Approve
-    # Runs on `pull_request_target` and therefore has access to secrets. Do NOT check
-    # out or execute pull request code here.
+    # This runs on `pull_request_target`, which means it can read secrets. Never check
+    # out or run code from the pull request here.
     #
-    # Keep the continuation line indented exactly as it is: a more-indented line in a
-    # `>-` block keeps its newline and breaks the expression.
+    # Don't indent the second line of the `if` any further: in a `>-` block an extra
+    # indented line keeps its line break, which breaks the expression.
     if: >-
       github.event.pull_request.draft == false &&
       contains(fromJSON('["IgorSusmelj", "mrpositron", "gabrielfruet", "liopeer"]'), github.event.pull_request.user.login)
@@ -39,8 +41,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          # Organization-level secrets for the `lightly-fast-track-bot` App, shared
-          # with lightly-studio.
+          # Org-level secrets of the `lightly-fast-track-bot` App. Also used by
+          # lightly-studio.
           app-id: ${{ secrets.FAST_TRACK_APP_ID }}
           private-key: ${{ secrets.FAST_TRACK_APP_PRIVATE_KEY }}
           permission-pull-requests: write
@@ -48,7 +50,8 @@ jobs:
       - name: Approve Pull Request
         uses: actions/github-script@v9
         env:
-          # Passed via env so that no `${{ }}` interpolation appears inside `script:`.
+          # Passed as an env variable. Never write `${{ }}` inside `script:`, GitHub
+          # pastes the value straight into the code.
           BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -62,13 +65,14 @@ jobs:
             });
             const mine = reviews.filter((r) => r.user?.login === botLogin);
 
-            // Reviews are not dismissed on push here, so DISMISSED means a human
-            // revoked the approval to force a real review.
+            // Nothing dismisses reviews automatically, so a dismissed review means a
+            // human removed our approval on purpose. Don't approve again.
             if (mine.some((r) => r.state === "DISMISSED")) {
               core.info(`An approval by ${botLogin} was dismissed; leaving this pull request to a human.`);
               return;
             }
-            // `reopened` and `ready_for_review` can fire more than once.
+            // `reopened` and `ready_for_review` can happen more than once per pull
+            // request, so we might have approved already.
             if (mine.some((r) => r.state === "APPROVED")) {
               core.info(`Already approved by ${botLogin}; nothing to do.`);
               return;

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,112 @@
+name: Auto Approve
+
+# Approve pull requests opened by an allowlisted maintainer, so they can use GitHub's
+# "Enable auto-merge" instead of waiting for a review.
+#
+# Why a bot at all: GitHub has no native "required approvals, except for these people"
+# rule, and auto-merge never consumes a ruleset bypass -- a bypass is only spent on an
+# interactive "merge without waiting for requirements" click, which also skips the
+# required status checks. Supplying the approval is the only way to keep CI mandatory
+# while removing the wait.
+#
+# This is deliberately NOT a CODEOWNERS mechanism. CODEOWNERS keys on paths and
+# requires approval *from* an owner (who cannot approve their own pull request), so
+# `* @maintainers` would demand a human on every pull request and a bot approval would
+# never satisfy it -- the opposite of the goal. The allowlist below keys on the pull
+# request *author* instead. Do not add a CODEOWNERS file expecting this to keep working.
+#
+# See CONTRIBUTING.md for what this means for reviews.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+# The App token minted below carries the only permission this workflow needs, so the
+# default token is stripped of all of them.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-approve:
+    name: Auto Approve
+    # Runs on `pull_request_target` so the App credentials are available. This is safe
+    # only because the workflow never checks out or executes pull request code -- its
+    # single input is the author login from the trusted event payload. The same pattern
+    # and reasoning is used in lint_pr_title.yml. Do NOT add a checkout of
+    # `github.event.pull_request.head.sha` to this workflow.
+    #
+    # The allowlist lives here. Continuation lines stay at this exact indentation so
+    # `>-` folds them into one line; a more-indented line would keep its newline and
+    # break the expression.
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["IgorSusmelj", "mrpositron", "gabrielfruet", "liopeer"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mint App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          # Organization-level secrets shared with lightly-studio, which uses the same
+          # `lightly-fast-track-bot` App. The names say FAST_TRACK rather than
+          # AUTO_APPROVE because they are the org secrets' existing names -- an org
+          # secret cannot be renamed per repository.
+          app-id: ${{ secrets.FAST_TRACK_APP_ID }}
+          private-key: ${{ secrets.FAST_TRACK_APP_PRIVATE_KEY }}
+          # The only permission an approval needs.
+          permission-pull-requests: write
+
+      - name: Approve Pull Request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+          # Passed via env rather than inline `${{ }}` so the value is never
+          # interpolated into the script text. The job's `if` already restricts it to
+          # the allowlist, but keep the safe pattern.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          # `synchronize` fires on every push, so skip when this App already has an
+          # active approval rather than stacking duplicate reviews.
+          #
+          # The full id list is captured before taking the first line: piping `gh`
+          # straight into `head -1` would close the pipe early on a pull request with
+          # many reviews, killing gh with SIGPIPE and failing the step under
+          # `pipefail`. `--jq` runs per page and output is concatenated, so this is
+          # pagination-safe.
+          approvals=$(
+            gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              --jq ".[] | select(.user.login == \"${BOT_LOGIN}\" and .state == \"APPROVED\") | .id"
+          )
+          if [ -n "${approvals}" ]; then
+            echo "Already approved by ${BOT_LOGIN} (review $(printf '%s\n' "${approvals}" | head -1)); nothing to do."
+            exit 0
+          fi
+
+          # Built as a variable to keep the API call readable. The text deliberately
+          # contains no backticks or `$` other than the author, so an expanding heredoc
+          # is safe here -- keep it that way if you edit the message.
+          body=$(cat <<EOF
+          Approved automatically: @${PR_AUTHOR} is on the auto-approve allowlist in .github/workflows/auto_approve.yml
+
+          This satisfies the approval requirement only. All required status checks still have to pass before this pull request can merge.
+          EOF
+          )
+
+          gh api --method POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            -f "commit_id=${HEAD_SHA}" \
+            -f "event=APPROVE" \
+            -f "body=${body}"
+          echo "Approved #${PR_NUMBER} at ${HEAD_SHA} as ${BOT_LOGIN}."

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,21 +1,11 @@
 name: Auto Approve
 
 # Approve pull requests opened by an allowlisted maintainer, so they can use GitHub's
-# "Enable auto-merge" instead of waiting for a review.
+# "Enable auto-merge" instead of waiting for a review. Only the approval requirement is
+# satisfied, all required status checks still have to pass. See CONTRIBUTING.md.
 #
-# Why a bot at all: GitHub has no native "required approvals, except for these people"
-# rule, and auto-merge never consumes a ruleset bypass -- a bypass is only spent on an
-# interactive "merge without waiting for requirements" click, which also skips the
-# required status checks. Supplying the approval is the only way to keep CI mandatory
-# while removing the wait.
-#
-# This is deliberately NOT a CODEOWNERS mechanism. CODEOWNERS keys on paths and
-# requires approval *from* an owner (who cannot approve their own pull request), so
-# `* @maintainers` would demand a human on every pull request and a bot approval would
-# never satisfy it -- the opposite of the goal. The allowlist below keys on the pull
-# request *author* instead. Do not add a CODEOWNERS file expecting this to keep working.
-#
-# See CONTRIBUTING.md for what this means for reviews.
+# The allowlist keys on the pull request author, not on paths. CODEOWNERS cannot do this:
+# it requires approval *from* an owner, who cannot approve their own pull request.
 
 on:
   pull_request_target:
@@ -25,8 +15,7 @@ on:
       - ready_for_review
       - synchronize
 
-# The App token minted below carries the only permission this workflow needs, so the
-# default token is stripped of all of them.
+# All permissions come from the App token minted below.
 permissions: {}
 
 concurrency:
@@ -36,15 +25,8 @@ concurrency:
 jobs:
   auto-approve:
     name: Auto Approve
-    # Runs on `pull_request_target` so the App credentials are available. This is safe
-    # only because the workflow never checks out or executes pull request code -- its
-    # single input is the author login from the trusted event payload. The same pattern
-    # and reasoning is used in lint_pr_title.yml. Do NOT add a checkout of
-    # `github.event.pull_request.head.sha` to this workflow.
-    #
-    # The allowlist lives here. Continuation lines stay at this exact indentation so
-    # `>-` folds them into one line; a more-indented line would keep its newline and
-    # break the expression.
+    # This workflow runs on `pull_request_target` and therefore has access to secrets.
+    # Do NOT check out or execute pull request code here.
     if: >-
       github.event.pull_request.draft == false &&
       contains(fromJSON('["IgorSusmelj", "mrpositron", "gabrielfruet", "liopeer"]'), github.event.pull_request.user.login)
@@ -55,13 +37,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          # Organization-level secrets shared with lightly-studio, which uses the same
-          # `lightly-fast-track-bot` App. The names say FAST_TRACK rather than
-          # AUTO_APPROVE because they are the org secrets' existing names -- an org
-          # secret cannot be renamed per repository.
+          # Organization-level secrets for the `lightly-fast-track-bot` App, shared
+          # with lightly-studio.
           app-id: ${{ secrets.FAST_TRACK_APP_ID }}
           private-key: ${{ secrets.FAST_TRACK_APP_PRIVATE_KEY }}
-          # The only permission an approval needs.
           permission-pull-requests: write
 
       - name: Approve Pull Request
@@ -71,21 +50,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
-          # Passed via env rather than inline `${{ }}` so the value is never
-          # interpolated into the script text. The job's `if` already restricts it to
-          # the allowlist, but keep the safe pattern.
+          # Passed via env rather than inline `${{ }}` to avoid script injection.
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
 
           # `synchronize` fires on every push, so skip when this App already has an
-          # active approval rather than stacking duplicate reviews.
-          #
-          # The full id list is captured before taking the first line: piping `gh`
-          # straight into `head -1` would close the pipe early on a pull request with
-          # many reviews, killing gh with SIGPIPE and failing the step under
-          # `pipefail`. `--jq` runs per page and output is concatenated, so this is
-          # pagination-safe.
+          # active approval rather than stacking duplicate reviews. The full id list is
+          # captured before taking the first line, piping `gh` into `head -1` would kill
+          # it with SIGPIPE and fail the step under `pipefail`.
           approvals=$(
             gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
               --jq ".[] | select(.user.login == \"${BOT_LOGIN}\" and .state == \"APPROVED\") | .id"
@@ -95,9 +68,8 @@ jobs:
             exit 0
           fi
 
-          # Built as a variable to keep the API call readable. The text deliberately
-          # contains no backticks or `$` other than the author, so an expanding heredoc
-          # is safe here -- keep it that way if you edit the message.
+          # Expanding heredoc: the message must not contain backticks or `$` other
+          # than the author.
           body=$(cat <<EOF
           Approved automatically: @${PR_AUTHOR} is on the auto-approve allowlist in .github/workflows/auto_approve.yml
 

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -48,14 +48,43 @@ jobs:
               - '!.github/**'
             this-workflow:
               - '.github/workflows/test_unit.yml'
-  test-unit:
-    name: Test Unit
+  # The two jobs below do not use a matrix. This is deliberate.
+  #
+  # GitHub does not expand a matrix for a job that it skips. Such a job reports one check
+  # with the plain job name, 'Test Unit'. The branch ruleset requires the names with the
+  # matrix value, 'Test Unit (ubuntu-latest)' and 'Test Unit (windows-latest)'. Those
+  # names only exist when the job runs. As a result, a pull request that skips the tests
+  # waits forever for a check that never arrives.
+  #
+  # A job without a matrix always reports the same name. Keep these jobs separate.
+  test-unit-ubuntu:
+    name: Test Unit (ubuntu-latest)
     needs: detect-code-changes
     if: needs.detect-code-changes.outputs.run-tests == 'true'
-    strategy:
-      matrix:
-        runners: ["ubuntu-latest", "windows-latest"]
-    runs-on: ${{ matrix.runners }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v7
+        id: setup-uv
+        with:
+          version: 0.11.15
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Set Up Environment
+        run: |
+          make install-pinned-3.13
+      - name: Run Pytest
+        run: |
+          make test-ci-maximal
+  test-unit-windows:
+    name: Test Unit (windows-latest)
+    needs: detect-code-changes
+    if: needs.detect-code-changes.outputs.run-tests == 'true'
+    runs-on: windows-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -48,15 +48,9 @@ jobs:
               - '!.github/**'
             this-workflow:
               - '.github/workflows/test_unit.yml'
-  # The two jobs below do not use a matrix. This is deliberate.
-  #
-  # GitHub does not expand a matrix for a job that it skips. Such a job reports one check
-  # with the plain job name, 'Test Unit'. The branch ruleset requires the names with the
-  # matrix value, 'Test Unit (ubuntu-latest)' and 'Test Unit (windows-latest)'. Those
-  # names only exist when the job runs. As a result, a pull request that skips the tests
-  # waits forever for a check that never arrives.
-  #
-  # A job without a matrix always reports the same name. Keep these jobs separate.
+  # Do not use a matrix here. GitHub does not expand a matrix for a job that it skips.
+  # A skipped job then reports 'Test Unit', not the two names below that the branch
+  # ruleset requires.
   test-unit-ubuntu:
     name: Test Unit (ubuntu-latest)
     needs: detect-code-changes

--- a/.github/workflows/test_unit_minimal_dependencies.yml
+++ b/.github/workflows/test_unit_minimal_dependencies.yml
@@ -48,16 +48,9 @@ jobs:
               - '!.github/**'
             this-workflow:
               - '.github/workflows/test_unit_minimal_dependencies.yml'
-  # The two jobs below do not use a matrix. This is deliberate.
-  #
-  # GitHub does not expand a matrix for a job that it skips. Such a job reports one check
-  # with the plain job name, 'Test Unit Minimal Dependencies'. The branch ruleset requires
-  # the names with the matrix value, 'Test Unit Minimal Dependencies (minimal)' and
-  # 'Test Unit Minimal Dependencies (minimal-extras)'. Those names only exist when the job
-  # runs. As a result, a pull request that skips the tests waits forever for a check that
-  # never arrives.
-  #
-  # A job without a matrix always reports the same name. Keep these jobs separate.
+  # Do not use a matrix here. GitHub does not expand a matrix for a job that it skips.
+  # A skipped job then reports 'Test Unit Minimal Dependencies', not the two names below
+  # that the branch ruleset requires.
   test-unit-minimal-dependencies-minimal:
     name: Test Unit Minimal Dependencies (minimal)
     needs: detect-code-changes

--- a/.github/workflows/test_unit_minimal_dependencies.yml
+++ b/.github/workflows/test_unit_minimal_dependencies.yml
@@ -48,14 +48,21 @@ jobs:
               - '!.github/**'
             this-workflow:
               - '.github/workflows/test_unit_minimal_dependencies.yml'
-  test-unit-minimal-dependencies:
-    name: Test Unit Minimal Dependencies
+  # The two jobs below do not use a matrix. This is deliberate.
+  #
+  # GitHub does not expand a matrix for a job that it skips. Such a job reports one check
+  # with the plain job name, 'Test Unit Minimal Dependencies'. The branch ruleset requires
+  # the names with the matrix value, 'Test Unit Minimal Dependencies (minimal)' and
+  # 'Test Unit Minimal Dependencies (minimal-extras)'. Those names only exist when the job
+  # runs. As a result, a pull request that skips the tests waits forever for a check that
+  # never arrives.
+  #
+  # A job without a matrix always reports the same name. Keep these jobs separate.
+  test-unit-minimal-dependencies-minimal:
+    name: Test Unit Minimal Dependencies (minimal)
     needs: detect-code-changes
     if: needs.detect-code-changes.outputs.run-tests == 'true'
     runs-on: "ubuntu-latest"
-    strategy:
-      matrix:
-        dependencies: ["minimal", "minimal-extras"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -70,7 +77,30 @@ jobs:
             **/uv.lock
       - name: Set Up Environment
         run: |
-          make install-${{ matrix.dependencies }}
+          make install-minimal
+      - name: Run Pytest
+        run: |
+          make test-ci-minimal
+  test-unit-minimal-dependencies-minimal-extras:
+    name: Test Unit Minimal Dependencies (minimal-extras)
+    needs: detect-code-changes
+    if: needs.detect-code-changes.outputs.run-tests == 'true'
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Set Up uv
+        uses: astral-sh/setup-uv@v7
+        id: setup-uv
+        with:
+          version: 0.11.15
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Set Up Environment
+        run: |
+          make install-minimal-extras
       - name: Run Pytest
         run: |
           make test-ci-minimal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,28 +113,6 @@ minor version instead of the major version.
 Entries in [CHANGELOG.md](./CHANGELOG.md) are still written by hand. See
 [RELEASING.md](./RELEASING.md) for the full release process.
 
-#### Automatic Approval
-
-Pull requests opened by a maintainer on the allowlist in
-[`.github/workflows/auto_approve.yml`](./.github/workflows/auto_approve.yml) are
-approved automatically by a bot. This exists so those authors can use GitHub's "Enable
-auto-merge" and have the pull request merge on its own once CI is green, instead of
-waiting for a review they were not going to receive anyway.
-
-It only satisfies the *approval* requirement: the bot approval cannot merge anything on
-its own, and **all required status checks still have to pass**. The bot cannot bypass a
-check, and it never re-approves a pull request whose approval a human has dismissed.
-
-Individual jobs are still skipped by their path filters when a change provably cannot
-affect them — a change under `.github/` does not run the test suites, for example — and
-a skipped job counts as successful. That is why
-[`.github/CODEOWNERS`](./.github/CODEOWNERS) puts all of `.github/` behind a human
-review. Changes to CI, to the allowlist itself, or to `CODEOWNERS` need an approving
-review from one of the maintainers listed there, which a bot can never give: GitHub apps
-cannot be code owners. Keep that owner list and the allowlist in sync.
-
-Everyone else's pull requests need a human approval.
-
 ### Documentation
 
 Documentation is in the [docs](./docs) folder. To build the documentation, install dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,20 @@ minor version instead of the major version.
 Entries in [CHANGELOG.md](./CHANGELOG.md) are still written by hand. See
 [RELEASING.md](./RELEASING.md) for the full release process.
 
+#### Automatic Approval
+
+Pull requests opened by a maintainer on the allowlist in
+[`.github/workflows/auto_approve.yml`](./.github/workflows/auto_approve.yml) are
+approved automatically by a bot. This exists so those authors can use GitHub's "Enable
+auto-merge" and have the pull request merge on its own once CI is green, instead of
+waiting for a review they were not going to receive anyway.
+
+It only satisfies the *approval* requirement. **All required status checks still have to
+pass** — the bot approval cannot merge anything on its own, and there is no way to skip
+CI.
+
+Everyone else's pull requests need a human approval.
+
 ### Documentation
 
 Documentation is in the [docs](./docs) folder. To build the documentation, install dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,17 @@ approved automatically by a bot. This exists so those authors can use GitHub's "
 auto-merge" and have the pull request merge on its own once CI is green, instead of
 waiting for a review they were not going to receive anyway.
 
-It only satisfies the *approval* requirement. **All required status checks still have to
-pass** — the bot approval cannot merge anything on its own, and there is no way to skip
-CI.
+It only satisfies the *approval* requirement: the bot approval cannot merge anything on
+its own, and **all required status checks still have to pass**. The bot cannot bypass a
+check, and it never re-approves a pull request whose approval a human has dismissed.
+
+Individual jobs are still skipped by their path filters when a change provably cannot
+affect them — a change under `.github/` does not run the test suites, for example — and
+a skipped job counts as successful. That is why
+[`.github/CODEOWNERS`](./.github/CODEOWNERS) puts all of `.github/` behind a human
+review. Changes to CI, to the allowlist itself, or to `CODEOWNERS` need an approving
+review from one of the maintainers listed there, which a bot can never give: GitHub apps
+cannot be code owners. Keep that owner list and the allowlist in sync.
 
 Everyone else's pull requests need a human approval.
 


### PR DESCRIPTION
Maintainers on an allowlist can now use "Enable auto-merge" instead of waiting for a review. CI stays mandatory.

## What

`auto_approve.yml`: the `lightly-fast-track-bot` App approves a pull request if the author is `IgorSusmelj`, `mrpositron`, `gabrielfruet`, or `liopeer`. This satisfies the approval requirement only. It cannot merge and it cannot bypass a status check. All other pull requests still need a human approval.

`.github/CODEOWNERS`: all of `/.github/` needs a review from one of the four maintainers. A GitHub App cannot be a code owner, so the bot approval never satisfies this. Changes to the bypass itself need a human.

## Notes

- The `PR Approval` ruleset already sets `require_code_owner_review: true`. There was no CODEOWNERS file, so the rule was inert.
- The whole `/.github/` directory is owned, not only `auto_approve.yml`. Otherwise a pull request can add a second workflow that approves itself.
- `pull_request_target` gives the workflow the App credentials. It never checks out or runs pull request code, like `lint_pr_title.yml`. The token has `pull-requests: write` only.
- No `synchronize` trigger: approvals survive pushes, and the bot stops when it finds a `DISMISSED` review of its own.
- Not covered: the ruleset itself is editable in the repository settings, and the four code owners are the four allowlisted authors.
- Left for later: pin `actions/create-github-app-token` and `actions/github-script` to commit SHAs.

## Unrelated fix: no matrix in the unit test jobs

This is not part of auto-approve. Without it this pull request cannot merge.

`Detect Code Changes` skips the test jobs for a `.github/**` change. GitHub does not expand a matrix for a job that it skips. The job reports `Test Unit`, but the ruleset requires `Test Unit (ubuntu-latest)` and the three other matrix names. Those names never arrive, so the pull request stays blocked. Every docs-only pull request has the same problem since #953.

The two workflows now use explicit jobs. A job without a matrix always reports the same name. A run reports the same names as before, so the ruleset needs no edit.

## How to merge this one

The status checks pass now. Only the approval is left.

`pull_request_target` runs from the base branch, so this pull request cannot approve itself. `main` has no CODEOWNERS file yet, so one approval from any person is sufficient.

After it is on `main`: test it on a throwaway pull request, then remove the `liopeer` bypass entries from the `CI Enforcement` and `PR Approval` rulesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ba5beg1L8GwUDdPBJ1zGWY


