### PR TITLE
fix(dino): update teacher and center once per accumulation window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Update the DINO teacher EMA and center once per optimizer step when using gradient
+  accumulation, keeping teacher targets fixed within each accumulation window.
+
 ### Security
 
 ## [0.17.0] - 2026-07-28

--- a/src/lightly_train/_methods/dino/dino.py
+++ b/src/lightly_train/_methods/dino/dino.py
@@ -216,6 +216,45 @@ class DINOSGDArgs(SGDArgs):
     weight_decay: float = 0.0001
 
 
+class _AccumulatingDINOLoss(DINOLoss):  # type: ignore[misc]  # Lightly does not expose a typed DINOLoss.
+    """Keep centering fixed until all microbatches in an optimizer step finish."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._teacher_sum: Tensor | None = None
+        self._teacher_count = 0
+        self._teacher_dtype = torch.float32
+
+    @torch.no_grad()
+    def update_center(self, teacher_out: Tensor) -> None:
+        accumulation_dtype = (
+            torch.float32
+            if teacher_out.dtype in (torch.float16, torch.bfloat16)
+            else teacher_out.dtype
+        )
+        teacher_sum = teacher_out.sum(
+            dim=(0, 1), keepdim=True, dtype=accumulation_dtype
+        )
+        if self._teacher_sum is None:
+            self._teacher_sum = teacher_sum
+            self._teacher_dtype = teacher_out.dtype
+        else:
+            self._teacher_sum.add_(teacher_sum)
+        self._teacher_count += teacher_out.shape[0] * teacher_out.shape[1]
+
+    @torch.no_grad()
+    def commit_center(self) -> None:
+        if self._teacher_sum is not None:
+            # Reuse Lightly's center reduction and momentum update with the
+            # mean of the whole local window, including a partial final window.
+            window_mean = (self._teacher_sum / self._teacher_count).to(
+                self._teacher_dtype
+            )
+            super().update_center(window_mean)
+            self._teacher_sum = None
+            self._teacher_count = 0
+
+
 class DINO(Method):
     def __init__(
         self,
@@ -254,13 +293,14 @@ class DINO(Method):
             norm_last_layer=method_args.norm_last_layer,
         )
         self.flatten = Flatten(start_dim=1)
-        self.criterion = DINOLoss(
+        self.criterion = _AccumulatingDINOLoss(
             output_dim=no_auto(method_args.output_dim),
             teacher_temp=no_auto(method_args.teacher_temp),
             warmup_teacher_temp=no_auto(method_args.warmup_teacher_temp),
             student_temp=method_args.student_temp,
             center_momentum=method_args.center_momentum,
         )
+        self._teacher_updated_in_window = False
 
     def training_step_impl(self, batch: Batch, batch_idx: int) -> TrainingStepResult:
         momentum = cosine_schedule(
@@ -269,12 +309,14 @@ class DINO(Method):
             start_value=no_auto(self.method_args.momentum_start),
             end_value=self.method_args.momentum_end,
         )
-        update_momentum(
-            self.student_embedding_model, self.teacher_embedding_model, m=momentum
-        )
-        update_momentum(
-            self.student_projection_head, self.teacher_projection_head, m=momentum
-        )
+        if not self._teacher_updated_in_window:
+            update_momentum(
+                self.student_embedding_model, self.teacher_embedding_model, m=momentum
+            )
+            update_momentum(
+                self.student_projection_head, self.teacher_projection_head, m=momentum
+            )
+            self._teacher_updated_in_window = True
 
         views = batch["views"]
         global_views = torch.cat(views[:2])
@@ -438,6 +480,8 @@ class DINO(Method):
         return [optim], [scheduler]  # type: ignore[return-value]
 
     def on_before_optimizer_step(self, optimizer: Optimizer, *args: Any) -> None:
+        self.criterion.commit_center()
+        self._teacher_updated_in_window = False
         weight_decay = cosine_schedule(
             step=self.trainer.global_step,
             max_steps=self.trainer.estimated_stepping_batches,

--- a/tests/_methods/dino/test_dino.py
+++ b/tests/_methods/dino/test_dino.py
@@ -7,9 +7,13 @@
 #
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Literal
 
 import pytest
+import torch
+from pytorch_lightning import Trainer
+from torch.utils.data import DataLoader, TensorDataset, default_collate
 
 from lightly_train._methods.dino.dino import (
     DINO,
@@ -17,6 +21,7 @@ from lightly_train._methods.dino.dino import (
     DINOArgs,
     DINOSGDArgs,
 )
+from lightly_train._models.embedding_model import EmbeddingModel
 from lightly_train._optim.optimizer_args import OptimizerArgs
 from lightly_train._optim.optimizer_type import OptimizerType
 from lightly_train._scaling import IMAGENET_SIZE, ScalingInfo
@@ -81,6 +86,98 @@ class TestDINOArgs:
 
 
 class TestDINO:
+    @pytest.mark.parametrize(
+        "dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64]
+    )
+    def test_center_accumulation_matches_full_batch(self, dtype: torch.dtype) -> None:
+        from lightly.loss import DINOLoss
+
+        from lightly_train._methods.dino.dino import _AccumulatingDINOLoss
+
+        reference = DINOLoss(output_dim=4, center_momentum=0.9)
+        accumulated = _AccumulatingDINOLoss(output_dim=4, center_momentum=0.9)
+        # A half-precision sum over the whole window would overflow, while its mean is finite.
+        teacher = torch.full((2, 64, 4), 1000.0, dtype=dtype)
+        for start in range(0, 64, 16):
+            accumulated.update_center(teacher[:, start : start + 16])
+            assert torch.count_nonzero(accumulated.center) == 0
+        accumulated.commit_center()
+        reference.update_center(teacher)
+        torch.testing.assert_close(accumulated.center, reference.center, rtol=0, atol=0)
+        accumulated.commit_center()
+        torch.testing.assert_close(accumulated.center, reference.center, rtol=0, atol=0)
+
+    @pytest.mark.parametrize("num_examples", [12, 10])
+    def test_gradient_accumulation_preserves_teacher_and_center(
+        self, tmp_path: Path, num_examples: int
+    ) -> None:
+        def run(batch_size: int, accumulation: int) -> dict[str, torch.Tensor]:
+            torch.manual_seed(19)
+            method = DINO(
+                method_args=DINOArgs(
+                    output_dim=8,
+                    hidden_dim=16,
+                    bottleneck_dim=4,
+                    teacher_temp=0.07,
+                    warmup_teacher_temp=0.07,
+                    warmup_teacher_temp_steps=0,
+                    student_freeze_last_layer_steps=0,
+                    momentum_start=0.9,
+                    momentum_end=0.9,
+                    weight_decay_start=0.0,
+                    weight_decay_end=0.0,
+                    warmup_steps=0,
+                    reference_batch_size=4,
+                ),
+                optimizer_args=DINOSGDArgs(lr=0.01, momentum=0.0, weight_decay=0.0),
+                embedding_model=EmbeddingModel(DummyCustomModel(feature_dim=4)),
+                global_batch_size=4,
+                num_input_channels=3,
+            )
+            # A resumed teacher can differ from the student before the first window.
+            with torch.no_grad():
+                for parameter in method.teacher_embedding_model.parameters():
+                    parameter.add_(0.1)
+            images = torch.randn(num_examples, 3, 4, 4)
+            data = TensorDataset(images, images * 0.5 + 0.1)
+            trainer = Trainer(
+                accelerator="cpu",
+                devices=1,
+                max_epochs=1,
+                accumulate_grad_batches=accumulation,
+                logger=False,
+                enable_checkpointing=False,
+                enable_progress_bar=False,
+                enable_model_summary=False,
+                default_root_dir=tmp_path,
+            )
+            trainer.fit(
+                method,
+                train_dataloaders=DataLoader(
+                    data,
+                    batch_size=batch_size,
+                    collate_fn=lambda views: {"views": default_collate(views)},
+                ),
+            )
+            assert trainer.global_step == (num_examples + 3) // 4
+            return {
+                name: value.detach().clone()
+                for name, value in method.state_dict().items()
+            }
+
+        full = run(batch_size=4, accumulation=1)
+        accumulated = run(batch_size=1, accumulation=4)
+        for name, expected in full.items():
+            # Lightning separately controls loss normalization in partial windows.
+            # The last partial window must still commit the correct teacher and center.
+            if num_examples % 4 and not (
+                "teacher" in name or name == "criterion.center"
+            ):
+                continue
+            torch.testing.assert_close(
+                accumulated[name], expected, rtol=1e-5, atol=1e-6, msg=name
+            )
+
     @pytest.mark.parametrize(
         "optim_type, expected",
         [


### PR DESCRIPTION
## Summary

Update the DINO teacher once at the start of each gradient accumulation window, keep the teacher and center fixed while its microbatches run, and commit the center at the optimizer boundary. This keeps the update order of the non-accumulated path.

Center statistics are weighted by the number of teacher outputs. Half-precision outputs accumulate in FP32 to avoid overflowing the running sum, then the window mean is converted back before Lightly's usual center update.

Fixes #968. A changelog entry is included.

## Validation

- `python -m pytest -q tests/_methods/dino/test_dino.py`: 12 passed on CPU.
- The native Lightning training tests compare one batch of four with four batches of one across three optimizer steps. They check teacher and center state, including a partial final window; student state is also compared for complete windows. Both cases fail on unmodified `295f04f8`.
- Separate checks cover FP16, BF16, FP32, and FP64 center accumulation against Lightly's full-batch center update, including a sum that would overflow in FP16.
- Mypy, Ruff lint/format checks, Python compilation, and `git diff --check` pass for the changed Python files.

The pinned-version GPU results are in the linked issue; GPU tests were not rerun for this PR.
