### PR TITLE
feat(transforms): expose random resized crop ratio

### DIFF
--- a/docs/source/settings/pretrain_settings.md
+++ b/docs/source/settings/pretrain_settings.md
@@ -623,10 +623,14 @@ lightly_train.pretrain(
 		"random_resize": {
 			"min_scale": 0.2,
 			"max_scale": 1.0,
+			"ratio": [0.75, 1.3333333333333333],
 		},
 	},
 )
 ```
+
+`ratio` controls the minimum and maximum aspect ratio sampled by the random resized
+crop. It defaults to `(0.75, 4 / 3)`.
 
 #### `random_flip`
 

--- a/src/lightly_train/_transforms/transform.py
+++ b/src/lightly_train/_transforms/transform.py
@@ -47,6 +47,15 @@ class ResizeArgs(PydanticConfig):
 class RandomResizeArgs(PydanticConfig):
     min_scale: float = 0.08
     max_scale: float = 1.0
+    # Minimum and maximum aspect ratio sampled by RandomResizedCrop.
+    ratio: tuple[float, float] = Field(default=(0.75, 4.0 / 3.0), strict=False)
+
+    @field_validator("ratio")
+    @classmethod
+    def validate_ratio(cls, value: tuple[float, float]) -> tuple[float, float]:
+        if value[0] <= 0 or value[0] > value[1]:
+            raise ValueError("ratio must contain two positive values in ascending order.")
+        return value
 
     def as_tuple(self) -> tuple[float, float]:
         return self.min_scale, self.max_scale

--- a/src/lightly_train/_transforms/view_transform.py
+++ b/src/lightly_train/_transforms/view_transform.py
@@ -66,12 +66,14 @@ def _get_RandomResizedCrop(args: RandomResizedCropArgs) -> RandomResizedCrop:
         return RandomResizedCrop(
             size=(args.size[0], args.size[1]),
             scale=args.scale.as_tuple(),
+            ratio=args.scale.ratio,
             interpolation=cv2.INTER_AREA,
         )
     return RandomResizedCrop(
         height=args.size[0],
         width=args.size[1],
         scale=args.scale.as_tuple(),
+        ratio=args.scale.ratio,
         interpolation=cv2.INTER_AREA,
     )
 

--- a/tests/_transforms/test_view_transform.py
+++ b/tests/_transforms/test_view_transform.py
@@ -27,7 +27,11 @@ from lightly_train._transforms.transform import (
     RandomRotationArgs,
     SolarizeArgs,
 )
-from lightly_train._transforms.view_transform import ViewTransform, ViewTransformArgs
+from lightly_train._transforms.view_transform import (
+    ViewTransform,
+    ViewTransformArgs,
+    _get_RandomResizedCrop,
+)
 from lightly_train.types import TransformInput
 
 ALBUMENTATIONS_VERSION_2XX = RequirementCache("albumentations>=2.0.0")
@@ -49,6 +53,22 @@ def _get_random_resized_crop_args() -> RandomResizedCropArgs:
         size=(64, 64),
         scale=RandomResizeArgs(min_scale=0.2, max_scale=1.0),
     )
+
+
+def test_random_resized_crop_exposes_ratio() -> None:
+    args = RandomResizedCropArgs(
+        size=(64, 64),
+        scale=RandomResizeArgs(min_scale=0.2, max_scale=1.0, ratio=(1.0, 1.0)),
+    )
+    transform = _get_RandomResizedCrop(args)
+    assert transform.ratio == (1.0, 1.0)
+
+
+def test_random_resized_crop_rejects_invalid_ratio() -> None:
+    with pytest.raises(ValueError, match="ratio"):
+        RandomResizeArgs(ratio=(0.0, 1.0))
+    with pytest.raises(ValueError, match="ratio"):
+        RandomResizeArgs(ratio=(2.0, 1.0))
 
 
 def _get_random_flip_args() -> RandomFlipArgs:


### PR DESCRIPTION
Closes #958

## What

Expose the random resized crop aspect-ratio range through `transform_args.random_resize.ratio` and pass it through to Albumentations.

- Keep the existing default `(0.75, 4 / 3)`.
- Validate that both ratio bounds are positive and ordered.
- Document the new setting and add coverage for propagation and invalid values.

## Testing

- `python -m compileall -q src tests` (passed)
- Targeted pytest could not run locally because pytest and the project runtime dependencies are not installed; the repository CI will run the full test suite.
