### PR TITLE
fix(timm): map new timm 1.0.29 model families

### DIFF
--- a/src/lightly_train/_models/timm/timm.py
+++ b/src/lightly_train/_models/timm/timm.py
@@ -94,11 +94,13 @@ _TIMM_ARCH_NAME_PREFIXES: list[tuple[str, ArchitectureInfo]] = [
     # Hybrid + BatchNorm (attention augmented conv networks)
     ("bat_", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("botnet", {"model_type": "hybrid", "norm_type": "batchnorm"}),
+    ("cpubone_", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("eca_botnext", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("eca_halonext", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("halo", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("lambda_resnet", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("lamhalobotnet", {"model_type": "hybrid", "norm_type": "batchnorm"}),
+    ("lowformer_", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("sebotnet", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     ("sehalonet", {"model_type": "hybrid", "norm_type": "batchnorm"}),
     # Conv + LayerNorm
@@ -170,6 +172,7 @@ _TIMM_ARCH_NAME_PREFIXES: list[tuple[str, ArchitectureInfo]] = [
     ("hrnet_", {"model_type": "convolutional", "norm_type": "batchnorm"}),
     ("inception_resnet_", {"model_type": "convolutional", "norm_type": "batchnorm"}),
     ("inception_v", {"model_type": "convolutional", "norm_type": "batchnorm"}),
+    ("lcnetv2_", {"model_type": "convolutional", "norm_type": "batchnorm"}),
     ("lcnet_", {"model_type": "convolutional", "norm_type": "batchnorm"}),
     ("legacy_", {"model_type": "convolutional", "norm_type": "batchnorm"}),
     ("mixnet_", {"model_type": "convolutional", "norm_type": "batchnorm"}),


### PR DESCRIPTION
`test_architecture_info__all_timm_model_names_match_prefix` fails on CI because timm 1.0.29 adds three new model families that have no entry in `_TIMM_ARCH_NAME_PREFIXES`: `cpubone_*`, `lowformer_*` and `lcnetv2_*` (20 model names total). Without a matching prefix, `TIMMModelWrapper.architecture_info()` logs a warning and falls back to classifying them as transformer/layernorm.

Classification based on the timm 1.0.29 sources:

- `cpubone_` → hybrid / batchnorm. CPUBone (CVPR Findings 2026) is a conv backbone with `ConvAttention` stages; `norm_layer` defaults to `nn.BatchNorm2d` throughout.
- `lowformer_` → hybrid / batchnorm. LowFormer (WACV 2025) is a convolutional transformer backbone with a `ConvAttention` branch; `norm_layer` defaults to `nn.BatchNorm2d`.
- `lcnetv2_` → convolutional / batchnorm. PP-LCNetV2 is a pure conv net built on PP-LCNet, matching the existing `lcnet_` entry. Placed before `lcnet_` to keep the specific-before-general ordering used elsewhere in the list.

Verified against timm 1.0.29 (1317 models, 0 unmatched) and checked that `architecture_info()` returns the expected values for `cpubone_nano`, `lowformer_b0` and `lcnetv2_small`.